### PR TITLE
Fix camera landing page layout: prompt fills space above controls

### DIFF
--- a/apps/camera/index.html
+++ b/apps/camera/index.html
@@ -36,7 +36,6 @@
             flex: 1;
             display: flex;
             flex-direction: column;
-            justify-content: center;
             align-items: center;
             position: relative;
             background: #111;
@@ -47,6 +46,11 @@
         }
 
         .camera-prompt {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
             text-align: center;
             padding: 40px;
             color: #999;


### PR DESCRIPTION
The camera prompt now expands to fill available vertical space and
centers its content, while controls stay pinned at the bottom. This
prevents content from awkwardly floating in the middle of the screen.