### PR TITLE
Fix rain mm readability in weather app forecast

### DIFF
--- a/apps/weather/index.html
+++ b/apps/weather/index.html
@@ -210,7 +210,8 @@
 
         .forecast-rain {
             font-size: 13px;
-            color: #87CEEB;
+            color: #fff;
+            opacity: 0.85;
             width: 55px;
             text-align: center;
         }


### PR DESCRIPTION
Change forecast-rain color from light blue (#87CEEB) to white with
0.85 opacity for better contrast against blue backgrounds.