### PR TITLE
Fix speedometer map page layout and tab bar size

### DIFF
--- a/apps/speedometer/index.html
+++ b/apps/speedometer/index.html
@@ -27,7 +27,7 @@
         .pages-container {
             display: flex;
             width: 200vw;
-            height: calc(100vh - env(safe-area-inset-top) - 60px - env(safe-area-inset-bottom));
+            height: calc(100vh - env(safe-area-inset-top) - 80px - env(safe-area-inset-bottom));
             transition: transform 0.3s ease-out;
         }
 
@@ -47,7 +47,7 @@
             bottom: 0;
             left: 0;
             right: 0;
-            height: 60px;
+            height: calc(80px + env(safe-area-inset-bottom));
             padding-bottom: env(safe-area-inset-bottom);
             background: #1a1a1a;
             border-top: 1px solid #333;
@@ -61,7 +61,7 @@
             flex-direction: column;
             align-items: center;
             justify-content: center;
-            gap: 4px;
+            gap: 6px;
             color: #666;
             cursor: pointer;
             transition: color 0.2s;
@@ -72,12 +72,12 @@
         }
 
         .tab svg {
-            width: 24px;
-            height: 24px;
+            width: 28px;
+            height: 28px;
         }
 
         .tab span {
-            font-size: 10px;
+            font-size: 12px;
             text-transform: uppercase;
             letter-spacing: 0.5px;
         }
@@ -294,34 +294,35 @@
         .map-page {
             background: #111;
             padding: 0;
+            display: flex;
+            flex-direction: column;
+            justify-content: flex-start;
         }
 
         .map-header {
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            padding: 15px 20px;
-            background: rgba(17, 17, 17, 0.9);
-            z-index: 100;
+            position: relative;
+            padding: 20px;
+            background: #111;
+            z-index: 1000;
             display: flex;
             justify-content: space-between;
             align-items: center;
+            flex-shrink: 0;
         }
 
         .map-speed {
             display: flex;
             align-items: baseline;
-            gap: 4px;
+            gap: 6px;
         }
 
         .map-speed-value {
-            font-size: 32px;
+            font-size: 48px;
             font-weight: 300;
         }
 
         .map-speed-unit {
-            font-size: 14px;
+            font-size: 18px;
             color: #888;
         }
 
@@ -329,8 +330,8 @@
             display: flex;
             flex-direction: column;
             align-items: flex-end;
-            gap: 2px;
-            font-size: 12px;
+            gap: 6px;
+            font-size: 16px;
             color: #888;
         }
 
@@ -341,7 +342,7 @@
 
         #map {
             width: 100%;
-            height: 100%;
+            flex: 1;
             background: #1a1a1a;
         }
 
@@ -350,7 +351,7 @@
             flex-direction: column;
             align-items: center;
             justify-content: center;
-            height: 100%;
+            flex: 1;
             color: #555;
             text-align: center;
             padding: 40px;


### PR DESCRIPTION
- Increase tab bar height from 60px to 80px for better touch targets
- Enlarge tab icons (24px to 28px) and text (10px to 12px)
- Change map header from absolute to relative positioning so it displays above map
- Increase speed display size (32px to 48px) and stats text for better visibility
- Use flex layout for map page to properly arrange header, map, and empty state