### PR TITLE
Fix mixed content issue in network app

### DIFF
--- a/apps/network/index.html
+++ b/apps/network/index.html
@@ -386,7 +386,7 @@
         // Fetch IP geolocation data
         async function fetchIPData() {
             try {
-                const response = await fetch('http://ip-api.com/json/?fields=status,message,country,countryCode,region,regionName,city,zip,lat,lon,timezone,isp,org,as,query');
+                const response = await fetch('https://ip-api.com/json/?fields=status,message,country,countryCode,region,regionName,city,zip,lat,lon,timezone,isp,org,as,query');
                 const data = await response.json();
                 if (data.status === 'success') {
                     return data;


### PR DESCRIPTION
Change ip-api.com fetch from http:// to https:// to prevent
mixed content blocking when site is served over HTTPS.