### PR TITLE
Fix network app for iOS: use HTTPS geo API and improve UX

### DIFF
--- a/apps/network/index.html
+++ b/apps/network/index.html
@@ -385,22 +385,59 @@
 
         // Fetch IP geolocation data
         async function fetchIPData() {
+            // Try ipwho.is first (free, HTTPS, CORS enabled)
             try {
-                const response = await fetch('https://ip-api.com/json/?fields=status,message,country,countryCode,region,regionName,city,zip,lat,lon,timezone,isp,org,as,query');
+                const response = await fetch('https://ipwho.is/');
                 const data = await response.json();
-                if (data.status === 'success') {
-                    return data;
+                if (data.success) {
+                    return {
+                        query: data.ip,
+                        country: data.country,
+                        countryCode: data.country_code,
+                        regionName: data.region,
+                        city: data.city,
+                        zip: data.postal,
+                        lat: data.latitude,
+                        lon: data.longitude,
+                        timezone: data.timezone?.id,
+                        isp: data.connection?.isp,
+                        org: data.connection?.org,
+                        as: data.connection?.asn ? `AS${data.connection.asn} ${data.connection.org}` : null
+                    };
                 }
                 throw new Error(data.message || 'Failed to fetch IP data');
             } catch (error) {
-                console.error('IP-API error:', error);
-                // Fallback to ipify for just the IP
+                console.error('ipwho.is error:', error);
+                // Fallback to ipapi.co (also free with HTTPS)
                 try {
-                    const ipResponse = await fetch('https://api.ipify.org?format=json');
-                    const ipData = await ipResponse.json();
-                    return { query: ipData.ip, fallback: true };
+                    const response = await fetch('https://ipapi.co/json/');
+                    const data = await response.json();
+                    if (!data.error) {
+                        return {
+                            query: data.ip,
+                            country: data.country_name,
+                            countryCode: data.country_code,
+                            regionName: data.region,
+                            city: data.city,
+                            zip: data.postal,
+                            lat: data.latitude,
+                            lon: data.longitude,
+                            timezone: data.timezone,
+                            isp: data.org,
+                            org: data.org,
+                            as: data.asn ? `${data.asn} ${data.org}` : null
+                        };
+                    }
+                    throw new Error('ipapi.co failed');
                 } catch {
-                    return null;
+                    // Final fallback to ipify for just the IP
+                    try {
+                        const ipResponse = await fetch('https://api.ipify.org?format=json');
+                        const ipData = await ipResponse.json();
+                        return { query: ipData.ip, fallback: true };
+                    } catch {
+                        return null;
+                    }
                 }
             }
         }
@@ -422,6 +459,13 @@
         // Measure latency to an endpoint
         async function measureLatency(name, url) {
             try {
+                // Warmup request to establish connection (DNS + TCP + TLS)
+                await fetch(url, {
+                    method: 'HEAD',
+                    mode: 'no-cors',
+                    cache: 'no-store'
+                });
+                // Actual measurement on established connection
                 const start = performance.now();
                 await fetch(url, {
                     method: 'HEAD',
@@ -626,7 +670,8 @@
             } else {
                 html += `
                     <div class="info-item full-width" style="text-align: center; padding: 20px;">
-                        <div class="info-value na">Network Information API not supported in this browser</div>
+                        <div class="info-value na">Connection details unavailable</div>
+                        <div class="info-label" style="margin-top: 8px;">Safari and iOS don't support the Network Information API</div>
                     </div>
                 `;
             }


### PR DESCRIPTION
- Switch from ip-api.com (HTTPS requires paid) to ipwho.is with
  ipapi.co fallback - both support free HTTPS with CORS
- Improve error message for Safari/iOS users explaining Network
  Information API limitation
- Add warmup request before latency tests to exclude DNS/TCP/TLS
  handshake time from measurements