### PR TITLE
Remove visualizer from radio app and add AM/PM to flip clock

### DIFF
--- a/apps/clock/index.html
+++ b/apps/clock/index.html
@@ -393,6 +393,44 @@
                 transparent 100%);
         }
 
+        /* AM/PM indicator for flip clock */
+        .flip-ampm {
+            display: none;
+            flex-direction: column;
+            justify-content: center;
+            gap: 4px;
+            margin-left: clamp(4px, 1.5vw, 12px);
+            font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+            font-size: clamp(14px, 4vw, 24px);
+            font-weight: 600;
+        }
+
+        .flip-ampm.visible {
+            display: flex;
+        }
+
+        .flip-ampm-text {
+            padding: clamp(4px, 1vw, 8px) clamp(6px, 1.5vw, 12px);
+            background: linear-gradient(to bottom, #2a2a2a 0%, #1f1f1f 50%, #1a1a1a 50%, #252525 100%);
+            border-radius: clamp(3px, 0.8vw, 6px);
+            color: #ddd;
+            text-shadow: 0 2px 4px rgba(0,0,0,0.5);
+            box-shadow:
+                inset 0 1px 0 rgba(255,255,255,0.1),
+                inset 0 -1px 0 rgba(255,255,255,0.05),
+                0 4px 8px rgba(0,0,0,0.4);
+        }
+
+        .flip-page.light .flip-ampm-text {
+            background: linear-gradient(to bottom, #f5f5f5 0%, #e8e8e8 50%, #ddd 50%, #eee 100%);
+            color: #222;
+            text-shadow: 0 1px 2px rgba(255,255,255,0.5);
+            box-shadow:
+                inset 0 1px 0 rgba(255,255,255,0.8),
+                inset 0 -1px 0 rgba(255,255,255,0.5),
+                0 4px 8px rgba(0,0,0,0.15);
+        }
+
         /* Side screws/rivets for realism */
         .flip-digit::before {
             content: '';
@@ -541,6 +579,9 @@
                         </div>
                     </div>
                 </div>
+                <div class="flip-ampm" id="flip-ampm">
+                    <div class="flip-ampm-text" id="flip-ampm-text">AM</div>
+                </div>
             </div>
         </div>
     </div>
@@ -582,6 +623,8 @@
             s1: document.getElementById('flip-s1'),
             s2: document.getElementById('flip-s2')
         };
+        const flipAmpm = document.getElementById('flip-ampm');
+        const flipAmpmText = document.getElementById('flip-ampm-text');
         let lastFlipValues = { h1: '', h2: '', m1: '', m2: '', s1: '', s2: '' };
 
         // Swipe handling
@@ -661,13 +704,15 @@
             dots.forEach((dot, i) => {
                 dot.classList.toggle('active', i === currentPage);
             });
-            formatToggle.style.display = currentPage === 1 ? 'block' : 'none';
+            formatToggle.style.display = (currentPage === 1 || currentPage === 2) ? 'block' : 'none';
         }
 
         // Format toggle
         formatToggle.addEventListener('click', () => {
             use24Hour = !use24Hour;
             formatToggle.textContent = use24Hour ? '24h' : '12h';
+            // Reset flip clock values to force update with new format
+            lastFlipValues = { h1: '', h2: '', m1: '', m2: '', s1: '', s2: '' };
             updateClocks();
         });
 
@@ -890,13 +935,23 @@
 
         function updateFlipClock() {
             const now = new Date();
-            const hours = now.getHours().toString().padStart(2, '0');
+            let hours = now.getHours();
             const minutes = now.getMinutes().toString().padStart(2, '0');
             const seconds = now.getSeconds().toString().padStart(2, '0');
 
+            // Handle 12-hour format
+            if (use24Hour) {
+                flipAmpm.classList.remove('visible');
+            } else {
+                flipAmpm.classList.add('visible');
+                flipAmpmText.textContent = hours >= 12 ? 'PM' : 'AM';
+                hours = hours % 12 || 12;
+            }
+
+            const hoursStr = hours.toString().padStart(2, '0');
             const values = {
-                h1: hours[0],
-                h2: hours[1],
+                h1: hoursStr[0],
+                h2: hoursStr[1],
                 m1: minutes[0],
                 m2: minutes[1],
                 s1: seconds[0],

--- a/apps/radio/index.html
+++ b/apps/radio/index.html
@@ -63,29 +63,15 @@
             background: rgba(255, 255, 255, 0.2);
         }
 
-        /* Visualizer */
-        .visualizer-container {
-            flex: 1;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            min-height: 150px;
-            max-height: 250px;
-            margin-bottom: 20px;
-        }
-
-        #visualizer {
-            width: 100%;
-            height: 100%;
-            border-radius: 16px;
-            background: rgba(0, 0, 0, 0.3);
-        }
-
         /* Now Playing */
         .now-playing {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
             text-align: center;
             margin-bottom: 30px;
-            min-height: 100px;
         }
 
         .station-name {
@@ -216,26 +202,6 @@
             background: #fff;
             cursor: pointer;
             border: none;
-        }
-
-        /* Visualizer toggle */
-        .visualizer-toggle {
-            display: flex;
-            justify-content: center;
-            margin-top: 10px;
-        }
-
-        .toggle-btn {
-            background: none;
-            border: none;
-            color: rgba(255, 255, 255, 0.5);
-            font-size: 12px;
-            cursor: pointer;
-            padding: 5px 10px;
-        }
-
-        .toggle-btn.active {
-            color: #e94560;
         }
 
         /* Search Modal */
@@ -390,10 +356,6 @@
             <button class="search-btn" onclick="openSearch()">Search Stations</button>
         </div>
 
-        <div class="visualizer-container">
-            <canvas id="visualizer"></canvas>
-        </div>
-
         <div class="now-playing">
             <div class="station-name" id="stationName">KEXP 90.3 FM</div>
             <div class="track-title" id="trackTitle">--</div>
@@ -415,9 +377,6 @@
                 <input type="range" class="volume-slider" id="volumeSlider" min="0" max="100" value="80">
             </div>
 
-            <div class="visualizer-toggle">
-                <button class="toggle-btn active" id="visualizerToggle" onclick="toggleVisualizer()">Visualizer ON</button>
-            </div>
         </div>
     </div>
 
@@ -447,13 +406,8 @@
     <script>
         // State
         let audio = null;
-        let audioContext = null;
-        let analyser = null;
-        let source = null;
         let isPlaying = false;
         let currentQuality = '160';
-        let visualizerEnabled = true;
-        let animationId = null;
         let searchTimeout = null;
         let currentStation = {
             name: 'KEXP 90.3 FM',
@@ -472,8 +426,6 @@
         const playIcon = document.getElementById('playIcon');
         const volumeSlider = document.getElementById('volumeSlider');
         const volumeIcon = document.getElementById('volumeIcon');
-        const canvas = document.getElementById('visualizer');
-        const ctx = canvas.getContext('2d');
         const trackTitle = document.getElementById('trackTitle');
         const trackArtist = document.getElementById('trackArtist');
         const trackAlbum = document.getElementById('trackAlbum');
@@ -484,7 +436,6 @@
 
         // Initialize
         function init() {
-            setupCanvas();
             updateVolumeIcon();
             if (currentStation.isKEXP) {
                 fetchKEXPNowPlaying();
@@ -492,18 +443,6 @@
             }
 
             volumeSlider.addEventListener('input', updateVolume);
-            window.addEventListener('resize', setupCanvas);
-        }
-
-        function setupCanvas() {
-            const container = canvas.parentElement;
-            const rect = container.getBoundingClientRect();
-            const dpr = window.devicePixelRatio || 1;
-            canvas.width = rect.width * dpr;
-            canvas.height = rect.height * dpr;
-            canvas.style.width = rect.width + 'px';
-            canvas.style.height = rect.height + 'px';
-            ctx.scale(dpr, dpr);
         }
 
         // Audio setup
@@ -521,9 +460,6 @@
                 isPlaying = true;
                 playIcon.innerHTML = '&#10074;&#10074;';
                 playBtn.classList.remove('loading');
-                if (visualizerEnabled) {
-                    setupVisualizer();
-                }
             });
 
             audio.addEventListener('pause', () => {
@@ -546,99 +482,6 @@
             audio.addEventListener('canplay', () => {
                 playBtn.classList.remove('loading');
             });
-        }
-
-        function setupVisualizer() {
-            if (!audioContext) {
-                audioContext = new (window.AudioContext || window.webkitAudioContext)();
-            }
-
-            if (audioContext.state === 'suspended') {
-                audioContext.resume();
-            }
-
-            if (!source && audio) {
-                try {
-                    source = audioContext.createMediaElementSource(audio);
-                    analyser = audioContext.createAnalyser();
-                    analyser.fftSize = 256;
-                    source.connect(analyser);
-                    analyser.connect(audioContext.destination);
-                } catch (e) {
-                    console.log('Visualizer setup error (CORS):', e);
-                }
-            }
-
-            if (!animationId) {
-                drawVisualizer();
-            }
-        }
-
-        function drawVisualizer() {
-            if (!visualizerEnabled) {
-                cancelAnimationFrame(animationId);
-                animationId = null;
-                drawIdleVisualizer();
-                return;
-            }
-
-            animationId = requestAnimationFrame(drawVisualizer);
-
-            const width = canvas.width / (window.devicePixelRatio || 1);
-            const height = canvas.height / (window.devicePixelRatio || 1);
-
-            ctx.fillStyle = 'rgba(0, 0, 0, 0.3)';
-            ctx.fillRect(0, 0, width, height);
-
-            if (analyser && isPlaying) {
-                const bufferLength = analyser.frequencyBinCount;
-                const dataArray = new Uint8Array(bufferLength);
-                analyser.getByteFrequencyData(dataArray);
-
-                const barWidth = (width / bufferLength) * 2.5;
-                let x = 0;
-
-                for (let i = 0; i < bufferLength; i++) {
-                    const barHeight = (dataArray[i] / 255) * height * 0.8;
-
-                    const gradient = ctx.createLinearGradient(0, height - barHeight, 0, height);
-                    gradient.addColorStop(0, '#e94560');
-                    gradient.addColorStop(1, '#ff6b6b');
-
-                    ctx.fillStyle = gradient;
-                    ctx.fillRect(x, height - barHeight, barWidth - 2, barHeight);
-
-                    x += barWidth;
-                }
-            } else {
-                drawIdleVisualizer();
-            }
-        }
-
-        function drawIdleVisualizer() {
-            const width = canvas.width / (window.devicePixelRatio || 1);
-            const height = canvas.height / (window.devicePixelRatio || 1);
-
-            ctx.fillStyle = 'rgba(0, 0, 0, 0.3)';
-            ctx.fillRect(0, 0, width, height);
-
-            // Draw simple idle animation
-            const time = Date.now() / 1000;
-            const bars = 32;
-            const barWidth = width / bars;
-
-            for (let i = 0; i < bars; i++) {
-                const barHeight = (Math.sin(time * 2 + i * 0.3) + 1) * 20 + 5;
-                const gradient = ctx.createLinearGradient(0, height - barHeight, 0, height);
-                gradient.addColorStop(0, 'rgba(233, 69, 96, 0.3)');
-                gradient.addColorStop(1, 'rgba(255, 107, 107, 0.3)');
-                ctx.fillStyle = gradient;
-                ctx.fillRect(i * barWidth, height - barHeight, barWidth - 2, barHeight);
-            }
-
-            if (!isPlaying || !visualizerEnabled) {
-                requestAnimationFrame(drawIdleVisualizer);
-            }
         }
 
         // Playback controls
@@ -672,7 +515,6 @@
             if (isPlaying) {
                 const wasPlaying = isPlaying;
                 audio.pause();
-                source = null;
                 setupAudio();
                 audio.src = currentStation.url;
                 if (wasPlaying) {
@@ -698,21 +540,6 @@
                 volumeIcon.innerHTML = '&#128265;';
             } else {
                 volumeIcon.innerHTML = '&#128266;';
-            }
-        }
-
-        function toggleVisualizer() {
-            visualizerEnabled = !visualizerEnabled;
-            const btn = document.getElementById('visualizerToggle');
-            btn.textContent = visualizerEnabled ? 'Visualizer ON' : 'Visualizer OFF';
-            btn.classList.toggle('active', visualizerEnabled);
-
-            if (visualizerEnabled && isPlaying) {
-                setupVisualizer();
-            } else if (!visualizerEnabled) {
-                cancelAnimationFrame(animationId);
-                animationId = null;
-                drawIdleVisualizer();
             }
         }
 
@@ -819,7 +646,6 @@
             if (audio) {
                 audio.pause();
             }
-            source = null;
             setupAudio();
             audio.src = station.url;
             playBtn.classList.add('loading');
@@ -852,7 +678,6 @@
             if (audio) {
                 audio.pause();
             }
-            source = null;
             setupAudio();
             audio.src = currentStation.url;
             playBtn.classList.add('loading');
@@ -870,7 +695,6 @@
 
         // Start
         init();
-        drawIdleVisualizer();
     </script>
 </body>
 </html>


### PR DESCRIPTION
- Remove non-functional audio visualizer from radio app (canvas,
  styles, and all related JavaScript)
- Add 12h/24h format toggle support to flip clock (page 3)
- Add styled AM/PM indicator that matches flip clock aesthetic