### PR TITLE
Fix scanner status lights to match actual playback state

### DIFF
--- a/apps/scanner/index.html
+++ b/apps/scanner/index.html
@@ -339,6 +339,7 @@
         let audio = null;
         let isPlaying = false;
         let currentChannel = null;
+        let audioSessionId = 0;
 
         // DOM elements
         const playBtn = document.getElementById('playBtn');
@@ -403,8 +404,11 @@
             }
 
             audio = new Audio();
+            audioSessionId++;
+            const thisSession = audioSessionId;
 
             audio.addEventListener('playing', () => {
+                if (thisSession !== audioSessionId) return; // Ignore stale events
                 isPlaying = true;
                 playIcon.innerHTML = '&#10074;&#10074;';
                 playBtn.classList.remove('loading');
@@ -420,8 +424,10 @@
             });
 
             audio.addEventListener('pause', () => {
+                if (thisSession !== audioSessionId) return; // Ignore stale events
                 isPlaying = false;
                 playIcon.innerHTML = '&#9654;';
+                playBtn.classList.remove('loading');
                 statusDot.classList.remove('live');
                 statusText.textContent = 'Paused';
                 // Remove playing indicator from all channels
@@ -431,6 +437,7 @@
             });
 
             audio.addEventListener('error', (e) => {
+                if (thisSession !== audioSessionId) return; // Ignore stale events
                 console.error('Audio error:', e);
                 playBtn.classList.remove('loading');
                 playIcon.innerHTML = '&#9654;';
@@ -445,11 +452,13 @@
             });
 
             audio.addEventListener('waiting', () => {
+                if (thisSession !== audioSessionId) return; // Ignore stale events
                 playBtn.classList.add('loading');
                 statusText.textContent = 'Buffering...';
             });
 
             audio.addEventListener('canplay', () => {
+                if (thisSession !== audioSessionId) return; // Ignore stale events
                 playBtn.classList.remove('loading');
             });
         }
@@ -491,10 +500,13 @@
                 } else {
                     playBtn.classList.add('loading');
                     playIcon.innerHTML = '<div class="spinner"></div>';
+                    statusText.textContent = 'Connecting...';
                     audio.play().catch(e => {
                         console.error('Play error:', e);
                         playBtn.classList.remove('loading');
                         playIcon.innerHTML = '&#9654;';
+                        statusText.textContent = 'Error';
+                        currentDescEl.textContent = 'Tap play to try again';
                     });
                 }
             }

--- a/apps/scanner/index.html
+++ b/apps/scanner/index.html
@@ -219,7 +219,7 @@
             opacity: 0;
         }
 
-        .channel-item.active .channel-live {
+        .channel-item.playing .channel-live {
             opacity: 1;
             animation: pulse 2s infinite;
         }
@@ -410,6 +410,13 @@
                 playBtn.classList.remove('loading');
                 statusDot.classList.add('live');
                 statusText.textContent = 'Live';
+                // Restore channel description and show playing indicator
+                if (currentChannel) {
+                    currentDescEl.textContent = currentChannel.desc;
+                    document.querySelectorAll('.channel-item').forEach(el => {
+                        el.classList.toggle('playing', el.classList.contains('active'));
+                    });
+                }
             });
 
             audio.addEventListener('pause', () => {
@@ -417,6 +424,10 @@
                 playIcon.innerHTML = '&#9654;';
                 statusDot.classList.remove('live');
                 statusText.textContent = 'Paused';
+                // Remove playing indicator from all channels
+                document.querySelectorAll('.channel-item').forEach(el => {
+                    el.classList.remove('playing');
+                });
             });
 
             audio.addEventListener('error', (e) => {
@@ -425,8 +436,12 @@
                 playIcon.innerHTML = '&#9654;';
                 isPlaying = false;
                 statusDot.classList.remove('live');
-                statusText.textContent = 'Error';
+                statusText.textContent = 'Unavailable';
                 currentDescEl.textContent = 'Stream unavailable - try another channel';
+                // Remove playing indicator from all channels
+                document.querySelectorAll('.channel-item').forEach(el => {
+                    el.classList.remove('playing');
+                });
             });
 
             audio.addEventListener('waiting', () => {


### PR DESCRIPTION
- Channel green dot now only shows when stream is actually playing, not just selected
- Reset channel description when stream starts playing successfully
- Header status dot and channel dots now stay in sync