### PR TITLE
Match flip clock background to minimal clock page

### DIFF
--- a/apps/clock/index.html
+++ b/apps/clock/index.html
@@ -147,13 +147,13 @@
 
         /* Page 3: Flip Clock */
         .flip-page {
-            background: #1a1a1a;
+            background: #000;
             cursor: pointer;
             transition: background 0.3s;
         }
 
         .flip-page.light {
-            background: #e8e8e8;
+            background: #fff;
         }
 
         .flip-clock {


### PR DESCRIPTION
Changed flip clock (page 3) background colors to match page 2:
- Dark mode: #1a1a1a → #000
- Light mode: #e8e8e8 → #fff