### PR TITLE
Fix weather forecast to show today + 6 future days

### DIFF
--- a/apps/weather/index.html
+++ b/apps/weather/index.html
@@ -468,7 +468,7 @@
 
         // Fetch weather data
         async function fetchWeather(lat, lon) {
-            const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m,pressure_msl,uv_index&hourly=temperature_2m,weather_code&daily=weather_code,temperature_2m_max,temperature_2m_min,sunrise,sunset,precipitation_probability_max,precipitation_sum&timezone=auto`;
+            const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,relative_humidity_2m,apparent_temperature,weather_code,wind_speed_10m,wind_direction_10m,pressure_msl,uv_index&hourly=temperature_2m,weather_code&daily=weather_code,temperature_2m_max,temperature_2m_min,sunrise,sunset,precipitation_probability_max,precipitation_sum&timezone=auto&forecast_days=7`;
 
             const response = await fetch(url);
             if (!response.ok) throw new Error('Weather data unavailable');
@@ -584,24 +584,34 @@
                 <div class="forecast">
                     <div class="forecast-title">7-Day Forecast</div>
                     <div class="forecast-list">
-                        ${daily.time.map((date, i) => {
-                            const dayInfo = getWeatherInfo(daily.weather_code[i]);
-                            const high = formatTemp(daily.temperature_2m_max[i], false);
-                            const low = formatTemp(daily.temperature_2m_min[i], false);
-                            const precip = daily.precipitation_sum[i];
-                            const precipDisplay = precip > 0 ? `${precip.toFixed(1)} mm` : '';
-                            return `
-                                <div class="forecast-day">
-                                    <div class="forecast-day-name">${getDayName(date)}</div>
-                                    <div class="forecast-icon">${dayInfo.icon}</div>
-                                    <div class="forecast-rain">${precipDisplay}</div>
-                                    <div class="forecast-temps">
-                                        <span class="forecast-high">${high.c} / ${high.f}</span>
-                                        <span class="forecast-low">${low.c} / ${low.f}</span>
+                        ${(() => {
+                            // Filter to start from today and show 7 days
+                            const today = new Date();
+                            today.setHours(0, 0, 0, 0);
+                            const todayStr = today.toISOString().split('T')[0];
+                            const startIdx = daily.time.findIndex(d => d >= todayStr);
+                            const forecastDays = daily.time.slice(startIdx, startIdx + 7);
+
+                            return forecastDays.map((date, idx) => {
+                                const i = startIdx + idx;
+                                const dayInfo = getWeatherInfo(daily.weather_code[i]);
+                                const high = formatTemp(daily.temperature_2m_max[i], false);
+                                const low = formatTemp(daily.temperature_2m_min[i], false);
+                                const precip = daily.precipitation_sum[i];
+                                const precipDisplay = precip > 0 ? `${precip.toFixed(1)} mm` : '';
+                                return `
+                                    <div class="forecast-day">
+                                        <div class="forecast-day-name">${getDayName(date)}</div>
+                                        <div class="forecast-icon">${dayInfo.icon}</div>
+                                        <div class="forecast-rain">${precipDisplay}</div>
+                                        <div class="forecast-temps">
+                                            <span class="forecast-high">${high.c} / ${high.f}</span>
+                                            <span class="forecast-low">${low.c} / ${low.f}</span>
+                                        </div>
                                     </div>
-                                </div>
-                            `;
-                        }).join('')}
+                                `;
+                            }).join('');
+                        })()}
                     </div>
                 </div>
             `;

--- a/apps/weather/index.html
+++ b/apps/weather/index.html
@@ -587,8 +587,7 @@
                         ${(() => {
                             // Filter to start from today and show 7 days
                             const today = new Date();
-                            today.setHours(0, 0, 0, 0);
-                            const todayStr = today.toISOString().split('T')[0];
+                            const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
                             const startIdx = daily.time.findIndex(d => d >= todayStr);
                             const forecastDays = daily.time.slice(startIdx, startIdx + 7);
 


### PR DESCRIPTION
Filter out yesterday from the 7-day forecast by finding today's date
and starting the forecast from there. Also explicitly request 7
forecast days from the Open-Meteo API.