### PR TITLE
Fix timezone bug in getDayName date parsing

### DIFF
--- a/apps/weather/index.html
+++ b/apps/weather/index.html
@@ -422,15 +422,20 @@
 
         // Get day name from date
         function getDayName(dateStr, short = false) {
-            const date = new Date(dateStr);
+            // Parse as local date (dateStr is "YYYY-MM-DD")
+            const [year, month, day] = dateStr.split('-').map(Number);
+            const date = new Date(year, month - 1, day);
+
             const today = new Date();
+            today.setHours(0, 0, 0, 0);
+
             const tomorrow = new Date(today);
             tomorrow.setDate(tomorrow.getDate() + 1);
 
-            if (date.toDateString() === today.toDateString()) {
+            if (date.getTime() === today.getTime()) {
                 return 'Today';
             }
-            if (date.toDateString() === tomorrow.toDateString()) {
+            if (date.getTime() === tomorrow.getTime()) {
                 return 'Tomorrow';
             }
 


### PR DESCRIPTION
Parse YYYY-MM-DD date strings as local dates instead of UTC. new Date("2026-01-26") parses as UTC midnight, which in US timezones appears as the previous day. Now manually parsing components to create local midnight for correct day name comparison.