### PR TITLE
Simplify news sources: keep BBC, NPR, add Hacker News

### DIFF
--- a/apps/news/index.html
+++ b/apps/news/index.html
@@ -229,16 +229,14 @@
 
     <div class="container">
         <div class="header">
-            <h1>World News</h1>
+            <h1>News</h1>
             <div class="last-updated" id="last-updated"></div>
         </div>
 
         <div class="sources" id="sources">
             <button class="source-btn active" data-source="bbc">BBC</button>
-            <button class="source-btn" data-source="cbc">CBC</button>
             <button class="source-btn" data-source="npr">NPR</button>
-            <button class="source-btn" data-source="reuters">Reuters</button>
-            <button class="source-btn" data-source="aljazeera">Al Jazeera</button>
+            <button class="source-btn" data-source="hn">Hacker News</button>
         </div>
 
         <div id="app">
@@ -252,13 +250,11 @@
     <script>
         const RSS_FEEDS = {
             bbc: 'https://feeds.bbci.co.uk/news/world/rss.xml',
-            cbc: 'https://www.cbc.ca/webfeed/rss/rss-world',
-            npr: 'https://feeds.npr.org/1004/rss.xml',
-            reuters: 'https://www.reutersagency.com/feed/?taxonomy=best-sectors&post_type=best',
-            aljazeera: 'https://www.aljazeera.com/xml/rss/all.xml'
+            npr: 'https://feeds.npr.org/1004/rss.xml'
         };
 
         const RSS2JSON_API = 'https://api.rss2json.com/v1/api.json?rss_url=';
+        const HN_API = 'https://hacker-news.firebaseio.com/v0';
 
         let currentSource = 'bbc';
         let cache = {};
@@ -276,6 +272,11 @@
             return date.toLocaleDateString();
         }
 
+        // Format time from Unix timestamp
+        function timeAgoUnix(timestamp) {
+            return timeAgo(new Date(timestamp * 1000).toISOString());
+        }
+
         // Strip HTML tags from text
         function stripHtml(html) {
             const tmp = document.createElement('div');
@@ -283,8 +284,34 @@
             return tmp.textContent || tmp.innerText || '';
         }
 
+        // Fetch Hacker News stories
+        async function fetchHackerNews() {
+            const response = await fetch(`${HN_API}/topstories.json`);
+            if (!response.ok) throw new Error('Failed to fetch HN stories');
+            const storyIds = await response.json();
+
+            // Fetch first 30 stories
+            const stories = await Promise.all(
+                storyIds.slice(0, 30).map(async id => {
+                    const res = await fetch(`${HN_API}/item/${id}.json`);
+                    return res.json();
+                })
+            );
+
+            return stories.map(story => ({
+                title: story.title,
+                description: story.score + ' points',
+                link: story.url || `https://news.ycombinator.com/item?id=${story.id}`,
+                pubDate: new Date(story.time * 1000).toISOString()
+            }));
+        }
+
         // Fetch news from RSS feed
         async function fetchNews(source) {
+            if (source === 'hn') {
+                return fetchHackerNews();
+            }
+
             const feedUrl = RSS_FEEDS[source];
             const apiUrl = RSS2JSON_API + encodeURIComponent(feedUrl);
 


### PR DESCRIPTION
Remove non-working sources (CBC, Reuters, Al Jazeera). Add Hacker News using their native API. Rename title from "World News" to "News".