### PR TITLE
Fix off-by-one date error in countdown app

### DIFF
--- a/apps/countdown/index.html
+++ b/apps/countdown/index.html
@@ -487,7 +487,8 @@
             // Add custom dates
             const customDates = getCustomDates();
             customDates.forEach(custom => {
-                let date = new Date(custom.date);
+                // Parse as local time by appending T00:00:00 (otherwise "YYYY-MM-DD" is parsed as UTC)
+                let date = new Date(custom.date + 'T00:00:00');
 
                 if (custom.recurring) {
                     const now = new Date();


### PR DESCRIPTION
When parsing date strings like "2026-01-27", JavaScript's Date constructor
interprets them as UTC midnight. For users in timezones behind UTC, this
displayed as the previous day. Fixed by appending T00:00:00 to force
local time parsing.

https://claude.ai/code/session_01C6xse7cK5P5EfPY9ezsqTj