### PR TITLE
Fix delete button visibility in countdown app

### DIFF
--- a/apps/countdown/index.html
+++ b/apps/countdown/index.html
@@ -139,6 +139,8 @@
             z-index: 1;
             transition: transform 0.3s ease;
             touch-action: pan-y;
+            background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+            border-radius: 16px;
         }
 
         .swipe-content.swiping {


### PR DESCRIPTION
Add background to swipe-content to prevent the red delete button
from showing through the semi-transparent countdown items.

https://claude.ai/code/session_01GgDbgPGfn3WV3oS2pFV4Pp