### PR TITLE
Fix inconsistent comment threading line spacing

### DIFF
--- a/apps/reddit/index.html
+++ b/apps/reddit/index.html
@@ -334,9 +334,9 @@
 
         .comment-depth-0 { border-left: none; padding-left: 0; }
         .comment-depth-1 { border-left: 3px solid #6cb4ff; margin-left: 6px; }
-        .comment-depth-2 { border-left: 3px solid #4caf50; margin-left: 12px; }
-        .comment-depth-3 { border-left: 3px solid #ff9800; margin-left: 18px; }
-        .comment-depth-4 { border-left: 3px solid #9c27b0; margin-left: 24px; }
+        .comment-depth-2 { border-left: 3px solid #4caf50; margin-left: 6px; }
+        .comment-depth-3 { border-left: 3px solid #ff9800; margin-left: 6px; }
+        .comment-depth-4 { border-left: 3px solid #9c27b0; margin-left: 6px; }
 
         .comment-author {
             font-size: 12px;


### PR DESCRIPTION
The margin-left values were increasing per depth level (6, 12, 18, 24px)
but since comments are nested, these values compound. This caused the
gap between adjacent threading lines to grow at each nesting level.
Use a uniform 6px margin-left so the spacing between lines is consistent.

https://claude.ai/code/session_01K13fNEWagu5H3QiFafqg6D