### PR TITLE
Add seconds and AM/PM to launcher flip clock

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -55,9 +55,28 @@
             justify-content: center;
             gap: 4px;
             margin-bottom: 30px;
+            margin-top: -15px;
             position: relative;
             z-index: 1;
             perspective: 1000px;
+        }
+
+        .flip-ampm {
+            display: flex;
+            align-items: center;
+            margin-left: 4px;
+            font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+            font-size: 13px;
+            font-weight: 700;
+            background: linear-gradient(to bottom, #2a2a2a 0%, #222 100%);
+            color: #ddd;
+            padding: 4px 5px;
+            border-radius: 4px;
+            letter-spacing: 1px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.4);
+            text-shadow: 0 1px 2px rgba(0,0,0,0.5);
+            height: 40px;
+            align-self: center;
         }
 
         .flip-group {
@@ -350,6 +369,29 @@
                 </div>
             </div>
         </div>
+        <div class="flip-separator">
+            <div class="flip-separator-dot"></div>
+            <div class="flip-separator-dot"></div>
+        </div>
+        <div class="flip-group">
+            <div class="flip-digit" id="flip-s1">
+                <div class="flip-digit-inner">
+                    <div class="flip-card flip-card-top"><div class="flip-card-content">0</div></div>
+                    <div class="flip-card flip-card-bottom"><div class="flip-card-content">0</div></div>
+                    <div class="flip-card-flip flip-card-flip-top"><div class="flip-card-content">0</div></div>
+                    <div class="flip-card-flip flip-card-flip-bottom"><div class="flip-card-content">0</div></div>
+                </div>
+            </div>
+            <div class="flip-digit" id="flip-s2">
+                <div class="flip-digit-inner">
+                    <div class="flip-card flip-card-top"><div class="flip-card-content">0</div></div>
+                    <div class="flip-card flip-card-bottom"><div class="flip-card-content">0</div></div>
+                    <div class="flip-card-flip flip-card-flip-top"><div class="flip-card-content">0</div></div>
+                    <div class="flip-card-flip flip-card-flip-bottom"><div class="flip-card-content">0</div></div>
+                </div>
+            </div>
+        </div>
+        <div class="flip-ampm" id="flip-ampm">AM</div>
     </div>
 
     <div class="apps-grid">
@@ -463,9 +505,13 @@
             h1: document.getElementById('flip-h1'),
             h2: document.getElementById('flip-h2'),
             m1: document.getElementById('flip-m1'),
-            m2: document.getElementById('flip-m2')
+            m2: document.getElementById('flip-m2'),
+            s1: document.getElementById('flip-s1'),
+            s2: document.getElementById('flip-s2')
         };
-        let lastFlipValues = { h1: '', h2: '', m1: '', m2: '' };
+        const ampmEl = document.getElementById('flip-ampm');
+        let lastFlipValues = { h1: '', h2: '', m1: '', m2: '', s1: '', s2: '' };
+        let lastAmpm = '';
 
         function flipDigit(digitEl, oldValue, newValue) {
             const staticTop = digitEl.querySelector('.flip-card-top .flip-card-content');
@@ -502,14 +548,20 @@
         function updateFlipClock() {
             const now = new Date();
             let hours = now.getHours();
-            const minutes = now.getMinutes().toString().padStart(2, '0');
+            const ampm = hours >= 12 ? 'PM' : 'AM';
+            hours = hours % 12;
+            if (hours === 0) hours = 12;
             const hoursStr = hours.toString().padStart(2, '0');
+            const minutes = now.getMinutes().toString().padStart(2, '0');
+            const seconds = now.getSeconds().toString().padStart(2, '0');
 
             const values = {
                 h1: hoursStr[0],
                 h2: hoursStr[1],
                 m1: minutes[0],
-                m2: minutes[1]
+                m2: minutes[1],
+                s1: seconds[0],
+                s2: seconds[1]
             };
 
             for (const key in values) {
@@ -523,6 +575,11 @@
                     }
                     lastFlipValues[key] = values[key];
                 }
+            }
+
+            if (ampm !== lastAmpm) {
+                ampmEl.textContent = ampm;
+                lastAmpm = ampm;
             }
         }
 


### PR DESCRIPTION
- Added seconds digits with flip animation matching existing hour/minute style
- Converted from 24-hour to 12-hour format with AM/PM indicator
- Moved clock up with negative top margin for better positioning

https://claude.ai/code/session_018A3Lw4zZ9grpabYCSisc7p