### PR TITLE
Fix header notch overlap when adding first stopwatch

### DIFF
--- a/apps/stopwatch/index.html
+++ b/apps/stopwatch/index.html
@@ -19,7 +19,6 @@
             background: #000;
             height: 100vh;
             color: #fff;
-            padding-top: env(safe-area-inset-top);
             padding-bottom: env(safe-area-inset-bottom);
             overflow: hidden;
             display: flex;
@@ -31,6 +30,7 @@
             align-items: center;
             justify-content: space-between;
             padding: 16px 20px;
+            padding-top: calc(16px + env(safe-area-inset-top));
             border-bottom: 1px solid rgba(255, 255, 255, 0.1);
             flex-shrink: 0;
         }


### PR DESCRIPTION
Move safe-area-inset-top from body padding to header padding-top.
This prevents layout recalculation issues when DOM changes dynamically.

https://claude.ai/code/session_013Eou1bR9brBWScs6dxbeS9