### PR TITLE
Remove hamburger menu, document iOS PWA patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,46 @@ All apps live under `/apps/` so iOS standalone web apps can navigate between the
 
 When adding a new utility:
 1. Create `/apps/[name]/index.html`
-2. Add to hamburger menu in `/index.html`
-3. Add to launcher in `/apps/index.html`
+2. Add to launcher in `/apps/index.html`
+
+## iOS PWA Patterns
+
+All apps are designed to run as full-screen iOS Progressive Web Apps. Use these patterns:
+
+### Required Meta Tags
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="theme-color" content="#1a1a2e">
+```
+
+- `viewport-fit=cover` extends content behind the notch/status bar
+- `apple-mobile-web-app-capable` enables full-screen standalone mode
+- `black-translucent` makes the status bar overlay the content with a translucent background
+- `theme-color` sets the status bar background color
+
+### Safe Area Handling
+
+Use CSS environment variables to handle notch and home indicator areas:
+
+```css
+padding-top: env(safe-area-inset-top);
+padding-bottom: env(safe-area-inset-bottom);
+padding-left: env(safe-area-inset-left);
+padding-right: env(safe-area-inset-right);
+
+/* Or combine with other values */
+padding-top: calc(env(safe-area-inset-top) + 20px);
+```
+
+### iOS-Specific CSS
+
+```css
+-webkit-overflow-scrolling: touch;  /* Smooth momentum scrolling */
+-webkit-tap-highlight-color: transparent;  /* Remove tap highlight */
+```
 
 ## Local Development
 

--- a/apps/index.html
+++ b/apps/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="theme-color" content="#f4a4b4">
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <link rel="apple-touch-icon" href="icon.png">
     <title>Apps</title>

--- a/index.html
+++ b/index.html
@@ -31,59 +31,6 @@
             text-decoration: none;
         }
 
-        .hamburger {
-            position: fixed;
-            top: 20px;
-            left: 20px;
-            width: 30px;
-            height: 24px;
-            cursor: pointer;
-            z-index: 1001;
-            display: flex;
-            flex-direction: column;
-            justify-content: space-between;
-        }
-
-        .hamburger span {
-            display: block;
-            height: 3px;
-            background: #0f0;
-            border-radius: 2px;
-            transition: all 0.3s ease;
-        }
-
-
-        .nav-menu {
-            position: fixed;
-            top: 0;
-            left: -251px;
-            width: 250px;
-            height: 100%;
-            background: rgba(0, 0, 0, 0.95);
-            border-right: 1px solid #0f0;
-            transition: left 0.3s ease;
-            z-index: 1000;
-            padding-top: 70px;
-        }
-
-        .nav-menu.open {
-            left: 0;
-        }
-
-        .nav-menu a {
-            display: block;
-            padding: 15px 25px;
-            color: #0f0;
-            text-decoration: none;
-            font-size: 18px;
-            border-bottom: 1px solid rgba(0, 255, 0, 0.2);
-            transition: background 0.2s ease;
-        }
-
-        .nav-menu a:hover {
-            background: rgba(0, 255, 0, 0.1);
-        }
-
         h1 {
             margin: 0;
             margin-bottom: 5px;
@@ -96,32 +43,6 @@
     </style>
 </head>
 <body>
-    <div class="hamburger" onclick="toggleMenu()">
-        <span></span>
-        <span></span>
-        <span></span>
-    </div>
-
-    <nav class="nav-menu">
-        <a href="/apps/aes/">AES Encryption</a>
-        <a href="/apps/clock/">Clock</a>
-        <a href="/apps/countdown/">Countdown</a>
-        <a href="/apps/lunar/">Lunar Calendar</a>
-        <a href="/apps/network/">Network Info</a>
-        <a href="/apps/news/">News</a>
-        <a href="/apps/podcasts/">Podcasts</a>
-        <a href="/apps/reddit/">Reddit</a>
-        <a href="/apps/radio/">Radio</a>
-        <a href="/apps/ruler/">Ruler</a>
-        <a href="/apps/scanner/">Scanner</a>
-        <a href="/apps/simon/">Simon</a>
-        <a href="/apps/speedometer/">Speedometer</a>
-        <a href="/apps/stopwatch/">Stopwatch</a>
-        <a href="/apps/totp/">TOTP Generator</a>
-        <a href="/apps/weather/">Weather</a>
-        <a href="/apps/zippo/">Zippo</a>
-    </nav>
-
     <canvas id="matrix-bg"></canvas>
 
     <div id="resume-content">
@@ -134,11 +55,6 @@
     </div>
 
     <script>
-        function toggleMenu() {
-            document.querySelector('.hamburger').classList.toggle('open');
-            document.querySelector('.nav-menu').classList.toggle('open');
-        }
-
         // Matrix Animation Script
         const canvas = document.getElementById('matrix-bg');
         const ctx = canvas.getContext('2d');


### PR DESCRIPTION
Remove the hamburger navigation menu from the main page since the
launcher at /apps/ serves as the app navigation. Update CLAUDE.md
to remove hamburger menu references and add comprehensive iOS PWA
pattern documentation including meta tags and safe area handling.

https://claude.ai/code/session_01BTJiy4iEGf42fADCQJq8bF