### PR TITLE
Add version display to feed app home screen

### DIFF
--- a/apps/feed/CLAUDE.md
+++ b/apps/feed/CLAUDE.md
@@ -1,0 +1,11 @@
+# Feed App
+
+## Version Management
+
+**IMPORTANT:** Increment the version number in `index.html` once per PR.
+
+The version is displayed in the Home Screen header as `v1`, `v2`, etc.
+
+Location: `<h1>Feed <span class="version">vX</span></h1>` (around line 605)
+
+Current version: **v1**

--- a/apps/feed/index.html
+++ b/apps/feed/index.html
@@ -54,6 +54,13 @@
             flex: 1;
         }
 
+        .version {
+            font-size: 12px;
+            color: #666;
+            font-weight: 400;
+            margin-left: 8px;
+        }
+
         .sort-select {
             background: #2a2a2a;
             border: 1px solid #3a3a3a;
@@ -595,7 +602,7 @@
 <body>
     <div class="home-view" id="home-view">
         <div class="header">
-            <h1>Feed</h1>
+            <h1>Feed <span class="version">v1</span></h1>
             <select class="sort-select" id="sort-select">
                 <option value="hot">Hot</option>
                 <option value="new">New</option>


### PR DESCRIPTION
Display version number (v1) in the header next to the Feed title.
Add CLAUDE.md with reminder to increment version on each PR.

https://claude.ai/code/session_01SykLZdwxcajxDRhjNzcae8