### PR TITLE
Fix iOS notch area showing wrong color on feed home view

### DIFF
--- a/apps/feed/CLAUDE.md
+++ b/apps/feed/CLAUDE.md
@@ -8,4 +8,4 @@ The version is displayed in the Home Screen header as `v1`, `v2`, etc.
 
 Location: `<h1>Feed <span class="version">vX</span></h1>` (around line 605)
 
-Current version: **v1**
+Current version: **v2**

--- a/apps/feed/index.html
+++ b/apps/feed/index.html
@@ -28,9 +28,11 @@
 
         /* Home view */
         .home-view {
-            height: 100%;
-            height: 100vh;
-            height: -webkit-fill-available;
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
             background: #1a1a1a;
             padding: 20px;
             padding-top: calc(env(safe-area-inset-top) + 20px);
@@ -602,7 +604,7 @@
 <body>
     <div class="home-view" id="home-view">
         <div class="header">
-            <h1>Feed <span class="version">v1</span></h1>
+            <h1>Feed <span class="version">v2</span></h1>
             <select class="sort-select" id="sort-select">
                 <option value="hot">Hot</option>
                 <option value="new">New</option>


### PR DESCRIPTION
Use position: fixed with explicit bounds instead of height: 100vh
to ensure the home view background extends behind the notch area.

https://claude.ai/code/session_011e9N1DYM8kGSicKUvniwrL