### PR TITLE
Fix media error message centering in feed app

### DIFF
--- a/apps/feed/index.html
+++ b/apps/feed/index.html
@@ -713,7 +713,7 @@
 <body>
     <div class="home-view" id="home-view">
         <div class="header">
-            <h1>Feed <span class="version">v12</span></h1>
+            <h1>Feed <span class="version">v13</span></h1>
             <button class="export-btn" id="export-btn">Export</button>
             <select class="sort-select" id="sort-select">
                 <option value="hot">Hot</option>

--- a/apps/feed/index.html
+++ b/apps/feed/index.html
@@ -587,6 +587,8 @@
             justify-content: center;
             gap: 12px;
             color: #666;
+            width: 100%;
+            height: 100%;
         }
 
         .media-error-icon {
@@ -1440,9 +1442,9 @@
 
         // Handle media error - show error state with skip button
         function handleMediaError(feedItem, index) {
-            const mediaEl = feedItem.querySelector('.feed-item-media');
-            if (mediaEl) {
-                mediaEl.style.display = 'none';
+            const mediaContainer = feedItem.querySelector('.media-container');
+            if (mediaContainer) {
+                mediaContainer.style.display = 'none';
             }
 
             // Check if error state already exists


### PR DESCRIPTION
Hide the entire media-container (not just the media element) on error,
and give .media-error full width/height so it centers properly within
the flex parent.

https://claude.ai/code/session_013aLyXyKPmGdpgzd7eJf3Wb