### PR TITLE
Fix autoplay getting stuck on hidden small images

### DIFF
--- a/apps/feed/index.html
+++ b/apps/feed/index.html
@@ -713,7 +713,7 @@
 <body>
     <div class="home-view" id="home-view">
         <div class="header">
-            <h1>Feed <span class="version">v16</span></h1>
+            <h1>Feed <span class="version">v17</span></h1>
             <button class="export-btn" id="export-btn">Export</button>
             <select class="sort-select" id="sort-select">
                 <option value="hot">Hot</option>
@@ -1447,7 +1447,13 @@
         // Skip to next feed item
         function skipToNext(currentIndex) {
             const container = document.getElementById('feed-container');
-            const nextItem = container.querySelector(`.feed-item[data-index="${currentIndex + 1}"]`);
+            let nextIdx = currentIndex + 1;
+            let nextItem = container.querySelector(`.feed-item[data-index="${nextIdx}"]`);
+            // Skip over hidden items (e.g. small images that were filtered out)
+            while (nextItem && nextItem.style.display === 'none') {
+                nextIdx++;
+                nextItem = container.querySelector(`.feed-item[data-index="${nextIdx}"]`);
+            }
             if (nextItem) {
                 nextItem.scrollIntoView({ behavior: 'smooth' });
             }

--- a/apps/feed/index.html
+++ b/apps/feed/index.html
@@ -1455,7 +1455,14 @@
                 nextItem = container.querySelector(`.feed-item[data-index="${nextIdx}"]`);
             }
             if (nextItem) {
+                state.currentIndex = nextIdx;
+                updateMediaWindow(nextIdx);
                 nextItem.scrollIntoView({ behavior: 'smooth' });
+                // Restart autoplay for the new item (in case IntersectionObserver
+                // doesn't fire, e.g. if the item is already mostly visible)
+                if (state.autoplay) {
+                    startAutoplayForCurrentItem();
+                }
             }
         }
 
@@ -2197,19 +2204,7 @@
                     if (img.naturalWidth < 200 && img.naturalHeight < 200) {
                         feedItem.style.display = 'none';
                         if (state.currentIndex === index) {
-                            // Find next visible feed item
-                            const container = document.getElementById('feed-container');
-                            let nextIdx = index + 1;
-                            let nextItem = container.querySelector(`.feed-item[data-index="${nextIdx}"]`);
-                            while (nextItem && nextItem.style.display === 'none') {
-                                nextIdx++;
-                                nextItem = container.querySelector(`.feed-item[data-index="${nextIdx}"]`);
-                            }
-                            if (nextItem) {
-                                state.currentIndex = nextIdx;
-                                updateMediaWindow(nextIdx);
-                                nextItem.scrollIntoView({ behavior: 'smooth' });
-                            }
+                            skipToNext(index);
                         }
                     }
                 };


### PR DESCRIPTION
skipToNext() always targeted currentIndex+1 without checking if that
item was hidden (display:none) by the small image filter. When media
is preloaded ahead, tiny placeholder images get detected and hidden
before autoplay reaches them, causing scrollIntoView on a display:none
element which is a no-op — permanently stalling autoplay.

Add a while-loop to skip over hidden items, matching the pattern
already used in the small image onload handler.

Bump version to v17.

https://claude.ai/code/session_018XPfdMhoDNDtVKjmY8jUqt