### PR TITLE
Fix stopwatch header pushed behind notch when adding stopwatch

### DIFF
--- a/apps/stopwatch/index.html
+++ b/apps/stopwatch/index.html
@@ -17,7 +17,8 @@
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', Roboto, sans-serif;
             background: #000;
-            height: 100vh;
+            position: fixed;
+            inset: 0;
             color: #fff;
             padding-bottom: env(safe-area-inset-bottom);
             overflow: hidden;
@@ -697,6 +698,8 @@
         function hideAddModal() {
             const overlay = document.getElementById('modal-overlay');
             overlay.classList.remove('visible');
+            // Reset scroll position in case iOS keyboard scrolled the page
+            window.scrollTo(0, 0);
         }
 
         // Handle overlay click


### PR DESCRIPTION
On iOS, focusing the modal input triggers keyboard avoidance that scrolls
the body despite overflow:hidden. After the modal closes, the scroll
position isn't reset, leaving the header (and + button) behind the notch.

Replace height:100vh with position:fixed;inset:0 so the body can't be
scrolled by iOS keyboard behavior. Also reset scroll position on modal
close as a safety net.

https://claude.ai/code/session_01NNRpDcdKjxRw3tLAqfQj7Q