### PR TITLE
Fix moon phase display showing full moon for all phases

### DIFF
--- a/apps/cycle/index.html
+++ b/apps/cycle/index.html
@@ -410,7 +410,7 @@ function drawMoonPhase(phase) {
         } else if (p < 0.5) {
             // Waxing gibbous - right side lit, expanding
             const f = Math.cos((p - 0.25) / 0.25 * Math.PI / 2);
-            xLeft = cx - xBase * f;
+            xLeft = cx - xBase * (1 - f);
             xRight = cx + xBase;
         } else if (p < 0.75) {
             // Waning gibbous - left side lit
@@ -421,7 +421,7 @@ function drawMoonPhase(phase) {
             // Waning crescent - left side lit, shrinking
             const f = Math.cos((p - 0.75) / 0.25 * Math.PI / 2);
             xLeft = cx - xBase;
-            xRight = cx - xBase * f;
+            xRight = cx - xBase * (1 - f);
         }
 
         if (i === -r) ctx.moveTo(xLeft, y);
@@ -441,7 +441,7 @@ function drawMoonPhase(phase) {
             xRight = cx + xBase * f;
         } else {
             const f = Math.cos((p - 0.75) / 0.25 * Math.PI / 2);
-            xRight = cx - xBase * f;
+            xRight = cx - xBase * (1 - f);
         }
         ctx.lineTo(xRight, y);
     }


### PR DESCRIPTION
The waxing gibbous and waning crescent interpolation formulas were
reversed — the cosine factor `f` was used directly instead of `(1-f)`,
causing the illuminated region to be nearly the full circle for most
phase values. This was especially visible with today's waxing gibbous
phase (~0.27), where xLeft landed near the left edge of the circle
instead of near the center.

https://claude.ai/code/session_01Vg5LgojJRqDGyQGurW54ew