### PR TITLE
Fix pixel grid layout to fill the screen

### DIFF
--- a/apps/pixels/index.html
+++ b/apps/pixels/index.html
@@ -90,7 +90,7 @@
             border: 2px solid #333;
             border-radius: 4px;
             aspect-ratio: 1;
-            max-width: 100%;
+            width: 100%;
             max-height: 100%;
         }
 


### PR DESCRIPTION
The grid had max-width/max-height constraints but no explicit size,
causing it to collapse to minimal size. Set width: 100% so the grid
fills its container, with max-height: 100% and aspect-ratio: 1
keeping it square.

https://claude.ai/code/session_01KwroLyqYFMXjz7qruirKbJ