### PR TITLE
Fix pixels app API URL to use correct worker domain

### DIFF
--- a/apps/pixels/index.html
+++ b/apps/pixels/index.html
@@ -129,7 +129,7 @@
     </div>
 
     <script>
-        const API_BASE = 'https://worker.polkiewicz.com';
+        const API_BASE = 'https://cloudflare-backend.maattp.workers.dev';
         const GRID_SIZE = 25;
         const COLORS = [
             '#000000', '#ff4444', '#ff9900', '#ffdd00',


### PR DESCRIPTION
The pixels app was using https://worker.polkiewicz.com which has an
invalid SSL certificate (ERR_CERT_COMMON_NAME_INVALID), causing all
API requests to silently fail. Changed to use the same workers.dev
domain that all other apps use.

https://claude.ai/code/session_01SLA5HNQXBoFCctjxYrdFDt