### PR TITLE
Disable double-tap zoom in pixels app

### DIFF
--- a/apps/pixels/index.html
+++ b/apps/pixels/index.html
@@ -300,6 +300,16 @@
         document.addEventListener('gesturechange', e => e.preventDefault());
         document.addEventListener('gestureend', e => e.preventDefault());
 
+        // Prevent double-tap zoom (iOS ignores touch-action: none for this)
+        let lastTouchEnd = 0;
+        document.addEventListener('touchend', e => {
+            const now = Date.now();
+            if (now - lastTouchEnd <= 300) {
+                e.preventDefault();
+            }
+            lastTouchEnd = now;
+        }, { passive: false });
+
         // Load shared canvas on start
         loadGrid();
     </script>


### PR DESCRIPTION
iOS Safari ignores touch-action: none for double-tap zoom. Add a
touchend listener that detects rapid successive taps (<=300ms) and
prevents the default zoom behavior.

https://claude.ai/code/session_01FoViPyXFhw7BpCL2D78ipg