### PR TITLE
Add Dam Builder game: isometric beach with SPH fluid sim

### DIFF
--- a/apps/dam/css/main.css
+++ b/apps/dam/css/main.css
@@ -1,0 +1,260 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+html, body {
+    height: 100%;
+    overflow: hidden;
+    touch-action: none;
+    overscroll-behavior: none;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #e6c896;
+    color: #3a2a1a;
+    position: fixed;
+    inset: 0;
+}
+
+#scene {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+    touch-action: none;
+}
+
+.hud {
+    position: absolute;
+    top: calc(env(safe-area-inset-top) + 10px);
+    left: calc(env(safe-area-inset-left) + 14px);
+    right: calc(env(safe-area-inset-right) + 14px);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    z-index: 5;
+    pointer-events: none;
+}
+
+.hud-stat {
+    background: rgba(58, 42, 26, 0.72);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    color: #fff8e8;
+    padding: 6px 12px;
+    border-radius: 14px;
+    font-size: 13px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    pointer-events: auto;
+}
+
+.hud-label {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.7;
+}
+
+.hud-value {
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    min-width: 36px;
+}
+
+.hud-btn {
+    margin-left: auto;
+    background: rgba(58, 42, 26, 0.72);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    color: #fff8e8;
+    border: none;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    font-size: 16px;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: auto;
+    transition: transform 0.1s ease;
+}
+
+.hud-btn:active {
+    transform: scale(0.9);
+}
+
+.hud-btn + .hud-btn {
+    margin-left: 0;
+}
+
+.toolbar {
+    position: absolute;
+    bottom: calc(env(safe-area-inset-bottom) + 12px);
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 8px;
+    padding: 8px;
+    background: rgba(58, 42, 26, 0.82);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    border-radius: 22px;
+    z-index: 5;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.2);
+}
+
+.tool {
+    position: relative;
+    background: transparent;
+    border: none;
+    color: #fff8e8;
+    width: 62px;
+    height: 62px;
+    border-radius: 16px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    cursor: pointer;
+    transition: background 0.15s ease, transform 0.1s ease;
+    overflow: hidden;
+}
+
+.tool:active {
+    transform: scale(0.94);
+}
+
+.tool.active {
+    background: rgba(255, 248, 232, 0.18);
+}
+
+.tool.disabled {
+    opacity: 0.45;
+}
+
+.tool-icon {
+    width: 28px;
+    height: 28px;
+    display: block;
+    pointer-events: none;
+}
+
+.tool-label {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+.sand-icon {
+    background:
+        radial-gradient(circle at 30% 30%, #f0d090 2px, transparent 3px),
+        radial-gradient(circle at 65% 40%, #e6bf7a 2px, transparent 3px),
+        radial-gradient(circle at 45% 70%, #f5dc9f 2px, transparent 3px),
+        radial-gradient(circle at 75% 80%, #d9b268 2px, transparent 3px),
+        radial-gradient(circle at 20% 80%, #ecc888 2px, transparent 3px),
+        #c9a25c;
+    border-radius: 50%;
+    box-shadow: inset 0 -2px 4px rgba(0,0,0,0.2);
+}
+
+.rock-icon {
+    background:
+        radial-gradient(ellipse at 35% 30%, #a0a0a0 30%, #666 100%);
+    border-radius: 45% 55% 50% 50% / 55% 50% 50% 45%;
+    box-shadow:
+        inset -2px -3px 4px rgba(0,0,0,0.4),
+        inset 2px 2px 2px rgba(255,255,255,0.2);
+}
+
+.stick-icon {
+    background:
+        linear-gradient(135deg, #8b5a2b 0%, #6b3e18 100%);
+    border-radius: 3px;
+    transform: rotate(-30deg);
+    width: 32px;
+    height: 7px;
+    box-shadow:
+        inset 0 -1px 2px rgba(0,0,0,0.4),
+        inset 0 1px 1px rgba(255,255,255,0.2);
+    position: relative;
+}
+
+.stick-icon::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 3px;
+    background:
+        repeating-linear-gradient(90deg,
+            transparent 0px,
+            transparent 4px,
+            rgba(0,0,0,0.15) 4px,
+            rgba(0,0,0,0.15) 5px);
+}
+
+.dig-icon {
+    background:
+        linear-gradient(135deg, #d9a460 0%, #b07838 100%);
+    clip-path: polygon(50% 0%, 100% 40%, 85% 100%, 15% 100%, 0% 40%);
+    position: relative;
+}
+
+.dig-icon::before {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 30%;
+    width: 4px;
+    height: 50%;
+    background: rgba(0,0,0,0.35);
+    transform: translateX(-50%);
+    border-radius: 2px;
+}
+
+.cooldown-ring {
+    position: absolute;
+    inset: 4px;
+    border-radius: 12px;
+    pointer-events: none;
+    background: conic-gradient(
+        rgba(0,0,0,0.55) var(--fill, 0deg),
+        transparent 0deg
+    );
+    opacity: 0;
+    transition: opacity 0.15s ease;
+}
+
+.tool.cooling .cooldown-ring {
+    opacity: 1;
+}
+
+.flash {
+    position: absolute;
+    inset: 0;
+    background: #fff;
+    opacity: 0;
+    pointer-events: none;
+    z-index: 4;
+}
+
+.flash.show {
+    animation: flashAnim 0.4s ease-out;
+}
+
+@keyframes flashAnim {
+    0% { opacity: 0.35; }
+    100% { opacity: 0; }
+}

--- a/apps/dam/index.html
+++ b/apps/dam/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="theme-color" content="#d9b88c">
+    <title>Dam</title>
+    <link rel="stylesheet" href="css/main.css">
+</head>
+<body>
+    <canvas id="scene"></canvas>
+
+    <div class="hud" id="hud">
+        <div class="hud-stat" id="heldStat">
+            <span class="hud-label">Held</span>
+            <span class="hud-value" id="heldValue">0s</span>
+        </div>
+        <button class="hud-btn" id="resetBtn" aria-label="Reset">↺</button>
+        <button class="hud-btn" id="muteBtn" aria-label="Mute">🔊</button>
+    </div>
+
+    <div class="toolbar" id="toolbar">
+        <button class="tool active" data-tool="sand">
+            <span class="tool-icon sand-icon"></span>
+            <span class="tool-label">Sand</span>
+        </button>
+        <button class="tool" data-tool="rock">
+            <span class="tool-icon rock-icon"></span>
+            <span class="tool-label">Rock</span>
+            <span class="cooldown-ring"></span>
+        </button>
+        <button class="tool" data-tool="stick">
+            <span class="tool-icon stick-icon"></span>
+            <span class="tool-label">Stick</span>
+            <span class="cooldown-ring"></span>
+        </button>
+        <button class="tool" data-tool="dig">
+            <span class="tool-icon dig-icon"></span>
+            <span class="tool-label">Dig</span>
+        </button>
+    </div>
+
+    <script type="module" src="js/main.js"></script>
+</body>
+</html>

--- a/apps/dam/js/audio.js
+++ b/apps/dam/js/audio.js
@@ -1,0 +1,177 @@
+// Web Audio ambient loop (filtered noise ocean/stream bed) + short procedural SFX.
+// No external samples — everything generated from AudioBuffers.
+
+export class Audio {
+    constructor() {
+        this.ctx = null;
+        this.master = null;
+        this.ambientGain = null;
+        this.sfxGain = null;
+        this.ambientStarted = false;
+        this.muted = false;
+        this._lastSfxTime = 0;
+    }
+
+    unlock() {
+        if (this.ctx) return;
+        try {
+            this.ctx = new (window.AudioContext || window.webkitAudioContext)();
+        } catch (e) {
+            return;
+        }
+        this.master = this.ctx.createGain();
+        this.master.gain.value = this.muted ? 0 : 0.6;
+        this.master.connect(this.ctx.destination);
+        this.ambientGain = this.ctx.createGain();
+        this.ambientGain.gain.value = 0;
+        this.ambientGain.connect(this.master);
+        this.sfxGain = this.ctx.createGain();
+        this.sfxGain.gain.value = 0.9;
+        this.sfxGain.connect(this.master);
+        this._startAmbient();
+    }
+
+    setMuted(m) {
+        this.muted = m;
+        if (this.master) {
+            this.master.gain.linearRampToValueAtTime(
+                m ? 0 : 0.6,
+                this.ctx.currentTime + 0.1,
+            );
+        }
+    }
+
+    _startAmbient() {
+        if (this.ambientStarted) return;
+        this.ambientStarted = true;
+        const ctx = this.ctx;
+
+        // Pink-ish noise through a lowpass for distant surf
+        const noiseBuffer = ctx.createBuffer(1, ctx.sampleRate * 2, ctx.sampleRate);
+        const data = noiseBuffer.getChannelData(0);
+        let last = 0;
+        for (let i = 0; i < data.length; i++) {
+            const white = Math.random() * 2 - 1;
+            last = 0.98 * last + 0.02 * white;
+            data[i] = last * 1.5;
+        }
+        const surf = ctx.createBufferSource();
+        surf.buffer = noiseBuffer;
+        surf.loop = true;
+        const lp = ctx.createBiquadFilter();
+        lp.type = 'lowpass';
+        lp.frequency.value = 360;
+        lp.Q.value = 0.3;
+        const surfGain = ctx.createGain();
+        surfGain.gain.value = 0.35;
+        surf.connect(lp).connect(surfGain).connect(this.ambientGain);
+        surf.start();
+
+        // Higher-frequency "stream trickle" layer
+        const trickle = ctx.createBufferSource();
+        trickle.buffer = noiseBuffer;
+        trickle.loop = true;
+        trickle.detune.value = 600;
+        const bp = ctx.createBiquadFilter();
+        bp.type = 'bandpass';
+        bp.frequency.value = 2800;
+        bp.Q.value = 0.6;
+        const trickleGain = ctx.createGain();
+        trickleGain.gain.value = 0.15;
+        trickle.connect(bp).connect(trickleGain).connect(this.ambientGain);
+        trickle.start();
+
+        // Slow LFO modulates lowpass for "waves" feel
+        const lfo = ctx.createOscillator();
+        lfo.frequency.value = 0.11;
+        const lfoGain = ctx.createGain();
+        lfoGain.gain.value = 140;
+        lfo.connect(lfoGain).connect(lp.frequency);
+        lfo.start();
+
+        // Fade in
+        this.ambientGain.gain.linearRampToValueAtTime(0.55, ctx.currentTime + 2.5);
+    }
+
+    playPlace(kind) {
+        if (!this.ctx) return;
+        const now = this.ctx.currentTime;
+        if (now - this._lastSfxTime < 0.03) return; // throttle
+        this._lastSfxTime = now;
+        if (kind === 'sand' || kind === 'dig') {
+            this._playNoiseBurst(0.08, 800, 3200, 0.18);
+        } else if (kind === 'rock') {
+            this._playThunk(120, 0.22, 0.35);
+        } else if (kind === 'stick') {
+            this._playThunk(260, 0.15, 0.22);
+        }
+    }
+
+    playBreak(kind, xPan = 0) {
+        if (!this.ctx) return;
+        if (kind === 'rock') {
+            this._playRumble(0.9, 0.5);
+        } else {
+            this._playNoiseBurst(0.25, 400, 2400, 0.3);
+        }
+    }
+
+    _playNoiseBurst(duration, freqFrom, freqTo, gain) {
+        const ctx = this.ctx;
+        const buf = ctx.createBuffer(1, Math.floor(ctx.sampleRate * duration), ctx.sampleRate);
+        const d = buf.getChannelData(0);
+        for (let i = 0; i < d.length; i++) {
+            d[i] = (Math.random() * 2 - 1) * (1 - i / d.length);
+        }
+        const src = ctx.createBufferSource();
+        src.buffer = buf;
+        const f = ctx.createBiquadFilter();
+        f.type = 'bandpass';
+        f.frequency.setValueAtTime(freqFrom, ctx.currentTime);
+        f.frequency.exponentialRampToValueAtTime(freqTo, ctx.currentTime + duration);
+        f.Q.value = 1.1;
+        const g = ctx.createGain();
+        g.gain.value = gain;
+        g.gain.setValueAtTime(gain, ctx.currentTime);
+        g.gain.linearRampToValueAtTime(0, ctx.currentTime + duration);
+        src.connect(f).connect(g).connect(this.sfxGain);
+        src.start();
+        src.stop(ctx.currentTime + duration + 0.02);
+    }
+
+    _playThunk(freq, duration, gain) {
+        const ctx = this.ctx;
+        const osc = ctx.createOscillator();
+        osc.type = 'sine';
+        osc.frequency.setValueAtTime(freq * 1.4, ctx.currentTime);
+        osc.frequency.exponentialRampToValueAtTime(freq * 0.6, ctx.currentTime + duration);
+        const g = ctx.createGain();
+        g.gain.setValueAtTime(0, ctx.currentTime);
+        g.gain.linearRampToValueAtTime(gain, ctx.currentTime + 0.01);
+        g.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + duration);
+        osc.connect(g).connect(this.sfxGain);
+        osc.start();
+        osc.stop(ctx.currentTime + duration + 0.02);
+    }
+
+    _playRumble(duration, gain) {
+        const ctx = this.ctx;
+        const buf = ctx.createBuffer(1, Math.floor(ctx.sampleRate * duration), ctx.sampleRate);
+        const d = buf.getChannelData(0);
+        let last = 0;
+        for (let i = 0; i < d.length; i++) {
+            last = 0.97 * last + 0.03 * (Math.random() * 2 - 1);
+            d[i] = last * 2.2 * (1 - i / d.length);
+        }
+        const src = ctx.createBufferSource();
+        src.buffer = buf;
+        const lp = ctx.createBiquadFilter();
+        lp.type = 'lowpass';
+        lp.frequency.value = 220;
+        const g = ctx.createGain();
+        g.gain.value = gain;
+        src.connect(lp).connect(g).connect(this.sfxGain);
+        src.start();
+        src.stop(ctx.currentTime + duration + 0.05);
+    }
+}

--- a/apps/dam/js/config.js
+++ b/apps/dam/js/config.js
@@ -1,0 +1,61 @@
+// World grid (the stream flows from back, j=0, toward camera, j=GRID_H-1)
+export const GRID_W = 26;
+export const GRID_H = 40;
+
+// Isometric tile dimensions in screen pixels at scale 1
+export const TILE_W = 24;
+export const TILE_H = 12;
+export const HEIGHT_SCALE = 10;
+
+// Terrain shape
+export const BEACH_SLOPE = 0.09;      // rise per cell going upstream
+export const STREAM_DEPTH = 3.0;      // depth of the natural stream valley
+export const STREAM_WIDTH = 2.6;      // half-width of the valley in cells
+export const STREAM_MEANDER = 1.6;    // sine amplitude
+export const STREAM_FREQ = 0.2;       // meander frequency
+export const BANK_SLOPE = 1.1;        // rise per cell going laterally away from stream
+export const BANK_MAX = 3.8;          // cap on bank rise so beach plateaus
+export const SPRING_POOL_ROWS = 3;    // extra-deep rows near the top for the spring
+export const SPRING_POOL_EXTRA = 1.2;
+export const OCEAN_ROW = GRID_H - 3;  // where ocean waves start
+
+// SPH
+export const PARTICLE_MASS = 1.0;
+export const H = 0.78;                // smoothing length (world units)
+export const H2 = H * H;
+export const REST_DENSITY = 3.2;
+export const STIFFNESS = 55;
+export const VISCOSITY = 2.8;
+export const GRAVITY = 9.0;           // slope-driven force magnitude
+export const TERRAIN_WALL_K = 240;    // spring constant for terrain walls
+export const TERRAIN_DAMP = 4.0;
+export const MAX_PARTICLES = 1600;
+export const MAX_SPEED = 10.0;
+
+// Spawning
+export const SPAWN_PER_SEC = 240;     // total per second from the spring
+export const SPAWN_JITTER = 0.35;
+
+// Erosion thresholds (flow-force needed to dislodge 1 unit)
+export const SAND_RESIST = 0.55;      // easily washed
+export const STICK_RESIST = 2.8;      // medium
+export const ROCK_RESIST = 7.5;       // hard to move
+export const EROSION_RATE = 1.3;      // sand erosion scaling
+
+// Material heights per unit stacked in a cell (world units)
+export const SAND_UNIT_H = 0.18;
+export const STICK_UNIT_H = 0.30;
+export const ROCK_UNIT_H = 0.45;
+
+// Tool cooldowns (ms) and dispenses
+export const ROCK_CD = 850;
+export const STICK_CD = 450;
+export const SAND_PLACE_AMOUNT = 0.9;
+export const DIG_AMOUNT = 0.9;
+
+// Simulation
+export const DT = 1 / 90;             // physics timestep
+export const MAX_SUBSTEPS = 3;        // cap substeps per frame
+
+// Camera
+export const CAM_MARGIN = 28;

--- a/apps/dam/js/controls.js
+++ b/apps/dam/js/controls.js
@@ -1,0 +1,126 @@
+import { ROCK_CD, STICK_CD, GRID_W, GRID_H, SAND_PLACE_AMOUNT, DIG_AMOUNT } from './config.js';
+
+// Manages the active tool, cooldown UI, and pointer (touch/mouse) events
+// on the canvas. Placement is throttled so a drag emits a steady stream
+// of place events, not hundreds per second.
+
+export class Controls {
+    constructor(canvas, renderer, terrain, audio) {
+        this.canvas = canvas;
+        this.renderer = renderer;
+        this.terrain = terrain;
+        this.audio = audio;
+        this.activeTool = 'sand';
+        this.toolButtons = {};
+        this.cooldowns = { rock: 0, stick: 0 };
+        this.cooldownMax = { rock: ROCK_CD, stick: STICK_CD };
+        this.lastDragPlaceTime = 0;
+        this.pointerActive = false;
+        this.lastX = 0;
+        this.lastY = 0;
+        this._setupToolbar();
+        this._setupPointerEvents();
+    }
+
+    _setupToolbar() {
+        const buttons = document.querySelectorAll('.tool');
+        buttons.forEach(btn => {
+            this.toolButtons[btn.dataset.tool] = btn;
+            btn.addEventListener('click', (ev) => {
+                ev.preventDefault();
+                this.setTool(btn.dataset.tool);
+                this.audio?.unlock();
+            });
+        });
+    }
+
+    setTool(name) {
+        this.activeTool = name;
+        for (const tool in this.toolButtons) {
+            this.toolButtons[tool].classList.toggle('active', tool === name);
+        }
+    }
+
+    _setupPointerEvents() {
+        const c = this.canvas;
+        const onDown = (ev) => {
+            ev.preventDefault();
+            this.audio?.unlock();
+            this.pointerActive = true;
+            const { x, y } = this._clientXY(ev);
+            this.lastX = x;
+            this.lastY = y;
+            this._attemptPlace(x, y, true);
+        };
+        const onMove = (ev) => {
+            if (!this.pointerActive) return;
+            ev.preventDefault();
+            const { x, y } = this._clientXY(ev);
+            // Continuous drag placement (throttled)
+            this.lastX = x;
+            this.lastY = y;
+            this._attemptPlace(x, y, false);
+        };
+        const onUp = (ev) => {
+            this.pointerActive = false;
+        };
+        c.addEventListener('pointerdown', onDown);
+        c.addEventListener('pointermove', onMove);
+        c.addEventListener('pointerup', onUp);
+        c.addEventListener('pointercancel', onUp);
+        c.addEventListener('pointerleave', onUp);
+    }
+
+    _clientXY(ev) {
+        const rect = this.canvas.getBoundingClientRect();
+        return {
+            x: ev.clientX - rect.left,
+            y: ev.clientY - rect.top,
+        };
+    }
+
+    _attemptPlace(cx, cy, isTap) {
+        const world = this.renderer.clientToWorld(cx, cy);
+        if (world.x < 0 || world.x >= GRID_W || world.y < 0 || world.y >= GRID_H) return;
+        const tool = this.activeTool;
+
+        if (tool === 'sand') {
+            // Drag throttle: only place every ~50ms during drag
+            const now = performance.now();
+            if (!isTap && now - this.lastDragPlaceTime < 40) return;
+            this.lastDragPlaceTime = now;
+            this.terrain.addSand(world.x, world.y, 1.1, SAND_PLACE_AMOUNT * (isTap ? 1.0 : 0.55));
+            this.audio?.playPlace('sand');
+        } else if (tool === 'dig') {
+            const now = performance.now();
+            if (!isTap && now - this.lastDragPlaceTime < 40) return;
+            this.lastDragPlaceTime = now;
+            this.terrain.dig(world.x, world.y, 1.1, DIG_AMOUNT * (isTap ? 1.0 : 0.55));
+            this.audio?.playPlace('dig');
+        } else if (tool === 'rock') {
+            if (this.cooldowns.rock > 0) return;
+            const ci = Math.floor(world.x), cj = Math.floor(world.y);
+            this.terrain.addRock(ci, cj);
+            this.cooldowns.rock = this.cooldownMax.rock;
+            this.audio?.playPlace('rock');
+        } else if (tool === 'stick') {
+            if (this.cooldowns.stick > 0) return;
+            const ci = Math.floor(world.x), cj = Math.floor(world.y);
+            this.terrain.addStick(ci, cj);
+            this.cooldowns.stick = this.cooldownMax.stick;
+            this.audio?.playPlace('stick');
+        }
+    }
+
+    update(dtMs) {
+        for (const tool of ['rock', 'stick']) {
+            if (this.cooldowns[tool] > 0) {
+                this.cooldowns[tool] = Math.max(0, this.cooldowns[tool] - dtMs);
+                const btn = this.toolButtons[tool];
+                const frac = this.cooldowns[tool] / this.cooldownMax[tool];
+                btn.classList.toggle('cooling', frac > 0);
+                btn.style.setProperty('--fill', `${frac * 360}deg`);
+            }
+        }
+    }
+}

--- a/apps/dam/js/erosion.js
+++ b/apps/dam/js/erosion.js
@@ -1,0 +1,149 @@
+import { GRID_W, GRID_H, SAND_RESIST, STICK_RESIST, ROCK_RESIST } from './config.js';
+
+// Couples the SPH simulation to the terrain. Each frame, it walks the
+// particle array, figures out which cell each particle is in, and adds
+// kinetic-energy-proportional stress to that cell. Then it asks the
+// terrain to erode based on accumulated stress.
+//
+// Also simulates "debris" — rocks and sticks that have been dislodged and
+// are tumbling downstream. Debris can impact other cells and cause further
+// material to fail, producing the domino effect.
+
+export class Erosion {
+    constructor(terrain, sph, audio) {
+        this.terrain = terrain;
+        this.sph = sph;
+        this.audio = audio;
+        this.debris = [];        // tumbling objects
+        this.breachEvents = [];  // for audio/effects (list of {x,y,force})
+    }
+
+    step(dt) {
+        this._applyParticleStress();
+        this._updateFlowMag();
+        const newBreaches = [];
+        const debrisOut = [];
+        this.terrain.erode(dt, debrisOut);
+        for (const d of debrisOut) {
+            this.debris.push(d);
+            newBreaches.push({ x: d.x, y: d.y, kind: d.kind });
+        }
+        this._updateDebris(dt);
+        this.terrain.clearStress();
+
+        if (newBreaches.length > 0 && this.audio) {
+            for (const b of newBreaches) {
+                this.audio.playBreak(b.kind, b.x / GRID_W);
+            }
+        }
+        this.breachEvents = newBreaches;
+    }
+
+    _applyParticleStress() {
+        const { px, py, vx, vy, alive, capacity } = this.sph;
+        const { terrain } = this;
+        for (let p = 0; p < capacity; p++) {
+            if (!alive[p]) continue;
+            const ci = px[p] | 0;
+            const cj = py[p] | 0;
+            if (!terrain.inBounds(ci, cj)) continue;
+            // Stress from horizontal kinetic energy × (elevation above particle)
+            const v2 = vx[p] * vx[p] + vy[p] * vy[p];
+            const e = terrain.elevation(ci, cj);
+            // If the particle is near a raised cell, it pushes on the wall of that cell.
+            // Use per-neighbor stress so materials on tall cells get stressed by fast water below.
+            const stress = v2 * 0.06;
+            terrain.accumulateStress(ci, cj, stress);
+            // Bleed stress to neighbor cells the particle is pressing against
+            const fx = px[p] - ci - 0.5;
+            const fy = py[p] - cj - 0.5;
+            if (fx > 0.2) terrain.accumulateStress(ci + 1, cj, stress * 0.7);
+            if (fx < -0.2) terrain.accumulateStress(ci - 1, cj, stress * 0.7);
+            if (fy > 0.2) terrain.accumulateStress(ci, cj + 1, stress * 0.7);
+            if (fy < -0.2) terrain.accumulateStress(ci, cj - 1, stress * 0.7);
+        }
+    }
+
+    _updateFlowMag() {
+        const { px, py, vx, vy, alive, capacity } = this.sph;
+        const { terrain } = this;
+        // Exponential decay of previous frame's flow magnitude
+        for (let k = 0; k < terrain.flowMag.length; k++) terrain.flowMag[k] *= 0.88;
+        for (let p = 0; p < capacity; p++) {
+            if (!alive[p]) continue;
+            const ci = px[p] | 0;
+            const cj = py[p] | 0;
+            if (!terrain.inBounds(ci, cj)) continue;
+            const speed = Math.sqrt(vx[p] * vx[p] + vy[p] * vy[p]);
+            terrain.flowMag[terrain.idx(ci, cj)] = Math.min(
+                10,
+                terrain.flowMag[terrain.idx(ci, cj)] + speed * 0.02,
+            );
+        }
+    }
+
+    _updateDebris(dt) {
+        const { terrain } = this;
+        const surviving = [];
+        for (const d of this.debris) {
+            // Gravity on z
+            d.vz -= 9 * dt;
+            d.elevZ += d.vz * dt;
+            if (d.elevZ < 0) d.elevZ = 0;
+
+            // Slope-driven horizontal acceleration + sample velocity from water
+            const g = terrain.gradientAt(d.x, d.y);
+            const mass = d.kind === 'rock' ? 3.5 : 1.4;
+            d.vx += (-g.dx * 6 / mass) * dt;
+            d.vy += (-g.dy * 6 / mass + 1.6 / mass) * dt;
+            // Water drag
+            d.vx *= 1 - dt * 2.4;
+            d.vy = d.vy * (1 - dt * 2.4) + 1.2 * dt;
+            d.x += d.vx * dt;
+            d.y += d.vy * dt;
+
+            d.angle += d.spin * dt;
+            d.spin *= 1 - dt * 1.5;
+            d.life += dt;
+
+            // Collide with terrain walls: if new cell has much higher elevation, bounce
+            if (d.elevZ <= 0.05) {
+                const ci = d.x | 0, cj = d.y | 0;
+                if (terrain.inBounds(ci, cj)) {
+                    const here = terrain.elevation(ci, cj);
+                    // If we're still touching a raised cell (shouldn't happen often), nudge out
+                    // and apply stress that might domino another material away.
+                    const impact = Math.min(6, d.vx * d.vx + d.vy * d.vy);
+                    const threshold = d.kind === 'rock' ? SAND_RESIST * 2 : SAND_RESIST;
+                    if (impact > threshold) {
+                        terrain.accumulateStress(ci, cj, impact * 1.2);
+                        // Occasionally dislodge a neighbor rock/stick directly on impact
+                        if (d.kind === 'rock') {
+                            const nci = ci + Math.sign(d.vx || 1e-6) | 0;
+                            const ncj = cj + Math.sign(d.vy || 1e-6) | 0;
+                            if (terrain.inBounds(nci, ncj)) {
+                                terrain.accumulateStress(nci, ncj, impact * 0.6);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Kill if past ocean or off-grid
+            if (d.y > GRID_H - 0.3 || d.x < 0 || d.x > GRID_W) continue;
+            // Kill if it comes to rest after long time
+            if (d.life > 3.5 && Math.abs(d.vx) < 0.1 && Math.abs(d.vy) < 0.3) {
+                // Deposit as sand at this spot (it got buried)
+                const sandAmount = d.kind === 'rock' ? 0.3 : 0.15;
+                terrain.addSand(d.x, d.y, 0.7, sandAmount);
+                continue;
+            }
+            surviving.push(d);
+        }
+        this.debris = surviving;
+    }
+
+    reset() {
+        this.debris.length = 0;
+    }
+}

--- a/apps/dam/js/isometric.js
+++ b/apps/dam/js/isometric.js
@@ -1,0 +1,64 @@
+import { TILE_W, TILE_H, HEIGHT_SCALE, GRID_W, GRID_H, CAM_MARGIN } from './config.js';
+
+// Convert world (x, y, elev) -> screen pixels (before camera offset/scale).
+// World X is lateral (0..GRID_W), world Y is downstream (0..GRID_H).
+export function worldToScreenUnscaled(x, y, elev = 0) {
+    const sx = (x - y) * TILE_W * 0.5;
+    const sy = (x + y) * TILE_H * 0.5 - elev * HEIGHT_SCALE;
+    return { sx, sy };
+}
+
+// Inverse: screen (sx, sy) with elev=0 -> world (x, y). Used for input.
+export function screenToWorldFlat(sx, sy) {
+    const a = sx / (TILE_W * 0.5);
+    const b = sy / (TILE_H * 0.5);
+    const x = (a + b) * 0.5;
+    const y = (b - a) * 0.5;
+    return { x, y };
+}
+
+// Computes camera parameters (offsetX, offsetY, scale) so the grid fills `w x h`.
+export function computeCamera(canvasW, canvasH) {
+    // Corners of flat grid
+    const corners = [
+        worldToScreenUnscaled(0, 0),
+        worldToScreenUnscaled(GRID_W, 0),
+        worldToScreenUnscaled(0, GRID_H),
+        worldToScreenUnscaled(GRID_W, GRID_H),
+    ];
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+    for (const c of corners) {
+        if (c.sx < minX) minX = c.sx;
+        if (c.sx > maxX) maxX = c.sx;
+        if (c.sy < minY) minY = c.sy;
+        if (c.sy > maxY) maxY = c.sy;
+    }
+    // Allow headroom for stacked materials rising up
+    const headroom = 8 * HEIGHT_SCALE;
+    minY -= headroom;
+    const worldW = maxX - minX;
+    const worldH = maxY - minY;
+    const scale = Math.min(
+        (canvasW - CAM_MARGIN * 2) / worldW,
+        (canvasH - CAM_MARGIN * 2) / worldH,
+    );
+    const offsetX = canvasW * 0.5 - (minX + worldW * 0.5) * scale;
+    const offsetY = canvasH * 0.5 - (minY + worldH * 0.5) * scale;
+    return { scale, offsetX, offsetY };
+}
+
+// Full projection: world -> canvas pixels.
+export function project(x, y, elev, cam) {
+    const { sx, sy } = worldToScreenUnscaled(x, y, elev);
+    return {
+        sx: sx * cam.scale + cam.offsetX,
+        sy: sy * cam.scale + cam.offsetY,
+    };
+}
+
+// Canvas pixels -> world (flat, elev=0).
+export function unproject(cx, cy, cam) {
+    const sx = (cx - cam.offsetX) / cam.scale;
+    const sy = (cy - cam.offsetY) / cam.scale;
+    return screenToWorldFlat(sx, sy);
+}

--- a/apps/dam/js/main.js
+++ b/apps/dam/js/main.js
@@ -1,0 +1,100 @@
+import { DT, MAX_SUBSTEPS } from './config.js';
+import { Terrain } from './terrain.js';
+import { SPH } from './sph.js';
+import { Erosion } from './erosion.js';
+import { Renderer } from './renderer.js';
+import { Controls } from './controls.js';
+import { Audio } from './audio.js';
+
+const canvas = document.getElementById('scene');
+const heldValue = document.getElementById('heldValue');
+const resetBtn = document.getElementById('resetBtn');
+const muteBtn = document.getElementById('muteBtn');
+
+let terrain, sph, erosion, renderer, controls, audio;
+
+function init() {
+    terrain = new Terrain();
+    audio = new Audio();
+    sph = new SPH(terrain);
+    erosion = new Erosion(terrain, sph, audio);
+    renderer = new Renderer(canvas, terrain, sph, erosion);
+    controls = new Controls(canvas, renderer, terrain, audio);
+}
+
+init();
+
+let accumulator = 0;
+let lastTs = performance.now();
+let heldSeconds = 0;
+let heldStartReady = false;
+
+function loop(ts) {
+    let dtMs = ts - lastTs;
+    if (dtMs > 100) dtMs = 100; // clamp on tab unfocus
+    lastTs = ts;
+    accumulator += dtMs / 1000;
+
+    // Fixed physics timestep with capped substeps
+    let substeps = 0;
+    while (accumulator >= DT && substeps < MAX_SUBSTEPS) {
+        sph.spawnFromSpring(DT);
+        sph.step(DT);
+        erosion.step(DT);
+        accumulator -= DT;
+        substeps++;
+    }
+    if (substeps === MAX_SUBSTEPS) accumulator = 0; // drop leftover if we're falling behind
+
+    // Emit splash FX for high-velocity collisions (cheap proxy: debris just spawned)
+    for (const b of erosion.breachEvents) {
+        const force = b.kind === 'rock' ? 6 : 3;
+        renderer.addSplash(b.x, b.y, force);
+    }
+
+    // Update HUD: count how long there's been significant flow reaching the ocean
+    heldSeconds += dtMs / 1000;
+    heldValue.textContent = formatDuration(heldSeconds);
+
+    controls.update(dtMs);
+    renderer.draw();
+    requestAnimationFrame(loop);
+}
+
+function formatDuration(s) {
+    const mm = Math.floor(s / 60);
+    const ss = Math.floor(s % 60);
+    if (mm > 0) return `${mm}m${ss.toString().padStart(2, '0')}s`;
+    return `${ss}s`;
+}
+
+function resize() {
+    renderer.resize();
+}
+
+window.addEventListener('resize', resize);
+window.addEventListener('orientationchange', resize);
+
+resetBtn.addEventListener('click', () => {
+    terrain = new Terrain();
+    sph = new SPH(terrain);
+    erosion = new Erosion(terrain, sph, audio);
+    renderer.terrain = terrain;
+    renderer.sph = sph;
+    renderer.erosion = erosion;
+    controls.terrain = terrain;
+    heldSeconds = 0;
+    audio?.unlock();
+});
+
+muteBtn.addEventListener('click', () => {
+    audio.unlock();
+    audio.setMuted(!audio.muted);
+    muteBtn.textContent = audio.muted ? '🔇' : '🔊';
+});
+
+// Kick off
+requestAnimationFrame((ts) => {
+    lastTs = ts;
+    requestAnimationFrame(loop);
+});

--- a/apps/dam/js/renderer.js
+++ b/apps/dam/js/renderer.js
@@ -1,0 +1,400 @@
+import {
+    GRID_W, GRID_H, TILE_W, TILE_H, HEIGHT_SCALE,
+    OCEAN_ROW, STREAM_WIDTH,
+    SAND_UNIT_H, STICK_UNIT_H, ROCK_UNIT_H,
+} from './config.js';
+import { computeCamera, project, unproject } from './isometric.js';
+
+// Canvas 2D isometric renderer. Draws back-to-front:
+//   1. sky/ocean horizon (background gradient)
+//   2. terrain tiles (each cell as a filled diamond top + left/right side-walls)
+//   3. rocks, sticks (sprites anchored on top of their cell)
+//   4. water particles (depth-sorted by y)
+//   5. debris
+//   6. foam / splash overlays
+// Performance notes: batch same-color fills using Path2D where possible.
+
+export class Renderer {
+    constructor(canvas, terrain, sph, erosion) {
+        this.canvas = canvas;
+        this.ctx = canvas.getContext('2d', { alpha: false });
+        this.terrain = terrain;
+        this.sph = sph;
+        this.erosion = erosion;
+        this.dpr = 1;
+        this.cam = { scale: 1, offsetX: 0, offsetY: 0 };
+        this._splashes = [];
+        this.resize();
+    }
+
+    resize() {
+        const w = this.canvas.clientWidth;
+        const h = this.canvas.clientHeight;
+        const dpr = Math.min(window.devicePixelRatio || 1, 2);
+        this.dpr = dpr;
+        this.canvas.width = Math.floor(w * dpr);
+        this.canvas.height = Math.floor(h * dpr);
+        this.cam = computeCamera(w, h);
+        this._cssW = w;
+        this._cssH = h;
+    }
+
+    clientToWorld(cx, cy) {
+        return unproject(cx, cy, this.cam);
+    }
+
+    addSplash(x, y, force) {
+        this._splashes.push({
+            x, y,
+            life: 0,
+            maxLife: 0.35 + Math.random() * 0.25,
+            r: 0.15,
+            maxR: 0.5 + Math.min(force * 0.08, 0.7),
+        });
+    }
+
+    draw() {
+        const ctx = this.ctx;
+        const w = this._cssW;
+        const h = this._cssH;
+        ctx.setTransform(this.dpr, 0, 0, this.dpr, 0, 0);
+
+        // 1. Background: beach → sky gradient
+        this._drawBackground(ctx, w, h);
+
+        // 2. Ocean horizon (behind terrain because terrain is in front due to iso)
+        // Skipped: ocean tiles at the far/front render with terrain.
+
+        // 3. Terrain tiles
+        this._drawTerrain(ctx);
+
+        // 4. Water particles and debris (depth-sorted)
+        this._drawWaterAndDebris(ctx);
+
+        // 5. Ocean waves at the front of the beach (last few rows overlay)
+        this._drawOceanFoam(ctx);
+
+        // 6. Splashes fade
+        this._drawSplashes(ctx);
+    }
+
+    _drawBackground(ctx, w, h) {
+        const grd = ctx.createLinearGradient(0, 0, 0, h);
+        grd.addColorStop(0, '#a8d8f2');      // soft sky
+        grd.addColorStop(0.45, '#e8d3a1');   // distant sand
+        grd.addColorStop(1.0, '#d9b77f');    // warm foreground sand
+        ctx.fillStyle = grd;
+        ctx.fillRect(0, 0, w, h);
+    }
+
+    _drawTerrain(ctx) {
+        const { terrain, cam } = this;
+        const { w: W, h: H } = terrain;
+        // Iterate back-to-front (smaller i+j first) so later draws overlap earlier ones.
+        // To save work, precompute screen positions.
+        const hw = TILE_W * 0.5 * cam.scale;
+        const hh = TILE_H * 0.5 * cam.scale;
+        const hs = HEIGHT_SCALE * cam.scale;
+
+        for (let j = 0; j < H; j++) {
+            for (let i = 0; i < W; i++) {
+                const k = j * W + i;
+                const base = terrain.base[k];
+                const sand = terrain.sand[k];
+                const rocks = terrain.rockCells[k];
+                const sticks = terrain.stickCells[k];
+                const e = base + sand
+                        + (rocks ? rocks.length * ROCK_UNIT_H : 0)
+                        + (sticks ? sticks.length * STICK_UNIT_H : 0);
+
+                const p = project(i + 0.5, j + 0.5, e, cam);
+                const sx = p.sx, sy = p.sy;
+
+                // Draw side-walls going down to elevation=0 (rough cliff sides)
+                this._drawTileSides(ctx, i, j, e, hw, hh, hs);
+
+                // Top diamond: sand color (warmer where sand is thick, cooler where raw stream)
+                const isStreamBed = Math.abs(i - terrain.streamCenter[j]) < STREAM_WIDTH * 0.9 && e < 0.1;
+                this._drawTileTop(ctx, sx, sy, hw, hh, e, sand, isStreamBed, terrain.flowMag[k]);
+
+                // Materials
+                if (sticks) {
+                    for (let s = 0; s < sticks.length; s++) {
+                        const stick = sticks[s];
+                        const sh = sand + s * STICK_UNIT_H + (rocks ? rocks.length * ROCK_UNIT_H : 0);
+                        this._drawStick(ctx, i, j, stick, base + sh, cam);
+                    }
+                }
+                if (rocks) {
+                    for (let s = 0; s < rocks.length; s++) {
+                        const rock = rocks[s];
+                        const sh = sand + (sticks ? sticks.length * STICK_UNIT_H : 0) + s * ROCK_UNIT_H;
+                        this._drawRock(ctx, i, j, rock, base + sh, cam);
+                    }
+                }
+            }
+        }
+    }
+
+    _drawTileSides(ctx, i, j, e, hw, hh, hs) {
+        const { cam } = this;
+        // Right side (facing +x +y): visible when tile is raised
+        const top = project(i + 1, j, e, cam);
+        const topBack = project(i + 1, j + 1, e, cam);
+        const botBack = project(i + 1, j + 1, 0, cam);
+        const bot = project(i + 1, j, 0, cam);
+        if (e > 0.02) {
+            ctx.fillStyle = this._sandShade(e, -0.15);
+            ctx.beginPath();
+            ctx.moveTo(top.sx, top.sy);
+            ctx.lineTo(topBack.sx, topBack.sy);
+            ctx.lineTo(botBack.sx, botBack.sy);
+            ctx.lineTo(bot.sx, bot.sy);
+            ctx.closePath();
+            ctx.fill();
+        }
+
+        // Front-left side (facing +y, toward camera's left)
+        const l1 = project(i, j + 1, e, cam);
+        const l2 = project(i + 1, j + 1, e, cam);
+        const l3 = project(i + 1, j + 1, 0, cam);
+        const l4 = project(i, j + 1, 0, cam);
+        if (e > 0.02) {
+            ctx.fillStyle = this._sandShade(e, -0.25);
+            ctx.beginPath();
+            ctx.moveTo(l1.sx, l1.sy);
+            ctx.lineTo(l2.sx, l2.sy);
+            ctx.lineTo(l3.sx, l3.sy);
+            ctx.lineTo(l4.sx, l4.sy);
+            ctx.closePath();
+            ctx.fill();
+        }
+    }
+
+    _sandShade(e, brightnessDelta = 0) {
+        // Higher elevation = warmer light sand; lower = wetter/darker
+        const t = Math.max(0, Math.min(1, (e + 0.5) / 3.5));
+        const r = Math.floor((228 + t * 12) * (1 + brightnessDelta));
+        const g = Math.floor((196 + t * 14) * (1 + brightnessDelta));
+        const b = Math.floor((140 + t * 10) * (1 + brightnessDelta));
+        return `rgb(${clamp8(r)},${clamp8(g)},${clamp8(b)})`;
+    }
+
+    _drawTileTop(ctx, sx, sy, hw, hh, e, sand, isStreamBed, flowMag) {
+        // Diamond corners
+        ctx.beginPath();
+        ctx.moveTo(sx, sy - hh);
+        ctx.lineTo(sx + hw, sy);
+        ctx.lineTo(sx, sy + hh);
+        ctx.lineTo(sx - hw, sy);
+        ctx.closePath();
+        let fill;
+        if (isStreamBed) {
+            // Wet stream bed: darker, mossy
+            fill = '#8b7147';
+        } else if (e < -0.2) {
+            // Submerged (ocean approach)
+            const t = Math.min(1, -e / 1.5);
+            fill = `rgb(${80 - t * 20},${120 - t * 20},${140 - t * 10})`;
+        } else {
+            fill = this._sandShade(e, 0);
+        }
+        ctx.fillStyle = fill;
+        ctx.fill();
+
+        // Sand grain shimmer on top of thick sand piles
+        if (sand > 0.2) {
+            ctx.fillStyle = `rgba(255, 240, 200, ${Math.min(0.25, sand * 0.12)})`;
+            ctx.fill();
+        }
+    }
+
+    _drawRock(ctx, i, j, rock, elev, cam) {
+        const wx = i + 0.5 + rock.offX;
+        const wy = j + 0.5 + rock.offY;
+        const p = project(wx, wy, elev, cam);
+        const r = rock.size * cam.scale * 16;
+        const tone = rock.tone;
+        const grd = ctx.createRadialGradient(p.sx - r * 0.3, p.sy - r * 0.3, r * 0.1, p.sx, p.sy, r);
+        grd.addColorStop(0, `rgb(${180 * tone},${180 * tone},${180 * tone})`);
+        grd.addColorStop(1, `rgb(${70 * tone},${70 * tone},${70 * tone})`);
+        ctx.fillStyle = grd;
+        ctx.beginPath();
+        ctx.ellipse(p.sx, p.sy, r, r * 0.78, rock.angle, 0, Math.PI * 2);
+        ctx.fill();
+        // Tiny highlight
+        ctx.fillStyle = `rgba(255,255,255,0.25)`;
+        ctx.beginPath();
+        ctx.ellipse(p.sx - r * 0.35, p.sy - r * 0.4, r * 0.25, r * 0.1, rock.angle, 0, Math.PI * 2);
+        ctx.fill();
+    }
+
+    _drawStick(ctx, i, j, stick, elev, cam) {
+        const wx = i + 0.5 + stick.offX;
+        const wy = j + 0.5 + stick.offY;
+        const p = project(wx, wy, elev, cam);
+        const len = stick.length * cam.scale * TILE_W * 0.9;
+        const thick = cam.scale * 3.5;
+        const tone = stick.tone;
+        ctx.save();
+        ctx.translate(p.sx, p.sy);
+        ctx.rotate(stick.angle);
+        const grd = ctx.createLinearGradient(0, -thick, 0, thick);
+        grd.addColorStop(0, `rgb(${170 * tone},${110 * tone},${60 * tone})`);
+        grd.addColorStop(1, `rgb(${90 * tone},${55 * tone},${25 * tone})`);
+        ctx.fillStyle = grd;
+        roundRect(ctx, -len * 0.5, -thick * 0.5, len, thick, thick * 0.5);
+        ctx.fill();
+        // knots
+        ctx.fillStyle = 'rgba(0,0,0,0.15)';
+        ctx.fillRect(-len * 0.3, -thick * 0.5, thick * 0.3, thick);
+        ctx.fillRect(len * 0.18, -thick * 0.5, thick * 0.3, thick);
+        ctx.restore();
+    }
+
+    _drawWaterAndDebris(ctx) {
+        const { sph, cam, erosion } = this;
+        const { px, py, alive, capacity } = sph;
+
+        // Collect alive particles, sorted by depth key for correct iso layering
+        if (!this._sortPairs) this._sortPairs = [];
+        const pairs = this._sortPairs;
+        pairs.length = 0;
+        for (let p = 0; p < capacity; p++) {
+            if (!alive[p]) continue;
+            pairs.push([p, px[p] + py[p]]);
+        }
+        pairs.sort((a, b) => a[1] - b[1]);
+
+        // Merge debris into depth-sorted sequence with water particles
+        const debris = erosion.debris.slice().sort((a, b) => (a.x + a.y) - (b.x + b.y));
+        let dIdx = 0;
+        for (let k = 0; k < pairs.length; k++) {
+            const key = pairs[k][1];
+            while (dIdx < debris.length && (debris[dIdx].x + debris[dIdx].y) < key) {
+                this._drawDebrisItem(ctx, debris[dIdx], cam);
+                dIdx++;
+            }
+            this._drawWaterParticle(ctx, pairs[k][0], cam);
+        }
+        while (dIdx < debris.length) {
+            this._drawDebrisItem(ctx, debris[dIdx], cam);
+            dIdx++;
+        }
+    }
+
+    _drawWaterParticle(ctx, p, cam) {
+        const { px, py, vx, vy, density } = this.sph;
+        const e = this.terrain.elevationAt(px[p], py[p]);
+        const pileH = Math.min(1.4, Math.max(0, density[p] / 3.2 - 1) * 0.7);
+        const s = project(px[p], py[p], e + pileH, cam);
+        const speed = Math.sqrt(vx[p] * vx[p] + vy[p] * vy[p]);
+        const r = Math.max(4.2, 9 * cam.scale);
+        const bright = Math.min(1, speed / 9);
+        const cr = Math.floor(45 + bright * 140);
+        const cg = Math.floor(125 + bright * 90);
+        const cb = Math.floor(200 + bright * 45);
+        ctx.fillStyle = `rgba(${cr},${cg},${cb},0.88)`;
+        ctx.beginPath();
+        ctx.arc(s.sx, s.sy, r, 0, Math.PI * 2);
+        ctx.fill();
+        if (speed > 3.5) {
+            ctx.fillStyle = `rgba(255,255,255,${Math.min(0.45, speed * 0.04)})`;
+            ctx.beginPath();
+            ctx.arc(s.sx - r * 0.3, s.sy - r * 0.4, r * 0.38, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        if (speed > 3.5) {
+            ctx.fillStyle = `rgba(255,255,255,${Math.min(0.4, speed * 0.035)})`;
+            ctx.beginPath();
+            ctx.arc(s.sx - r * 0.3, s.sy - r * 0.4, r * 0.35, 0, Math.PI * 2);
+            ctx.fill();
+        }
+    }
+
+    _drawDebrisItem(ctx, d, cam) {
+        const p = project(d.x, d.y, d.elevZ, cam);
+        ctx.save();
+        ctx.translate(p.sx, p.sy);
+        ctx.rotate(d.angle);
+        if (d.kind === 'rock') {
+            const r = d.size * cam.scale * 16;
+            const grd = ctx.createRadialGradient(-r * 0.3, -r * 0.3, r * 0.1, 0, 0, r);
+            grd.addColorStop(0, `rgb(${160 * d.tone},${160 * d.tone},${160 * d.tone})`);
+            grd.addColorStop(1, `rgb(${60 * d.tone},${60 * d.tone},${60 * d.tone})`);
+            ctx.fillStyle = grd;
+            ctx.beginPath();
+            ctx.ellipse(0, 0, r, r * 0.8, 0, 0, Math.PI * 2);
+            ctx.fill();
+        } else {
+            const len = d.length * cam.scale * TILE_W * 0.9;
+            const thick = cam.scale * 3.5;
+            ctx.fillStyle = `rgb(${140 * d.tone},${85 * d.tone},${45 * d.tone})`;
+            roundRect(ctx, -len * 0.5, -thick * 0.5, len, thick, thick * 0.5);
+            ctx.fill();
+        }
+        ctx.restore();
+    }
+
+    _drawOceanFoam(ctx) {
+        const { terrain, cam } = this;
+        const t = performance.now() * 0.0012;
+        for (let j = OCEAN_ROW; j < GRID_H; j++) {
+            const oT = (j - OCEAN_ROW) / (GRID_H - 1 - OCEAN_ROW);
+            for (let i = 0; i < GRID_W; i++) {
+                const p = project(i + 0.5, j + 0.5, Math.sin(i * 0.5 + t + j * 0.2) * 0.05 - 0.15, cam);
+                const hw = TILE_W * 0.5 * cam.scale;
+                const hh = TILE_H * 0.5 * cam.scale;
+                ctx.fillStyle = `rgba(110,170,200,${0.55 + oT * 0.2})`;
+                ctx.beginPath();
+                ctx.moveTo(p.sx, p.sy - hh);
+                ctx.lineTo(p.sx + hw, p.sy);
+                ctx.lineTo(p.sx, p.sy + hh);
+                ctx.lineTo(p.sx - hw, p.sy);
+                ctx.closePath();
+                ctx.fill();
+                // Foam strips at the shore
+                if (j === OCEAN_ROW) {
+                    const foam = 0.35 + 0.25 * Math.sin(i + t * 2.5);
+                    ctx.fillStyle = `rgba(255,255,255,${foam})`;
+                    ctx.beginPath();
+                    ctx.ellipse(p.sx, p.sy - hh * 0.3, hw * 0.7, hh * 0.4, 0, 0, Math.PI * 2);
+                    ctx.fill();
+                }
+            }
+        }
+    }
+
+    _drawSplashes(ctx) {
+        for (let i = this._splashes.length - 1; i >= 0; i--) {
+            const s = this._splashes[i];
+            s.life += 1 / 60;
+            if (s.life > s.maxLife) {
+                this._splashes.splice(i, 1);
+                continue;
+            }
+            const t = s.life / s.maxLife;
+            s.r = s.maxR * t;
+            const p = project(s.x, s.y, 0, this.cam);
+            ctx.strokeStyle = `rgba(255,255,255,${0.6 * (1 - t)})`;
+            ctx.lineWidth = 2 * this.cam.scale;
+            ctx.beginPath();
+            ctx.ellipse(p.sx, p.sy, s.r * TILE_W * this.cam.scale * 0.5,
+                s.r * TILE_H * this.cam.scale * 0.5, 0, 0, Math.PI * 2);
+            ctx.stroke();
+        }
+    }
+}
+
+function roundRect(ctx, x, y, w, h, r) {
+    r = Math.min(r, w / 2, h / 2);
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.arcTo(x + w, y, x + w, y + h, r);
+    ctx.arcTo(x + w, y + h, x, y + h, r);
+    ctx.arcTo(x, y + h, x, y, r);
+    ctx.arcTo(x, y, x + w, y, r);
+    ctx.closePath();
+}
+
+function clamp8(v) { return Math.max(0, Math.min(255, v | 0)); }

--- a/apps/dam/js/sph.js
+++ b/apps/dam/js/sph.js
@@ -1,0 +1,283 @@
+import {
+    GRID_W, GRID_H, H, H2,
+    REST_DENSITY, STIFFNESS, VISCOSITY, GRAVITY,
+    TERRAIN_WALL_K, TERRAIN_DAMP,
+    MAX_PARTICLES, MAX_SPEED, PARTICLE_MASS,
+    SPAWN_PER_SEC, SPAWN_JITTER,
+    OCEAN_ROW,
+} from './config.js';
+
+// 2D Müller-style SPH. Top-down flow where "gravity" is actually the
+// gradient of the terrain elevation (shallow-water style), plus a
+// small downstream bias that keeps flow going toward the ocean.
+//
+// Layout of particle data in typed arrays so we can iterate cache-friendly.
+
+const POLY6 = 315 / (64 * Math.PI * Math.pow(H, 9));
+const SPIKY_GRAD = -45 / (Math.PI * Math.pow(H, 6));
+const VISC_LAP = 45 / (Math.PI * Math.pow(H, 6));
+
+export class SPH {
+    constructor(terrain) {
+        this.terrain = terrain;
+        const N = MAX_PARTICLES;
+        this.px = new Float32Array(N);
+        this.py = new Float32Array(N);
+        this.vx = new Float32Array(N);
+        this.vy = new Float32Array(N);
+        this.density = new Float32Array(N);
+        this.pressure = new Float32Array(N);
+        this.fx = new Float32Array(N);
+        this.fy = new Float32Array(N);
+        // Cell index per particle for hashing
+        this.alive = new Uint8Array(N);
+        this.count = 0;
+        this.capacity = N;
+
+        // Spatial hash: cell size = H. Domain slightly padded on both sides.
+        this.hashCellSize = H;
+        this.hashCols = Math.ceil((GRID_W + 2) / H) + 2;
+        this.hashRows = Math.ceil((GRID_H + 2) / H) + 2;
+        this.hashHeads = new Int32Array(this.hashCols * this.hashRows);
+        this.hashNext = new Int32Array(N);
+
+        this.spawnAccumulator = 0;
+        this.freeList = [];
+        for (let i = N - 1; i >= 0; i--) this.freeList.push(i);
+    }
+
+    _spawn(x, y, vx, vy) {
+        if (this.freeList.length === 0) return -1;
+        const idx = this.freeList.pop();
+        this.px[idx] = x;
+        this.py[idx] = y;
+        this.vx[idx] = vx;
+        this.vy[idx] = vy;
+        this.fx[idx] = 0;
+        this.fy[idx] = 0;
+        this.density[idx] = REST_DENSITY;
+        this.pressure[idx] = 0;
+        this.alive[idx] = 1;
+        this.count++;
+        return idx;
+    }
+
+    _kill(idx) {
+        this.alive[idx] = 0;
+        this.freeList.push(idx);
+        this.count--;
+    }
+
+    _hashIndex(i, j) {
+        if (i < 0 || j < 0 || i >= this.hashCols || j >= this.hashRows) return -1;
+        return j * this.hashCols + i;
+    }
+
+    _rebuildHash() {
+        this.hashHeads.fill(-1);
+        const invH = 1 / this.hashCellSize;
+        for (let p = 0; p < this.capacity; p++) {
+            if (!this.alive[p]) continue;
+            const ci = ((this.px[p] + 1) * invH) | 0;
+            const cj = ((this.py[p] + 1) * invH) | 0;
+            const h = this._hashIndex(ci, cj);
+            if (h < 0) {
+                this.hashNext[p] = -1;
+                continue;
+            }
+            this.hashNext[p] = this.hashHeads[h];
+            this.hashHeads[h] = p;
+        }
+    }
+
+    _forEachNeighbor(p, cb) {
+        const invH = 1 / this.hashCellSize;
+        const ci = ((this.px[p] + 1) * invH) | 0;
+        const cj = ((this.py[p] + 1) * invH) | 0;
+        for (let dj = -1; dj <= 1; dj++) {
+            for (let di = -1; di <= 1; di++) {
+                const h = this._hashIndex(ci + di, cj + dj);
+                if (h < 0) continue;
+                let q = this.hashHeads[h];
+                while (q !== -1) {
+                    cb(q);
+                    q = this.hashNext[q];
+                }
+            }
+        }
+    }
+
+    step(dt) {
+        this._rebuildHash();
+        this._computeDensity();
+        this._computeForces();
+        this._integrate(dt);
+        this._handleBoundaries();
+    }
+
+    _computeDensity() {
+        const { px, py, density, pressure, alive } = this;
+        for (let p = 0; p < this.capacity; p++) {
+            if (!alive[p]) continue;
+            let dens = 0;
+            const ppx = px[p], ppy = py[p];
+            this._forEachNeighbor(p, (q) => {
+                const dx = px[q] - ppx;
+                const dy = py[q] - ppy;
+                const r2 = dx * dx + dy * dy;
+                if (r2 < H2) {
+                    const diff = H2 - r2;
+                    dens += PARTICLE_MASS * POLY6 * diff * diff * diff;
+                }
+            });
+            density[p] = Math.max(dens, REST_DENSITY * 0.2);
+            pressure[p] = STIFFNESS * (density[p] - REST_DENSITY);
+            if (pressure[p] < 0) pressure[p] = 0;
+        }
+    }
+
+    _computeForces() {
+        const { px, py, vx, vy, density, pressure, fx, fy, alive, terrain } = this;
+        for (let p = 0; p < this.capacity; p++) {
+            if (!alive[p]) continue;
+            let ax = 0, ay = 0;
+            const ppx = px[p], ppy = py[p];
+            const pPress = pressure[p];
+            const pVx = vx[p], pVy = vy[p];
+
+            this._forEachNeighbor(p, (q) => {
+                if (q === p) return;
+                const dx = px[q] - ppx;
+                const dy = py[q] - ppy;
+                const r2 = dx * dx + dy * dy;
+                if (r2 >= H2 || r2 === 0) return;
+                const r = Math.sqrt(r2);
+                const nx = dx / r, ny = dy / r;  // unit vector from P -> Q
+                const diff = H - r;
+                // Pressure (spiky kernel gradient). SPIKY_GRAD is negative,
+                // so pTerm is negative and ax += nx * pTerm pushes P *away* from Q.
+                const pTerm = PARTICLE_MASS
+                    * (pPress + pressure[q]) / (2 * density[q])
+                    * SPIKY_GRAD * diff * diff;
+                ax += nx * pTerm;
+                ay += ny * pTerm;
+                // Viscosity (laplacian of poly6-ish — use VISC_LAP * (H-r))
+                const visc = VISCOSITY * PARTICLE_MASS
+                    * VISC_LAP * diff / density[q];
+                ax += (vx[q] - pVx) * visc;
+                ay += (vy[q] - pVy) * visc;
+            });
+
+            // Gravity: along the terrain gradient (flow downhill)
+            const g = terrain.gradientAt(ppx, ppy);
+            ax -= g.dx * GRAVITY;
+            ay -= g.dy * GRAVITY;
+            // Slight downstream bias so stagnation doesn't kill the flow entirely
+            ay += 0.6;
+
+            // Wall from nearby terrain elevation that exceeds particle "level"
+            // Estimate effective water surface height via density.
+            const waterSurface = pileHeightFromDensity(density[p]);
+            const cellI = ppx | 0, cellJ = ppy | 0;
+            // Push away from neighbor cells whose elevation is too tall
+            for (let dj = -1; dj <= 1; dj++) {
+                for (let di = -1; di <= 1; di++) {
+                    const ci = cellI + di, cj = cellJ + dj;
+                    if (!terrain.inBounds(ci, cj)) continue;
+                    const e = terrain.elevation(ci, cj);
+                    // "Floor" of this cell relative to local water surface
+                    const myFloor = terrain.elevationAt(ppx, ppy);
+                    const overhead = e - (myFloor + waterSurface);
+                    if (overhead > 0) {
+                        // Closest point on cell bounds
+                        const cx = Math.max(ci, Math.min(ci + 1, ppx));
+                        const cy = Math.max(cj, Math.min(cj + 1, ppy));
+                        const rx = ppx - cx;
+                        const ry = ppy - cy;
+                        const d = Math.sqrt(rx * rx + ry * ry);
+                        if (d < 0.4 && d > 1e-4) {
+                            const push = TERRAIN_WALL_K * overhead * (0.4 - d);
+                            ax += (rx / d) * push;
+                            ay += (ry / d) * push;
+                            // Damp velocity into the wall
+                            const vn = pVx * (-rx / d) + pVy * (-ry / d);
+                            if (vn > 0) {
+                                ax -= (-rx / d) * vn * TERRAIN_DAMP;
+                                ay -= (-ry / d) * vn * TERRAIN_DAMP;
+                            }
+                        }
+                    }
+                }
+            }
+
+            fx[p] = ax;
+            fy[p] = ay;
+        }
+    }
+
+    _integrate(dt) {
+        const { px, py, vx, vy, fx, fy, alive } = this;
+        for (let p = 0; p < this.capacity; p++) {
+            if (!alive[p]) continue;
+            let nvx = vx[p] + fx[p] * dt;
+            let nvy = vy[p] + fy[p] * dt;
+            const speed2 = nvx * nvx + nvy * nvy;
+            if (speed2 > MAX_SPEED * MAX_SPEED) {
+                const s = MAX_SPEED / Math.sqrt(speed2);
+                nvx *= s;
+                nvy *= s;
+            }
+            vx[p] = nvx;
+            vy[p] = nvy;
+            px[p] += nvx * dt;
+            py[p] += nvy * dt;
+        }
+    }
+
+    _handleBoundaries() {
+        const { px, py, vx, vy, alive, terrain } = this;
+        for (let p = 0; p < this.capacity; p++) {
+            if (!alive[p]) continue;
+            // Lateral walls of the grid
+            if (px[p] < 0.05) { px[p] = 0.05; if (vx[p] < 0) vx[p] = -vx[p] * 0.3; }
+            if (px[p] > GRID_W - 0.05) { px[p] = GRID_W - 0.05; if (vx[p] > 0) vx[p] = -vx[p] * 0.3; }
+            // Top wall (upstream end): soft wall
+            if (py[p] < 0.05) { py[p] = 0.05; if (vy[p] < 0) vy[p] = -vy[p] * 0.3; }
+            // Bottom: remove if past the ocean
+            if (py[p] > GRID_H - 0.1) {
+                this._kill(p);
+            }
+        }
+    }
+
+    // Spawn particles at the spring at the top of the stream.
+    // Streams emerge from a pool slightly inside the top edge.
+    spawnFromSpring(dt) {
+        this.spawnAccumulator += SPAWN_PER_SEC * dt;
+        const toSpawn = Math.floor(this.spawnAccumulator);
+        if (toSpawn <= 0) return;
+        this.spawnAccumulator -= toSpawn;
+        const cx = this.terrain.streamCenter[1];
+        for (let i = 0; i < toSpawn; i++) {
+            if (this.count >= this.capacity - 2) break;
+            const x = cx + (Math.random() - 0.5) * 1.4;
+            const y = 0.5 + Math.random() * 1.1;
+            const vx = (Math.random() - 0.5) * SPAWN_JITTER;
+            const vy = 1.0 + Math.random() * 0.8;
+            this._spawn(x, y, vx, vy);
+        }
+    }
+
+    reset() {
+        for (let p = 0; p < this.capacity; p++) {
+            if (this.alive[p]) this._kill(p);
+        }
+    }
+}
+
+// Very rough estimate of "water column height" from local particle density.
+// Used to decide when water overtops a wall.
+function pileHeightFromDensity(density) {
+    const t = Math.max(0, density / REST_DENSITY - 1);
+    return Math.min(1.8, t * 0.9);
+}

--- a/apps/dam/js/terrain.js
+++ b/apps/dam/js/terrain.js
@@ -1,0 +1,324 @@
+import {
+    GRID_W, GRID_H,
+    BEACH_SLOPE, STREAM_DEPTH, STREAM_WIDTH, STREAM_MEANDER, STREAM_FREQ,
+    BANK_SLOPE, BANK_MAX, OCEAN_ROW,
+    SPRING_POOL_ROWS, SPRING_POOL_EXTRA,
+    SAND_UNIT_H, STICK_UNIT_H, ROCK_UNIT_H,
+    SAND_RESIST, STICK_RESIST, ROCK_RESIST,
+    EROSION_RATE,
+} from './config.js';
+
+// Terrain is a heightfield with layered materials on top of base terrain.
+// Each cell has:
+//   base: natural terrain elevation (carved stream + sandy beach)
+//   sand: player-added sand (continuous float, scaled by SAND_UNIT_H)
+//   rocks, sticks: arrays of discrete material objects placed in this cell
+// Rocks and sticks raise elevation by their count × unit height.
+// Stress accumulator tracks integrated water force for erosion.
+
+let rockIdSeq = 1;
+
+export class Terrain {
+    constructor() {
+        this.w = GRID_W;
+        this.h = GRID_H;
+        const n = GRID_W * GRID_H;
+        this.base = new Float32Array(n);
+        this.sand = new Float32Array(n);
+        // Per-cell material arrays
+        this.rockCells = new Array(n);
+        this.stickCells = new Array(n);
+        // Stress accumulators (for erosion); reset each frame
+        this.stress = new Float32Array(n);
+        // Total flow magnitude per cell, for visual shimmer
+        this.flowMag = new Float32Array(n);
+
+        // Stream centerline row lookup (cached for spring/ocean placement)
+        this.streamCenter = new Float32Array(GRID_H);
+
+        this._buildBaseTerrain();
+        for (let i = 0; i < n; i++) {
+            this.rockCells[i] = null;
+            this.stickCells[i] = null;
+        }
+
+        this._scatterPebbles();
+    }
+
+    _buildBaseTerrain() {
+        const { w, h, base, streamCenter } = this;
+        for (let j = 0; j < h; j++) {
+            // Ocean ramp: last few rows taper to elevation 0 (water level)
+            const oceanT = Math.max(0, (j - OCEAN_ROW) / (h - 1 - OCEAN_ROW));
+            // Beach slope rises upstream (decreasing j). Top row is highest.
+            const beach = BEACH_SLOPE * (h - 1 - j);
+            // Meandering stream center
+            const cx = w * 0.5 + Math.sin(j * STREAM_FREQ) * STREAM_MEANDER
+                       + Math.sin(j * 0.07 + 1.3) * 0.7;
+            streamCenter[j] = cx;
+            // Extra depth for the spring pool at the top rows
+            const springT = j < SPRING_POOL_ROWS ? (1 - j / SPRING_POOL_ROWS) : 0;
+            for (let i = 0; i < w; i++) {
+                const dx = i - cx;
+                // Smooth Lorentzian valley — deep at centerline, falls off with distance
+                const valley = STREAM_DEPTH / (1 + Math.pow(dx / (STREAM_WIDTH * 0.6), 2));
+                // Aggressive lateral rise outside the valley so water stays contained
+                const bank = Math.min(BANK_MAX, Math.max(0, (Math.abs(dx) - STREAM_WIDTH) * BANK_SLOPE));
+                // Noise for natural look (deterministic)
+                const n = pseudoNoise(i, j) * 0.10;
+                // Taper into ocean — widen the channel and drop the banks
+                const bankSoften = 1 - oceanT * 0.9;
+                let e = beach - valley * bankSoften + bank * bankSoften + n;
+                // Spring pool: carve an extra bowl at the top
+                if (springT > 0 && Math.abs(dx) < STREAM_WIDTH * 1.5) {
+                    const bowl = SPRING_POOL_EXTRA * springT
+                        * Math.max(0, 1 - Math.abs(dx) / (STREAM_WIDTH * 1.5));
+                    e -= bowl;
+                }
+                e *= (1 - oceanT * 0.9);
+                e -= oceanT * 0.6;
+                base[j * w + i] = e;
+            }
+        }
+    }
+
+    _scatterPebbles() {
+        // A few decorative pebbles on the banks (structural but breakable).
+        let s = 1337;
+        const rand = () => {
+            s = (s * 1103515245 + 12345) & 0x7fffffff;
+            return s / 0x7fffffff;
+        };
+        for (let j = 2; j < this.h - 4; j++) {
+            const cx = this.streamCenter[j];
+            for (let i = 0; i < this.w; i++) {
+                const dx = Math.abs(i - cx);
+                if (dx > STREAM_WIDTH + 0.5 && dx < STREAM_WIDTH + 3 && rand() < 0.08) {
+                    this.addRock(i, j, rand);
+                }
+            }
+        }
+    }
+
+    idx(i, j) { return j * this.w + i; }
+
+    inBounds(i, j) {
+        return i >= 0 && i < this.w && j >= 0 && j < this.h;
+    }
+
+    // Total elevation at cell (i, j): base + sand + rocks + sticks
+    elevation(i, j) {
+        if (!this.inBounds(i, j)) return 100; // off-grid: treated as solid wall
+        const k = this.idx(i, j);
+        let e = this.base[k] + this.sand[k];
+        const rocks = this.rockCells[k];
+        if (rocks) e += rocks.length * ROCK_UNIT_H;
+        const sticks = this.stickCells[k];
+        if (sticks) e += sticks.length * STICK_UNIT_H;
+        return e;
+    }
+
+    // Bilinear elevation at continuous world position
+    elevationAt(x, y) {
+        const i0 = Math.floor(x), j0 = Math.floor(y);
+        const fx = x - i0, fy = y - j0;
+        const e00 = this.elevation(i0, j0);
+        const e10 = this.elevation(i0 + 1, j0);
+        const e01 = this.elevation(i0, j0 + 1);
+        const e11 = this.elevation(i0 + 1, j0 + 1);
+        return (e00 * (1 - fx) + e10 * fx) * (1 - fy)
+             + (e01 * (1 - fx) + e11 * fx) * fy;
+    }
+
+    // Gradient of elevation at (x, y). Returns (dEdx, dEdy).
+    gradientAt(x, y) {
+        const d = 0.35;
+        const ex = this.elevationAt(x + d, y) - this.elevationAt(x - d, y);
+        const ey = this.elevationAt(x, y + d) - this.elevationAt(x, y - d);
+        return { dx: ex / (2 * d), dy: ey / (2 * d) };
+    }
+
+    // Place sand in a splash area around (wx, wy) with radius r.
+    addSand(wx, wy, r, amount) {
+        const minI = Math.max(0, Math.floor(wx - r));
+        const maxI = Math.min(this.w - 1, Math.ceil(wx + r));
+        const minJ = Math.max(0, Math.floor(wy - r));
+        const maxJ = Math.min(this.h - 1, Math.ceil(wy + r));
+        for (let j = minJ; j <= maxJ; j++) {
+            for (let i = minI; i <= maxI; i++) {
+                const dx = i + 0.5 - wx, dy = j + 0.5 - wy;
+                const d = Math.sqrt(dx * dx + dy * dy);
+                if (d < r) {
+                    const falloff = 1 - d / r;
+                    this.sand[this.idx(i, j)] += amount * falloff * falloff;
+                }
+            }
+        }
+    }
+
+    dig(wx, wy, r, amount) {
+        const minI = Math.max(0, Math.floor(wx - r));
+        const maxI = Math.min(this.w - 1, Math.ceil(wx + r));
+        const minJ = Math.max(0, Math.floor(wy - r));
+        const maxJ = Math.min(this.h - 1, Math.ceil(wy + r));
+        for (let j = minJ; j <= maxJ; j++) {
+            for (let i = minI; i <= maxI; i++) {
+                const dx = i + 0.5 - wx, dy = j + 0.5 - wy;
+                const d = Math.sqrt(dx * dx + dy * dy);
+                if (d < r) {
+                    const falloff = 1 - d / r;
+                    const k = this.idx(i, j);
+                    // First chew through added sand, then into base terrain.
+                    const consume = amount * falloff;
+                    const fromSand = Math.min(this.sand[k], consume);
+                    this.sand[k] -= fromSand;
+                    const remaining = consume - fromSand;
+                    if (remaining > 0) {
+                        this.base[k] -= remaining * 0.6;
+                    }
+                }
+            }
+        }
+    }
+
+    addRock(i, j, rand = Math.random) {
+        if (!this.inBounds(i, j)) return null;
+        const k = this.idx(i, j);
+        if (!this.rockCells[k]) this.rockCells[k] = [];
+        const rock = {
+            id: rockIdSeq++,
+            cellI: i, cellJ: j,
+            offX: (rand() - 0.5) * 0.6,
+            offY: (rand() - 0.5) * 0.6,
+            size: 0.32 + rand() * 0.18,
+            tone: 0.65 + rand() * 0.3,
+            angle: rand() * Math.PI,
+        };
+        this.rockCells[k].push(rock);
+        return rock;
+    }
+
+    addStick(i, j, rand = Math.random) {
+        if (!this.inBounds(i, j)) return null;
+        const k = this.idx(i, j);
+        if (!this.stickCells[k]) this.stickCells[k] = [];
+        const stick = {
+            cellI: i, cellJ: j,
+            offX: (rand() - 0.5) * 0.7,
+            offY: (rand() - 0.5) * 0.7,
+            length: 0.8 + rand() * 0.5,
+            angle: rand() * Math.PI,
+            tone: 0.55 + rand() * 0.35,
+        };
+        this.stickCells[k].push(stick);
+        return stick;
+    }
+
+    // Remove the top rock from a cell. Returns it (or null).
+    popRock(i, j) {
+        const rocks = this.rockCells[this.idx(i, j)];
+        if (!rocks || rocks.length === 0) return null;
+        return rocks.pop();
+    }
+
+    popStick(i, j) {
+        const sticks = this.stickCells[this.idx(i, j)];
+        if (!sticks || sticks.length === 0) return null;
+        return sticks.pop();
+    }
+
+    clearStress() {
+        this.stress.fill(0);
+    }
+
+    accumulateStress(i, j, amount) {
+        if (!this.inBounds(i, j)) return;
+        this.stress[this.idx(i, j)] += amount;
+    }
+
+    // Apply erosion given the accumulated stress this frame.
+    // `debrisOut` collects dislodged rocks/sticks as debris objects.
+    erode(dt, debrisOut) {
+        const { w, h, stress, sand, rockCells, stickCells, base } = this;
+        for (let j = 0; j < h; j++) {
+            for (let i = 0; i < w; i++) {
+                const k = j * w + i;
+                const s = stress[k];
+                if (s <= 0) continue;
+
+                // Sand is the easiest — gradually washed.
+                if (sand[k] > 0 && s > SAND_RESIST) {
+                    const removed = Math.min(sand[k], (s - SAND_RESIST) * EROSION_RATE * dt);
+                    sand[k] -= removed;
+                    if (sand[k] < 0.0001) sand[k] = 0;
+                }
+
+                // When sand is depleted, gently nibble base terrain near the stream bed only.
+                if (sand[k] === 0 && base[k] < 0.5 && s > SAND_RESIST * 2) {
+                    base[k] -= Math.min(0.04, (s - SAND_RESIST * 2) * 0.03 * dt);
+                }
+
+                // Sticks next. Need sand to be thin (no protection).
+                const sticks = stickCells[k];
+                if (sticks && sticks.length > 0 && sand[k] < 0.4 && s > STICK_RESIST) {
+                    const stick = sticks.pop();
+                    const angle = Math.atan2(
+                        this._stressDir(i, j, 1),
+                        this._stressDir(i, j, 0),
+                    );
+                    debrisOut.push(makeDebris('stick', i + 0.5 + stick.offX * 0.3,
+                        j + 0.5 + stick.offY * 0.3, angle, stick));
+                }
+
+                // Rocks: need much more force. When they go, emit a "break" event.
+                const rocks = rockCells[k];
+                if (rocks && rocks.length > 0 && sand[k] < 0.4 && s > ROCK_RESIST) {
+                    const rock = rocks.pop();
+                    const angle = Math.atan2(
+                        this._stressDir(i, j, 1),
+                        this._stressDir(i, j, 0),
+                    );
+                    debrisOut.push(makeDebris('rock', i + 0.5 + rock.offX * 0.3,
+                        j + 0.5 + rock.offY * 0.3, angle, rock));
+                }
+            }
+        }
+    }
+
+    // Returns a rough directional component of stress via neighbor lookups.
+    _stressDir(i, j, axis) {
+        // axis 0 = x, 1 = y. Use the flow magnitude stored during force pass.
+        if (axis === 0) {
+            const l = this.inBounds(i - 1, j) ? this.stress[this.idx(i - 1, j)] : 0;
+            const r = this.inBounds(i + 1, j) ? this.stress[this.idx(i + 1, j)] : 0;
+            return r - l;
+        } else {
+            const u = this.inBounds(i, j - 1) ? this.stress[this.idx(i, j - 1)] : 0;
+            const d = this.inBounds(i, j + 1) ? this.stress[this.idx(i, j + 1)] : 0;
+            return d - u;
+        }
+    }
+}
+
+function makeDebris(kind, x, y, flowAngle, props) {
+    return {
+        kind,
+        x, y,
+        vx: Math.cos(flowAngle) * 2.5 + (Math.random() - 0.5) * 0.8,
+        vy: Math.sin(flowAngle) * 2.5 + 2.4,  // downstream bias
+        angle: props.angle || 0,
+        spin: (Math.random() - 0.5) * 6,
+        life: 0,
+        size: props.size ?? (kind === 'rock' ? 0.36 : 0.2),
+        length: props.length ?? 1.0,
+        tone: props.tone ?? 0.7,
+        elevZ: 0.25,          // starts just above surface
+        vz: 1.2 + Math.random() * 0.6,
+        settled: false,
+    };
+}
+
+function pseudoNoise(x, y) {
+    const n = Math.sin(x * 12.9898 + y * 78.233) * 43758.5453;
+    return (n - Math.floor(n)) * 2 - 1; // -1..1
+}

--- a/apps/index.html
+++ b/apps/index.html
@@ -336,6 +336,7 @@
         .app-pixels { background: linear-gradient(135deg, #e74c3c, #f39c12); }
         .app-tides { background: linear-gradient(135deg, #0a1628, #1a6b7a); }
         .app-360 { background: linear-gradient(135deg, #0a0a1a, #00574a); }
+        .app-dam { background: linear-gradient(135deg, #d9b77f, #6ba5c0); }
     </style>
 </head>
 <body>
@@ -431,6 +432,11 @@
         <a href="cycle/" class="app-link">
             <div class="app-icon app-cycle">🌅</div>
             <span class="app-name">Cycle</span>
+        </a>
+
+        <a href="dam/" class="app-link">
+            <div class="app-icon app-dam">🏖️</div>
+            <span class="app-name">Dam</span>
         </a>
 
         <a href="feed/" class="app-link" id="feed-app" style="display: none;">


### PR DESCRIPTION
A kid-on-the-beach sandbox where the player dams a stream with rocks,
sticks, and sand. Water particles flow down a carved valley from a
spring pool at the top to the ocean at the bottom. The sim couples a
2D Müller-style SPH fluid (typed-arrays, spatial hash) to a terrain
heightfield so accumulated stress erodes sand, dislodges sticks, and
tumbles rocks downstream as debris (driving the domino-effect breach).

Includes a four-tool toolbar (sand/rock/stick/dig) with per-tool
cooldowns, procedural Web Audio ambience + SFX, and Canvas 2D iso
rendering with depth-sorted particles.

https://claude.ai/code/session_014yMeJrnonNbCSZzm3iW6wA