### PR TITLE
Rework Dam to fill the screen and flow gently

### DIFF
--- a/apps/dam/js/config.js
+++ b/apps/dam/js/config.js
@@ -1,11 +1,13 @@
 // World grid (the stream flows from back, j=0, toward camera, j=GRID_H-1)
-export const GRID_W = 26;
-export const GRID_H = 40;
+export const GRID_W = 34;
+export const GRID_H = 34;
 
-// Isometric tile dimensions in screen pixels at scale 1
-export const TILE_W = 24;
-export const TILE_H = 12;
-export const HEIGHT_SCALE = 10;
+// Isometric tile dimensions in screen pixels at scale 1.
+// Portrait orientation: diamonds are taller than wide so the grid
+// projects into a shape that fills a phone screen top-to-bottom.
+export const TILE_W = 12;
+export const TILE_H = 24;
+export const HEIGHT_SCALE = 11;
 
 // Terrain shape
 export const BEACH_SLOPE = 0.09;      // rise per cell going upstream
@@ -21,41 +23,45 @@ export const OCEAN_ROW = GRID_H - 3;  // where ocean waves start
 
 // SPH
 export const PARTICLE_MASS = 1.0;
-export const H = 0.78;                // smoothing length (world units)
+export const H = 0.82;                // smoothing length (world units)
 export const H2 = H * H;
-export const REST_DENSITY = 3.2;
-export const STIFFNESS = 55;
-export const VISCOSITY = 2.8;
-export const GRAVITY = 9.0;           // slope-driven force magnitude
-export const TERRAIN_WALL_K = 240;    // spring constant for terrain walls
-export const TERRAIN_DAMP = 4.0;
-export const MAX_PARTICLES = 1600;
-export const MAX_SPEED = 10.0;
+export const REST_DENSITY = 3.0;
+export const STIFFNESS = 70;
+export const VISCOSITY = 3.4;
+export const GRAVITY = 4.5;           // slope-driven force magnitude (gentle)
+export const DOWNSTREAM_BIAS = 0.15;  // small constant nudge toward the ocean
+export const TERRAIN_WALL_K = 900;    // spring constant for terrain walls
+export const TERRAIN_DAMP = 10.0;
+export const MAX_PARTICLES = 1400;
+export const MAX_SPEED = 5.5;
 
-// Spawning
-export const SPAWN_PER_SEC = 240;     // total per second from the spring
-export const SPAWN_JITTER = 0.35;
+// Spawning — keep it low so the stream is a trickle, not a flood.
+// Particles drain at the ocean, so this is a steady-state throughput.
+export const SPAWN_PER_SEC = 95;
+export const SPAWN_JITTER = 0.2;
 
 // Erosion thresholds (flow-force needed to dislodge 1 unit)
-export const SAND_RESIST = 0.55;      // easily washed
-export const STICK_RESIST = 2.8;      // medium
-export const ROCK_RESIST = 7.5;       // hard to move
-export const EROSION_RATE = 1.3;      // sand erosion scaling
+export const SAND_RESIST = 0.35;      // easily washed
+export const STICK_RESIST = 2.2;      // medium
+export const ROCK_RESIST = 6.5;       // hard to move
+export const EROSION_RATE = 0.9;      // sand erosion scaling
 
-// Material heights per unit stacked in a cell (world units)
-export const SAND_UNIT_H = 0.18;
-export const STICK_UNIT_H = 0.30;
-export const ROCK_UNIT_H = 0.45;
+// Material heights per unit stacked in a cell (world units).
+// Bigger numbers mean each placement is a more impactful obstacle.
+export const SAND_UNIT_H = 0.28;
+export const STICK_UNIT_H = 0.55;
+export const ROCK_UNIT_H = 1.05;
 
 // Tool cooldowns (ms) and dispenses
-export const ROCK_CD = 850;
-export const STICK_CD = 450;
-export const SAND_PLACE_AMOUNT = 0.9;
-export const DIG_AMOUNT = 0.9;
+export const ROCK_CD = 350;
+export const STICK_CD = 220;
+export const SAND_PLACE_AMOUNT = 1.7;
+export const SAND_PLACE_RADIUS = 1.6;
+export const DIG_AMOUNT = 1.6;
 
 // Simulation
 export const DT = 1 / 90;             // physics timestep
 export const MAX_SUBSTEPS = 3;        // cap substeps per frame
 
 // Camera
-export const CAM_MARGIN = 28;
+export const CAM_MARGIN = 16;

--- a/apps/dam/js/controls.js
+++ b/apps/dam/js/controls.js
@@ -1,4 +1,4 @@
-import { ROCK_CD, STICK_CD, GRID_W, GRID_H, SAND_PLACE_AMOUNT, DIG_AMOUNT } from './config.js';
+import { ROCK_CD, STICK_CD, GRID_W, GRID_H, SAND_PLACE_AMOUNT, SAND_PLACE_RADIUS, DIG_AMOUNT } from './config.js';
 
 // Manages the active tool, cooldown UI, and pointer (touch/mouse) events
 // on the canvas. Placement is throttled so a drag emits a steady stream
@@ -85,17 +85,16 @@ export class Controls {
         const tool = this.activeTool;
 
         if (tool === 'sand') {
-            // Drag throttle: only place every ~50ms during drag
             const now = performance.now();
-            if (!isTap && now - this.lastDragPlaceTime < 40) return;
+            if (!isTap && now - this.lastDragPlaceTime < 28) return;
             this.lastDragPlaceTime = now;
-            this.terrain.addSand(world.x, world.y, 1.1, SAND_PLACE_AMOUNT * (isTap ? 1.0 : 0.55));
+            this.terrain.addSand(world.x, world.y, SAND_PLACE_RADIUS, SAND_PLACE_AMOUNT * (isTap ? 1.0 : 0.55));
             this.audio?.playPlace('sand');
         } else if (tool === 'dig') {
             const now = performance.now();
-            if (!isTap && now - this.lastDragPlaceTime < 40) return;
+            if (!isTap && now - this.lastDragPlaceTime < 28) return;
             this.lastDragPlaceTime = now;
-            this.terrain.dig(world.x, world.y, 1.1, DIG_AMOUNT * (isTap ? 1.0 : 0.55));
+            this.terrain.dig(world.x, world.y, SAND_PLACE_RADIUS, DIG_AMOUNT * (isTap ? 1.0 : 0.55));
             this.audio?.playPlace('dig');
         } else if (tool === 'rock') {
             if (this.cooldowns.rock > 0) return;

--- a/apps/dam/js/erosion.js
+++ b/apps/dam/js/erosion.js
@@ -1,4 +1,4 @@
-import { GRID_W, GRID_H, SAND_RESIST, STICK_RESIST, ROCK_RESIST } from './config.js';
+import { GRID_W, GRID_H, SAND_RESIST } from './config.js';
 
 // Couples the SPH simulation to the terrain. Each frame, it walks the
 // particle array, figures out which cell each particle is in, and adds
@@ -91,14 +91,14 @@ export class Erosion {
             d.elevZ += d.vz * dt;
             if (d.elevZ < 0) d.elevZ = 0;
 
-            // Slope-driven horizontal acceleration + sample velocity from water
+            // Slope-driven horizontal acceleration + downstream drift (diagonal)
             const g = terrain.gradientAt(d.x, d.y);
             const mass = d.kind === 'rock' ? 3.5 : 1.4;
-            d.vx += (-g.dx * 6 / mass) * dt;
-            d.vy += (-g.dy * 6 / mass + 1.6 / mass) * dt;
-            // Water drag
+            const downstreamNudge = 0.9 / mass;
+            d.vx += (-g.dx * 6 / mass + downstreamNudge) * dt;
+            d.vy += (-g.dy * 6 / mass + downstreamNudge) * dt;
             d.vx *= 1 - dt * 2.4;
-            d.vy = d.vy * (1 - dt * 2.4) + 1.2 * dt;
+            d.vy *= 1 - dt * 2.4;
             d.x += d.vx * dt;
             d.y += d.vy * dt;
 
@@ -129,8 +129,9 @@ export class Erosion {
                 }
             }
 
-            // Kill if past ocean or off-grid
-            if (d.y > GRID_H - 0.3 || d.x < 0 || d.x > GRID_W) continue;
+            // Kill if past ocean (diagonal) or off-grid
+            if ((d.x + d.y) > (GRID_W + GRID_H) - 1.5) continue;
+            if (d.x < 0 || d.x > GRID_W || d.y < 0 || d.y > GRID_H) continue;
             // Kill if it comes to rest after long time
             if (d.life > 3.5 && Math.abs(d.vx) < 0.1 && Math.abs(d.vy) < 0.3) {
                 // Deposit as sand at this spot (it got buried)

--- a/apps/dam/js/renderer.js
+++ b/apps/dam/js/renderer.js
@@ -114,7 +114,10 @@ export class Renderer {
                 this._drawTileSides(ctx, i, j, e, hw, hh, hs);
 
                 // Top diamond: sand color (warmer where sand is thick, cooler where raw stream)
-                const isStreamBed = Math.abs(i - terrain.streamCenter[j]) < STREAM_WIDTH * 0.9 && e < 0.1;
+                const u = (j - i) * 0.5;
+                const sCoord = (i + j) * 0.5;
+                const meander = Math.sin(sCoord * 0.2) * 1.6;
+                const isStreamBed = Math.abs(u - meander) < STREAM_WIDTH * 0.9 && e < 0.1;
                 this._drawTileTop(ctx, sx, sy, hw, hh, e, sand, isStreamBed, terrain.flowMag[k]);
 
                 // Materials
@@ -337,15 +340,19 @@ export class Renderer {
     }
 
     _drawOceanFoam(ctx) {
-        const { terrain, cam } = this;
+        // Ocean sits at the high-(i+j) corner in diagonal-stream coords.
+        const { cam } = this;
         const t = performance.now() * 0.0012;
-        for (let j = OCEAN_ROW; j < GRID_H; j++) {
-            const oT = (j - OCEAN_ROW) / (GRID_H - 1 - OCEAN_ROW);
+        const threshold = (GRID_W + GRID_H) - 6; // (i+j) >= this means "ocean"
+        const hw = TILE_W * 0.5 * cam.scale;
+        const hh = TILE_H * 0.5 * cam.scale;
+        for (let j = 0; j < GRID_H; j++) {
             for (let i = 0; i < GRID_W; i++) {
-                const p = project(i + 0.5, j + 0.5, Math.sin(i * 0.5 + t + j * 0.2) * 0.05 - 0.15, cam);
-                const hw = TILE_W * 0.5 * cam.scale;
-                const hh = TILE_H * 0.5 * cam.scale;
-                ctx.fillStyle = `rgba(110,170,200,${0.55 + oT * 0.2})`;
+                if (i + j < threshold) continue;
+                const oT = Math.min(1, ((i + j) - threshold) / 6);
+                const p = project(i + 0.5, j + 0.5,
+                    Math.sin(i * 0.5 + t + j * 0.2) * 0.05 - 0.15, cam);
+                ctx.fillStyle = `rgba(110,170,200,${0.5 + oT * 0.25})`;
                 ctx.beginPath();
                 ctx.moveTo(p.sx, p.sy - hh);
                 ctx.lineTo(p.sx + hw, p.sy);
@@ -353,9 +360,9 @@ export class Renderer {
                 ctx.lineTo(p.sx - hw, p.sy);
                 ctx.closePath();
                 ctx.fill();
-                // Foam strips at the shore
-                if (j === OCEAN_ROW) {
-                    const foam = 0.35 + 0.25 * Math.sin(i + t * 2.5);
+                // Foam at the first shore line
+                if (Math.abs((i + j) - threshold) < 1) {
+                    const foam = 0.35 + 0.25 * Math.sin((i + j) + t * 2.5);
                     ctx.fillStyle = `rgba(255,255,255,${foam})`;
                     ctx.beginPath();
                     ctx.ellipse(p.sx, p.sy - hh * 0.3, hw * 0.7, hh * 0.4, 0, 0, Math.PI * 2);

--- a/apps/dam/js/sph.js
+++ b/apps/dam/js/sph.js
@@ -1,6 +1,6 @@
 import {
     GRID_W, GRID_H, H, H2,
-    REST_DENSITY, STIFFNESS, VISCOSITY, GRAVITY,
+    REST_DENSITY, STIFFNESS, VISCOSITY, GRAVITY, DOWNSTREAM_BIAS,
     TERRAIN_WALL_K, TERRAIN_DAMP,
     MAX_PARTICLES, MAX_SPEED, PARTICLE_MASS,
     SPAWN_PER_SEC, SPAWN_JITTER,
@@ -172,40 +172,43 @@ export class SPH {
             const g = terrain.gradientAt(ppx, ppy);
             ax -= g.dx * GRAVITY;
             ay -= g.dy * GRAVITY;
-            // Slight downstream bias so stagnation doesn't kill the flow entirely
-            ay += 0.6;
+            // Downstream bias along the diagonal (+x, +y)
+            ax += DOWNSTREAM_BIAS * 0.707;
+            ay += DOWNSTREAM_BIAS * 0.707;
 
-            // Wall from nearby terrain elevation that exceeds particle "level"
-            // Estimate effective water surface height via density.
+            // Soft wall from nearby raised cells — pushes water away from dams.
+            // We also do a hard position clamp after integration.
+            const myFloor = terrain.elevationAt(ppx, ppy);
             const waterSurface = pileHeightFromDensity(density[p]);
+            const topOfWater = myFloor + waterSurface;
             const cellI = ppx | 0, cellJ = ppy | 0;
-            // Push away from neighbor cells whose elevation is too tall
             for (let dj = -1; dj <= 1; dj++) {
                 for (let di = -1; di <= 1; di++) {
+                    if (di === 0 && dj === 0) continue;
                     const ci = cellI + di, cj = cellJ + dj;
                     if (!terrain.inBounds(ci, cj)) continue;
                     const e = terrain.elevation(ci, cj);
-                    // "Floor" of this cell relative to local water surface
-                    const myFloor = terrain.elevationAt(ppx, ppy);
-                    const overhead = e - (myFloor + waterSurface);
-                    if (overhead > 0) {
-                        // Closest point on cell bounds
-                        const cx = Math.max(ci, Math.min(ci + 1, ppx));
-                        const cy = Math.max(cj, Math.min(cj + 1, ppy));
-                        const rx = ppx - cx;
-                        const ry = ppy - cy;
-                        const d = Math.sqrt(rx * rx + ry * ry);
-                        if (d < 0.4 && d > 1e-4) {
-                            const push = TERRAIN_WALL_K * overhead * (0.4 - d);
-                            ax += (rx / d) * push;
-                            ay += (ry / d) * push;
-                            // Damp velocity into the wall
-                            const vn = pVx * (-rx / d) + pVy * (-ry / d);
-                            if (vn > 0) {
-                                ax -= (-rx / d) * vn * TERRAIN_DAMP;
-                                ay -= (-ry / d) * vn * TERRAIN_DAMP;
-                            }
-                        }
+                    const overhead = e - topOfWater;
+                    if (overhead <= 0) continue;
+                    // Closest point on that cell's AABB
+                    const cx = Math.max(ci, Math.min(ci + 1, ppx));
+                    const cy = Math.max(cj, Math.min(cj + 1, ppy));
+                    const rx = ppx - cx;
+                    const ry = ppy - cy;
+                    const d2 = rx * rx + ry * ry;
+                    const reach = 0.55;
+                    if (d2 >= reach * reach) continue;
+                    const d = Math.sqrt(d2) || 1e-4;
+                    const nxw = rx / d, nyw = ry / d;
+                    const pen = reach - d;
+                    const push = TERRAIN_WALL_K * Math.min(overhead, 1.5) * pen;
+                    ax += nxw * push;
+                    ay += nyw * push;
+                    // Damp velocity component heading into the wall
+                    const vn = pVx * -nxw + pVy * -nyw;
+                    if (vn > 0) {
+                        ax -= -nxw * vn * TERRAIN_DAMP;
+                        ay -= -nyw * vn * TERRAIN_DAMP;
                     }
                 }
             }
@@ -238,13 +241,52 @@ export class SPH {
         const { px, py, vx, vy, alive, terrain } = this;
         for (let p = 0; p < this.capacity; p++) {
             if (!alive[p]) continue;
-            // Lateral walls of the grid
+            // Grid edges
             if (px[p] < 0.05) { px[p] = 0.05; if (vx[p] < 0) vx[p] = -vx[p] * 0.3; }
             if (px[p] > GRID_W - 0.05) { px[p] = GRID_W - 0.05; if (vx[p] > 0) vx[p] = -vx[p] * 0.3; }
-            // Top wall (upstream end): soft wall
             if (py[p] < 0.05) { py[p] = 0.05; if (vy[p] < 0) vy[p] = -vy[p] * 0.3; }
-            // Bottom: remove if past the ocean
-            if (py[p] > GRID_H - 0.1) {
+
+            // Hard terrain wall: if this particle is inside a cell whose top
+            // is above our local water surface, shove it sideways toward the
+            // lowest neighbor. Prevents fast particles from tunneling dams.
+            const ci = px[p] | 0, cj = py[p] | 0;
+            const myTop = terrain.elevation(ci, cj);
+            const myFloor = terrain.elevationAt(px[p], py[p]);
+            const waterSurface = pileHeightFromDensity(this.density[p]);
+            if (myTop > myFloor + waterSurface + 0.25) {
+                // We're standing on a raised cell (a dam). Push to the lowest
+                // neighbor to simulate overtopping / spill.
+                let bestI = ci, bestJ = cj, bestE = myTop;
+                for (let dj = -1; dj <= 1; dj++) {
+                    for (let di = -1; di <= 1; di++) {
+                        if (di === 0 && dj === 0) continue;
+                        const ni = ci + di, nj = cj + dj;
+                        if (!terrain.inBounds(ni, nj)) continue;
+                        const ne = terrain.elevation(ni, nj);
+                        if (ne < bestE) { bestE = ne; bestI = ni; bestJ = nj; }
+                    }
+                }
+                if (bestI !== ci || bestJ !== cj) {
+                    const tx = bestI + 0.5, ty = bestJ + 0.5;
+                    const dx = tx - px[p], dy = ty - py[p];
+                    const dL = Math.sqrt(dx * dx + dy * dy) || 1;
+                    // Nudge across the edge of this cell
+                    px[p] += (dx / dL) * 0.15;
+                    py[p] += (dy / dL) * 0.15;
+                    vx[p] *= 0.5;
+                    vy[p] *= 0.5;
+                }
+            }
+
+            // Drain at the ocean shore so new water keeps entering the system.
+            // With the diagonal stream, downstream is measured as (x+y).
+            const ds = px[p] + py[p];
+            const oceanS = (GRID_W + GRID_H) - 6;
+            if (ds > oceanS) {
+                vx[p] *= 0.85;
+                vy[p] *= 0.85;
+            }
+            if (ds > (GRID_W + GRID_H) - 2.4) {
                 this._kill(p);
             }
         }
@@ -257,13 +299,19 @@ export class SPH {
         const toSpawn = Math.floor(this.spawnAccumulator);
         if (toSpawn <= 0) return;
         this.spawnAccumulator -= toSpawn;
-        const cx = this.terrain.streamCenter[1];
+        // Spring is at the back corner (world 0,0). Spawn along the stream
+        // centerline (s ~ 1..2, u ~ 0) which in world (x,y) = (s-u, s+u).
         for (let i = 0; i < toSpawn; i++) {
             if (this.count >= this.capacity - 2) break;
-            const x = cx + (Math.random() - 0.5) * 1.4;
-            const y = 0.5 + Math.random() * 1.1;
-            const vx = (Math.random() - 0.5) * SPAWN_JITTER;
-            const vy = 1.0 + Math.random() * 0.8;
+            const s = 0.9 + Math.random() * 1.6;
+            const u = (Math.random() - 0.5) * 0.9;
+            const x = s - u;
+            const y = s + u;
+            // Downstream direction is (+x, +y) in world so initial velocity
+            // nudges along that diagonal.
+            const nudge = 0.35 + Math.random() * 0.3;
+            const vx = nudge + (Math.random() - 0.5) * SPAWN_JITTER;
+            const vy = nudge + (Math.random() - 0.5) * SPAWN_JITTER;
             this._spawn(x, y, vx, vy);
         }
     }

--- a/apps/dam/js/terrain.js
+++ b/apps/dam/js/terrain.js
@@ -46,39 +46,63 @@ export class Terrain {
     }
 
     _buildBaseTerrain() {
+        // Stream runs DIAGONALLY across the square grid, from the back-top
+        // corner (world 0,0) to the front-bottom (world W,H). In the rotated
+        // isometric projection this reads as a purely vertical stream on
+        // screen. We use rotated coordinates (s, u) where s is the distance
+        // downstream and u is the lateral offset across the stream.
         const { w, h, base, streamCenter } = this;
+        const diag = Math.sqrt(w * w + h * h);
         for (let j = 0; j < h; j++) {
-            // Ocean ramp: last few rows taper to elevation 0 (water level)
-            const oceanT = Math.max(0, (j - OCEAN_ROW) / (h - 1 - OCEAN_ROW));
-            // Beach slope rises upstream (decreasing j). Top row is highest.
-            const beach = BEACH_SLOPE * (h - 1 - j);
-            // Meandering stream center
-            const cx = w * 0.5 + Math.sin(j * STREAM_FREQ) * STREAM_MEANDER
-                       + Math.sin(j * 0.07 + 1.3) * 0.7;
-            streamCenter[j] = cx;
-            // Extra depth for the spring pool at the top rows
-            const springT = j < SPRING_POOL_ROWS ? (1 - j / SPRING_POOL_ROWS) : 0;
             for (let i = 0; i < w; i++) {
-                const dx = i - cx;
-                // Smooth Lorentzian valley — deep at centerline, falls off with distance
-                const valley = STREAM_DEPTH / (1 + Math.pow(dx / (STREAM_WIDTH * 0.6), 2));
-                // Aggressive lateral rise outside the valley so water stays contained
-                const bank = Math.min(BANK_MAX, Math.max(0, (Math.abs(dx) - STREAM_WIDTH) * BANK_SLOPE));
-                // Noise for natural look (deterministic)
-                const n = pseudoNoise(i, j) * 0.10;
-                // Taper into ocean — widen the channel and drop the banks
+                // Downstream / lateral coordinates (rotated 45°)
+                const s = (i + j) * 0.5;                // 0..(w+h)/2, increases toward ocean
+                const u = (j - i) * 0.5;                // negative = left bank, positive = right bank
+                const sT = s / ((w + h) * 0.5);         // 0..1
+                // Gentle meander
+                const meander = Math.sin(s * STREAM_FREQ) * STREAM_MEANDER
+                              + Math.sin(s * 0.09 + 1.3) * 0.7;
+                const du = u - meander;
+
+                // Beach elevation: highest at the spring, tapers to the ocean
+                const beach = BEACH_SLOPE * (1 - sT) * diag;
+
+                // Lorentzian valley + aggressive banks
+                const valley = STREAM_DEPTH / (1 + Math.pow(du / (STREAM_WIDTH * 0.6), 2));
+                const bank = Math.min(BANK_MAX, Math.max(0, (Math.abs(du) - STREAM_WIDTH) * BANK_SLOPE));
+
+                // Ocean ramp
+                const oceanT = Math.max(0, (sT - (OCEAN_ROW / h)) / (1 - OCEAN_ROW / h));
+
                 const bankSoften = 1 - oceanT * 0.9;
+
+                // Noise for natural texture
+                const n = pseudoNoise(i, j) * 0.10;
                 let e = beach - valley * bankSoften + bank * bankSoften + n;
-                // Spring pool: carve an extra bowl at the top
-                if (springT > 0 && Math.abs(dx) < STREAM_WIDTH * 1.5) {
+
+                // Spring pool: extra depth near the spring corner
+                const springT = Math.max(0, 1 - s / SPRING_POOL_ROWS);
+                if (springT > 0 && Math.abs(du) < STREAM_WIDTH * 1.5) {
                     const bowl = SPRING_POOL_EXTRA * springT
-                        * Math.max(0, 1 - Math.abs(dx) / (STREAM_WIDTH * 1.5));
+                        * Math.max(0, 1 - Math.abs(du) / (STREAM_WIDTH * 1.5));
                     e -= bowl;
                 }
+
+                // Taper into the ocean
                 e *= (1 - oceanT * 0.9);
                 e -= oceanT * 0.6;
                 base[j * w + i] = e;
             }
+        }
+        // streamCenter[j] is used at spawn + spring queries. Since flow is
+        // diagonal, "row j" crosses the stream at x = j (centerline before
+        // meander). We store the x-coordinate where the centerline crosses
+        // each row — for spawn purposes we just use the spring corner.
+        for (let j = 0; j < h; j++) {
+            // centerline: the diagonal i = j (in world coords). With meander,
+            // the i value at the stream center in this row is j + meander*√2.
+            // We only really need this for spawn, where j is small.
+            streamCenter[j] = j;
         }
     }
 
@@ -89,11 +113,14 @@ export class Terrain {
             s = (s * 1103515245 + 12345) & 0x7fffffff;
             return s / 0x7fffffff;
         };
-        for (let j = 2; j < this.h - 4; j++) {
-            const cx = this.streamCenter[j];
+        for (let j = 0; j < this.h; j++) {
             for (let i = 0; i < this.w; i++) {
-                const dx = Math.abs(i - cx);
-                if (dx > STREAM_WIDTH + 0.5 && dx < STREAM_WIDTH + 3 && rand() < 0.08) {
+                const u = (j - i) * 0.5;
+                const sCoord = (i + j) * 0.5;
+                if (sCoord < 3 || sCoord > (this.w + this.h) * 0.5 - 4) continue;
+                const meander = Math.sin(sCoord * STREAM_FREQ) * STREAM_MEANDER;
+                const du = u - meander;
+                if (Math.abs(du) > STREAM_WIDTH + 0.5 && Math.abs(du) < STREAM_WIDTH + 3 && rand() < 0.08) {
                     this.addRock(i, j, rand);
                 }
             }


### PR DESCRIPTION
Addresses feedback on the original Dam Builder that the play area was too small, water rushed in so quickly there was no time to build, and placed materials didn't actually block the flow.

## Summary

- **Fills the screen**: swapped to portrait isometric (tall diamonds instead of wide) and routed the stream diagonally across a square grid so it reads as a vertical flow filling the phone screen top-to-bottom.
- **Not a lake**: particles drain as soon as they hit the ocean shore, so the system holds a steady trickle instead of filling to the particle cap and going still.
- **Time to build**: spawn rate dropped from 240/s to 95/s, max speed halved, and rock/stick cooldowns cut to 350/220 ms.
- **Dams actually block**: rocks add ~2.3× more elevation per placement, sand blobs are bigger and faster to lay down, wall spring constant is ~4× stronger, and there's now a hard position clamp that prevents fast particles from tunneling through a dam.

## Test plan

- [ ] Load `/apps/dam/` on an iPhone and confirm the playfield fills the screen top-to-bottom.
- [ ] Watch a few seconds of baseline flow — should be a visible trickle, not a flood, and shouldn't pool up into a static lake.
- [ ] Build a dam with sand + rocks across the stream and confirm water clearly pools upstream.
- [ ] Leave the dam alone and confirm it eventually breaches (sand washes, then rocks/sticks tumble downstream as debris).
- [ ] Check framerate stays smooth while water is fully backed up (worst case for SPH neighbor counts).
