### PR TITLE
Move Reddit proxy into main worker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,12 @@
 # CLAUDE.md
 
+## Domain
+
+**The site is served at `polkiewicz.com`.** The repository is named `maattp.github.io` for GitHub Pages routing, but that hostname is **not** the live site — do not assume `maattp.github.io` is the user-facing origin. When configuring CORS, `fetch` URLs, or anything origin-sensitive, the canonical origin is `https://polkiewicz.com`.
+
 ## Site Structure
 
-Static personal site with a collection of self-contained web utilities. Served at polkiewicz.com.
+Static personal site with a collection of self-contained web utilities.
 
 ```
 /index.html              - Main site (resume/portfolio)

--- a/apps/feed/index.html
+++ b/apps/feed/index.html
@@ -727,7 +727,7 @@
 <body>
     <div class="home-view" id="home-view">
         <div class="header">
-            <h1>Feed <span class="version">v18</span></h1>
+            <h1>Feed <span class="version">v19</span></h1>
             <button class="export-btn" id="export-btn">Export</button>
             <select class="sort-select" id="sort-select">
                 <option value="hot">Hot</option>
@@ -760,7 +760,7 @@
     </div>
 
     <script>
-        const PROXY = 'https://little-sunset-822a.maattp.workers.dev/';
+        const PROXY = 'https://cloudflare-backend.maattp.workers.dev/reddit-proxy';
         const LS_KEY = 'feed-subs';
         const LS_SORT_KEY = 'feed-sort';
         const LS_TIME_KEY = 'feed-time';

--- a/apps/reddit/index.html
+++ b/apps/reddit/index.html
@@ -571,7 +571,7 @@
     <div class="container" id="app"></div>
 
     <script>
-        const PROXY = 'https://little-sunset-822a.maattp.workers.dev/';
+        const PROXY = 'https://cloudflare-backend.maattp.workers.dev/reddit-proxy';
         const LS_KEY = 'reddit-subs';
         const LS_SORT_KEY = 'reddit-sort';
         const LS_TIME_KEY = 'reddit-time';

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -185,6 +185,37 @@ app.delete("/kv/:key", async (c) => {
   return c.json({ key, deleted: true });
 });
 
+// --- Reddit proxy ---
+// Browsers can't call reddit.com directly (no CORS). This proxies GET requests
+// to reddit.com with a descriptive User-Agent, which reddit requires.
+
+const REDDIT_UA = "web:polkiewicz.com:v1.0 (by /u/mp_readonly)";
+
+app.get("/reddit-proxy", async (c) => {
+  const target = c.req.query("url");
+  if (!target) return c.json({ error: "missing url" }, 400);
+  let parsed: URL;
+  try {
+    parsed = new URL(target);
+  } catch {
+    return c.json({ error: "invalid url" }, 400);
+  }
+  if (parsed.protocol !== "https:" || !/(^|\.)reddit\.com$/.test(parsed.hostname)) {
+    return c.json({ error: "only reddit.com is allowed" }, 400);
+  }
+  const upstream = await fetch(parsed.toString(), {
+    headers: { "User-Agent": REDDIT_UA, "Accept": "application/json" },
+  });
+  const body = await upstream.arrayBuffer();
+  return new Response(body, {
+    status: upstream.status,
+    headers: {
+      "Content-Type": upstream.headers.get("Content-Type") ?? "application/json",
+      "Cache-Control": "no-store",
+    },
+  });
+});
+
 // --- Pixels (shared canvas) ---
 
 const PIXELS_KEY = "pixels";


### PR DESCRIPTION
## Summary
- Adds `GET /reddit-proxy?url=...` to the main `cloudflare-backend` worker, forwarding to reddit.com with a descriptive `User-Agent` (Reddit blocks requests without one, which is why the feed and reddit apps had started 403ing).
- Points the `feed` and `reddit` apps at the new route so we can retire the undocumented `little-sunset-822a` worker once deploy confirms.
- Clarifies in `CLAUDE.md` that the live origin is `polkiewicz.com` — the `maattp.github.io` repo name is just GitHub Pages routing.

## Test plan
- [ ] CI passes (worker typecheck, deploy-worker on merge)
- [ ] After deploy, `curl "https://cloudflare-backend.maattp.workers.dev/reddit-proxy?url=https%3A%2F%2Fwww.reddit.com%2Fr%2Fpics%2Fhot.json%3Flimit%3D2"` returns 200 with Listing JSON
- [ ] `https://polkiewicz.com/apps/feed/` loads posts
- [ ] `https://polkiewicz.com/apps/reddit/` loads posts
- [ ] Delete the `little-sunset-822a` worker from the Cloudflare dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)