### PR TITLE
Add Cortex — atmospheric 3D neural network visualization

### DIFF
--- a/apps/cortex/camera.js
+++ b/apps/cortex/camera.js
@@ -1,0 +1,240 @@
+// Camera controller: autonomous orbital drift + user drag/pinch input
+// with smooth handoff back to drift after 3s of idle.
+//
+// Drift is a sum of sines at non-rational frequency ratios so the path
+// never quite repeats. A slow constant-rate orbital term ensures we keep
+// circling the network rather than oscillating around one face.
+//
+// Smoothing is applied to the underlying spherical state (theta, phi,
+// distance) every frame regardless of mode — so transitions between
+// drift and user input are inherently smooth without explicit blending.
+
+import * as THREE from 'three';
+
+const IDLE_HANDOFF_MS = 3000;
+
+const DRIFT_AMPL_THETA = [0.55, 0.18];
+const DRIFT_FREQ_THETA = [0.071, 0.113];
+const DRIFT_AMPL_PHI   = [0.30, 0.11, 0.04];
+const DRIFT_FREQ_PHI   = [0.083, 0.139, 0.201];
+const DRIFT_AMPL_DIST  = [22, 8];
+const DRIFT_FREQ_DIST  = [0.058, 0.097];
+const DRIFT_ORBIT_RATE = 0.022;     // rad/sec — slow continuous spin
+
+const SMOOTH_K_DRIFT = 0.06;
+const SMOOTH_K_USER = 0.18;
+
+const PHI_LIMIT = 1.35;             // ~77° — avoid pole flips
+const DIST_MIN = 60;
+const DIST_MAX = 360;
+
+export class CortexCamera {
+    constructor(threeCamera, canvas, opts = {}) {
+        this.camera = threeCamera;
+        this.canvas = canvas;
+        this.opts = Object.assign({
+            initialDistance: 220,
+            initialTheta: 0.4,
+            initialPhi: 0.15,
+            target: new THREE.Vector3(0, 0, 0),
+        }, opts);
+
+        // Logical (target) spherical state — what drift / input drives.
+        this.theta = this.opts.initialTheta;
+        this.phi = this.opts.initialPhi;
+        this.distance = this.opts.initialDistance;
+
+        // Smoothed (rendered) spherical state — what the camera is actually at.
+        this.smTheta = this.theta;
+        this.smPhi = this.phi;
+        this.smDistance = this.distance;
+
+        // Drift bookkeeping
+        this.mode = 'drift';
+        this.driftStartMs = 0;
+        this.driftBaseTheta = this.theta;
+        this.driftBasePhi = this.phi;
+        this.driftBaseDistance = this.distance;
+
+        // Input bookkeeping
+        this.lastInputMs = -Infinity;
+        this.activePointers = new Map();   // pointerId -> {x, y}
+        this.dragLastX = 0;
+        this.dragLastY = 0;
+        this.lastPinchDist = 0;
+
+        // External click callback (set by main)
+        this.onClickWorld = null;
+
+        // Distinguish click from drag
+        this._pointerDownAt = 0;
+        this._pointerDownX = 0;
+        this._pointerDownY = 0;
+        this._movedDuringPointerDown = false;
+
+        this._attach();
+    }
+
+    _attach() {
+        const c = this.canvas;
+        c.addEventListener('pointerdown', this._onPointerDown.bind(this));
+        c.addEventListener('pointermove', this._onPointerMove.bind(this));
+        c.addEventListener('pointerup', this._onPointerUp.bind(this));
+        c.addEventListener('pointercancel', this._onPointerUp.bind(this));
+        c.addEventListener('wheel', this._onWheel.bind(this), { passive: false });
+    }
+
+    _markInput(nowMs) {
+        this.lastInputMs = nowMs;
+        if (this.mode === 'drift') {
+            this.mode = 'user';
+        }
+    }
+
+    _onPointerDown(e) {
+        e.preventDefault();
+        this.canvas.setPointerCapture(e.pointerId);
+        this.activePointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+        this.dragLastX = e.clientX;
+        this.dragLastY = e.clientY;
+        this._pointerDownAt = performance.now();
+        this._pointerDownX = e.clientX;
+        this._pointerDownY = e.clientY;
+        this._movedDuringPointerDown = false;
+        if (this.activePointers.size === 2) {
+            this.lastPinchDist = this._currentPinchDist();
+        }
+        this._markInput(performance.now());
+    }
+
+    _onPointerMove(e) {
+        if (!this.activePointers.has(e.pointerId)) return;
+        const prev = this.activePointers.get(e.pointerId);
+        prev.x = e.clientX; prev.y = e.clientY;
+
+        if (this.activePointers.size === 1) {
+            // Drag to orbit
+            const dx = e.clientX - this.dragLastX;
+            const dy = e.clientY - this.dragLastY;
+            this.dragLastX = e.clientX;
+            this.dragLastY = e.clientY;
+            const dThetaPerPx = -0.005;
+            const dPhiPerPx = 0.005;
+            this.theta += dx * dThetaPerPx;
+            this.phi += dy * dPhiPerPx;
+            this.phi = Math.max(-PHI_LIMIT, Math.min(PHI_LIMIT, this.phi));
+        } else if (this.activePointers.size === 2) {
+            // Pinch to zoom
+            const d = this._currentPinchDist();
+            if (this.lastPinchDist > 0) {
+                const ratio = this.lastPinchDist / d;
+                this.distance *= ratio;
+                this.distance = Math.max(DIST_MIN, Math.min(DIST_MAX, this.distance));
+            }
+            this.lastPinchDist = d;
+        }
+
+        // Track if pointer moved appreciably (for click detection)
+        const totalDx = e.clientX - this._pointerDownX;
+        const totalDy = e.clientY - this._pointerDownY;
+        if (totalDx * totalDx + totalDy * totalDy > 36) {
+            this._movedDuringPointerDown = true;
+        }
+        this._markInput(performance.now());
+    }
+
+    _onPointerUp(e) {
+        const wasActive = this.activePointers.has(e.pointerId);
+        this.activePointers.delete(e.pointerId);
+        if (this.canvas.hasPointerCapture && this.canvas.hasPointerCapture(e.pointerId)) {
+            this.canvas.releasePointerCapture(e.pointerId);
+        }
+        if (this.activePointers.size < 2) this.lastPinchDist = 0;
+
+        // Click detection — short, no drag
+        if (wasActive && !this._movedDuringPointerDown
+            && (performance.now() - this._pointerDownAt) < 300
+            && this.activePointers.size === 0) {
+            if (this.onClickWorld) this.onClickWorld(e.clientX, e.clientY);
+        }
+        this._markInput(performance.now());
+    }
+
+    _onWheel(e) {
+        e.preventDefault();
+        // deltaY > 0 = scroll down = zoom out (intuitive on trackpad/mouse)
+        const factor = Math.exp(e.deltaY * 0.0014);
+        this.distance *= factor;
+        this.distance = Math.max(DIST_MIN, Math.min(DIST_MAX, this.distance));
+        this._markInput(performance.now());
+    }
+
+    _currentPinchDist() {
+        const pts = Array.from(this.activePointers.values());
+        if (pts.length < 2) return 0;
+        const dx = pts[0].x - pts[1].x;
+        const dy = pts[0].y - pts[1].y;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    update(nowMs) {
+        // Mode handoff: 3s after last input with no pointers down, return to drift
+        if (this.mode === 'user'
+            && this.activePointers.size === 0
+            && (nowMs - this.lastInputMs) > IDLE_HANDOFF_MS) {
+            this.mode = 'drift';
+            this.driftStartMs = nowMs;
+            // Rebase drift so its t=0 value equals current logical state.
+            // Subsequent drift values will then start from where the user
+            // left off and gradually wander.
+            this.driftBaseTheta = this.theta;
+            this.driftBasePhi = this.phi;
+            this.driftBaseDistance = this.distance;
+        }
+
+        if (this.mode === 'drift') {
+            const t = (nowMs - this.driftStartMs) * 0.001;
+            let th = this.driftBaseTheta + DRIFT_ORBIT_RATE * t;
+            for (let k = 0; k < DRIFT_AMPL_THETA.length; k++) {
+                th += DRIFT_AMPL_THETA[k] * Math.sin(t * DRIFT_FREQ_THETA[k] * Math.PI * 2);
+            }
+            let ph = this.driftBasePhi;
+            for (let k = 0; k < DRIFT_AMPL_PHI.length; k++) {
+                ph += DRIFT_AMPL_PHI[k] * Math.sin(t * DRIFT_FREQ_PHI[k] * Math.PI * 2 + k * 1.7);
+            }
+            ph = Math.max(-PHI_LIMIT, Math.min(PHI_LIMIT, ph));
+            let d = this.driftBaseDistance;
+            for (let k = 0; k < DRIFT_AMPL_DIST.length; k++) {
+                d += DRIFT_AMPL_DIST[k] * Math.sin(t * DRIFT_FREQ_DIST[k] * Math.PI * 2 + k * 0.9);
+            }
+            d = Math.max(DIST_MIN, Math.min(DIST_MAX, d));
+
+            this.theta = th;
+            this.phi = ph;
+            this.distance = d;
+        }
+
+        // Smooth toward logical state
+        const k = this.mode === 'user' ? SMOOTH_K_USER : SMOOTH_K_DRIFT;
+        this.smTheta += (this.theta - this.smTheta) * k;
+        this.smPhi += (this.phi - this.smPhi) * k;
+        this.smDistance += (this.distance - this.smDistance) * k;
+
+        // Apply to camera
+        const tgt = this.opts.target;
+        const cosPhi = Math.cos(this.smPhi);
+        const sinPhi = Math.sin(this.smPhi);
+        const cosTh = Math.cos(this.smTheta);
+        const sinTh = Math.sin(this.smTheta);
+        this.camera.position.set(
+            tgt.x + this.smDistance * cosPhi * sinTh,
+            tgt.y + this.smDistance * sinPhi,
+            tgt.z + this.smDistance * cosPhi * cosTh,
+        );
+        this.camera.lookAt(tgt);
+    }
+
+    getDistanceToTarget() {
+        return this.smDistance;
+    }
+}

--- a/apps/cortex/index.html
+++ b/apps/cortex/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="theme-color" content="#05060a">
+    <link rel="apple-touch-icon" href="../icon.png">
+    <title>Cortex</title>
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
+            background: #05060a;
+            -webkit-tap-highlight-color: transparent;
+            touch-action: none;
+            overscroll-behavior: none;
+        }
+        canvas {
+            display: block;
+            width: 100vw;
+            height: 100vh;
+            cursor: crosshair;
+        }
+    </style>
+    <script type="importmap">
+    {
+        "imports": {
+            "three": "https://unpkg.com/three@0.161.0/build/three.module.js",
+            "three/addons/": "https://unpkg.com/three@0.161.0/examples/jsm/"
+        }
+    }
+    </script>
+</head>
+<body>
+    <canvas id="cortex"></canvas>
+    <script type="module" src="./main.js"></script>
+</body>
+</html>

--- a/apps/cortex/main.js
+++ b/apps/cortex/main.js
@@ -33,7 +33,9 @@ function detectTier() {
     const dpr = window.devicePixelRatio || 1;
     const memHint = navigator.deviceMemory || 4;
 
-    // Try to read renderer string for finer tiering
+    // Try to read renderer string for finer tiering, then explicitly
+    // drop the probe context so its GPU resources free immediately
+    // rather than waiting for GC.
     let rendererStr = '';
     try {
         const tmp = document.createElement('canvas').getContext('webgl2');
@@ -42,6 +44,8 @@ function detectTier() {
             if (ext) {
                 rendererStr = tmp.getParameter(ext.UNMASKED_RENDERER_WEBGL) || '';
             }
+            const lose = tmp.getExtension('WEBGL_lose_context');
+            if (lose) lose.loseContext();
         }
     } catch (e) { /* ignore */ }
     const lowGpu = /SwiftShader|Mali|Adreno 3|Adreno 4|PowerVR/i.test(rendererStr);
@@ -111,7 +115,9 @@ function resize() {
     const h = window.innerHeight;
     const dpr = renderer.renderer.getPixelRatio();
     renderer.setSize(w, h, dpr);
-    post.setSize(w * dpr, h * dpr);
+    // Round so the composer's render targets get integer dimensions even
+    // when pixelRatio isn't an integer (e.g. tier-medium uses 1.75).
+    post.setSize(Math.round(w * dpr), Math.round(h * dpr));
 }
 window.addEventListener('resize', resize);
 resize();
@@ -120,8 +126,6 @@ resize();
 
 const ray = new THREE.Raycaster();
 const ndc = new THREE.Vector2();
-const tmpVec = new THREE.Vector3();
-const tmpRel = new THREE.Vector3();
 
 camCtl.onClickWorld = (clientX, clientY) => {
     const rect = canvas.getBoundingClientRect();
@@ -135,7 +139,6 @@ camCtl.onClickWorld = (clientX, clientY) => {
     const positions = network.positions;
     let bestIdx = -1;
     let bestD2 = Infinity;
-    let bestT = 0;
     for (let i = 0; i < network.n; i++) {
         const px = positions[i * 3 + 0];
         const py = positions[i * 3 + 1];
@@ -153,7 +156,6 @@ camCtl.onClickWorld = (clientX, clientY) => {
         if (d2 < bestD2) {
             bestD2 = d2;
             bestIdx = i;
-            bestT = t;
         }
     }
 

--- a/apps/cortex/main.js
+++ b/apps/cortex/main.js
@@ -1,0 +1,237 @@
+// Cortex — neural network visualization
+//
+// Stack: WebGL2 + Three.js, CPU-side leaky integrate-and-fire simulation,
+// GPU-instanced rendering with per-frame attribute uploads.
+//
+// Why CPU sim instead of GPGPU ping-pong textures: 16k neurons at 200Hz
+// is ~3M updates/sec, well within JS budget on a modern laptop. The
+// synapse delivery — push each spike's outgoing weight into scattered
+// future timesteps of a delay ring buffer — is exactly the kind of
+// variable-fanout scatter-write pattern that GPGPU is bad at. Doing it
+// on CPU lets us keep the pipeline straightforward and spend the GPU
+// budget on rendering quality instead.
+//
+// Why not WebGPU: Safari/WebKit support is uneven as of early 2026, and
+// this site runs as an iOS PWA. WebGL2 is the broader path.
+//
+// Loop topology: rAF → fixed-step simulation catch-up → state sync →
+// camera update → composer render. Postprocessing handles bloom, DoF,
+// chromatic aberration, grain, vignette.
+
+import * as THREE from 'three';
+import { Network, SIM_DT_MS } from './simulation.js';
+import { CortexRenderer } from './rendering.js';
+import { CortexPostprocessor } from './postprocessing.js';
+import { CortexCamera } from './camera.js';
+
+// ---------- Hardware tier detection ----------
+
+function detectTier() {
+    const ua = navigator.userAgent || '';
+    const isMobile = /iPhone|iPad|iPod|Android/.test(ua);
+    const cores = navigator.hardwareConcurrency || 4;
+    const dpr = window.devicePixelRatio || 1;
+    const memHint = navigator.deviceMemory || 4;
+
+    // Try to read renderer string for finer tiering
+    let rendererStr = '';
+    try {
+        const tmp = document.createElement('canvas').getContext('webgl2');
+        if (tmp) {
+            const ext = tmp.getExtension('WEBGL_debug_renderer_info');
+            if (ext) {
+                rendererStr = tmp.getParameter(ext.UNMASKED_RENDERER_WEBGL) || '';
+            }
+        }
+    } catch (e) { /* ignore */ }
+    const lowGpu = /SwiftShader|Mali|Adreno 3|Adreno 4|PowerVR/i.test(rendererStr);
+
+    if (isMobile || cores < 4 || memHint < 3 || lowGpu) {
+        return {
+            tier: 'low',
+            neuronCount: 6144,
+            enableDoF: false,
+            enableBloom: true,
+            bloomStrength: 0.85,
+            pixelRatio: Math.min(dpr, 1.5),
+            synapseSubsample: 0.14,
+        };
+    }
+    if (cores < 8) {
+        return {
+            tier: 'medium',
+            neuronCount: 12288,
+            enableDoF: true,
+            enableBloom: true,
+            bloomStrength: 1.0,
+            pixelRatio: Math.min(dpr, 1.75),
+            synapseSubsample: 0.20,
+        };
+    }
+    return {
+        tier: 'high',
+        neuronCount: 16384,
+        enableDoF: true,
+        enableBloom: true,
+        bloomStrength: 1.05,
+        pixelRatio: Math.min(dpr, 2),
+        synapseSubsample: 0.22,
+    };
+}
+
+// ---------- Init ----------
+
+const canvas = document.getElementById('cortex');
+const tier = detectTier();
+
+const network = new Network(tier.neuronCount);
+const renderer = new CortexRenderer(canvas, network, {
+    synapseSubsample: tier.synapseSubsample,
+});
+renderer.renderer.setPixelRatio(tier.pixelRatio);
+
+const post = new CortexPostprocessor(renderer.renderer, renderer.scene, renderer.camera, {
+    bloomStrength: tier.bloomStrength,
+    bloomRadius: 0.85,
+    bloomThreshold: 0.42,
+    enableDoF: tier.enableDoF,
+    enableBloom: tier.enableBloom,
+});
+
+const camCtl = new CortexCamera(renderer.camera, canvas, {
+    initialDistance: 230,
+    initialTheta: 0.4,
+    initialPhi: 0.18,
+});
+
+// ---------- Resize ----------
+
+function resize() {
+    const w = window.innerWidth;
+    const h = window.innerHeight;
+    const dpr = renderer.renderer.getPixelRatio();
+    renderer.setSize(w, h, dpr);
+    post.setSize(w * dpr, h * dpr);
+}
+window.addEventListener('resize', resize);
+resize();
+
+// ---------- Click → cascade ----------
+
+const ray = new THREE.Raycaster();
+const ndc = new THREE.Vector2();
+const tmpVec = new THREE.Vector3();
+const tmpRel = new THREE.Vector3();
+
+camCtl.onClickWorld = (clientX, clientY) => {
+    const rect = canvas.getBoundingClientRect();
+    ndc.x = ((clientX - rect.left) / rect.width) * 2 - 1;
+    ndc.y = -((clientY - rect.top) / rect.height) * 2 + 1;
+    ray.setFromCamera(ndc, renderer.camera);
+
+    // Find the neuron closest to the ray (3D point-to-line distance)
+    const origin = ray.ray.origin;
+    const dir = ray.ray.direction;
+    const positions = network.positions;
+    let bestIdx = -1;
+    let bestD2 = Infinity;
+    let bestT = 0;
+    for (let i = 0; i < network.n; i++) {
+        const px = positions[i * 3 + 0];
+        const py = positions[i * 3 + 1];
+        const pz = positions[i * 3 + 2];
+        const rx = px - origin.x;
+        const ry = py - origin.y;
+        const rz = pz - origin.z;
+        const t = rx * dir.x + ry * dir.y + rz * dir.z;
+        if (t < 0) continue;
+        const closestX = origin.x + dir.x * t;
+        const closestY = origin.y + dir.y * t;
+        const closestZ = origin.z + dir.z * t;
+        const dx = px - closestX, dy = py - closestY, dz = pz - closestZ;
+        const d2 = dx * dx + dy * dy + dz * dz;
+        if (d2 < bestD2) {
+            bestD2 = d2;
+            bestIdx = i;
+            bestT = t;
+        }
+    }
+
+    if (bestIdx >= 0) {
+        const px = network.positions[bestIdx * 3 + 0];
+        const py = network.positions[bestIdx * 3 + 1];
+        const pz = network.positions[bestIdx * 3 + 2];
+        network.stimulate(px, py, pz);
+    }
+};
+
+// ---------- Loop ----------
+
+const TARGET_SIM_HZ = 1000 / SIM_DT_MS;     // 200 Hz
+const MAX_SIM_STEPS_PER_FRAME = 8;          // catch-up cap; avoid spirals on tab-resume
+let simAccumulatorMs = 0;
+let lastFrameMs = performance.now();
+let firstFrameDone = false;
+
+// FPS monitor for live degradation
+let fpsSamples = [];
+let fpsCheckedAt = 0;
+let degradeTriggered = false;
+
+function tick(nowMs) {
+    requestAnimationFrame(tick);
+
+    const dtMs = Math.min(100, nowMs - lastFrameMs); // clamp big gaps (tab switch)
+    lastFrameMs = nowMs;
+    simAccumulatorMs += dtMs;
+
+    // Fixed-step simulation catch-up
+    let stepsThisFrame = 0;
+    while (simAccumulatorMs >= SIM_DT_MS && stepsThisFrame < MAX_SIM_STEPS_PER_FRAME) {
+        network.step();
+        simAccumulatorMs -= SIM_DT_MS;
+        stepsThisFrame++;
+    }
+    if (simAccumulatorMs > SIM_DT_MS * MAX_SIM_STEPS_PER_FRAME) {
+        // Hard reset accumulator if we fell way behind
+        simAccumulatorMs = 0;
+    }
+
+    // Camera + state sync + render
+    camCtl.update(nowMs);
+    renderer.syncFromSimulation();
+    // Keep DoF focus on the network's near edge so the front feels sharp
+    if (post.dofPass) post.setFocusDistance(camCtl.getDistanceToTarget() * 0.75);
+    post.render(nowMs);
+
+    // FPS-based live degradation
+    if (firstFrameDone && !degradeTriggered) {
+        fpsSamples.push(dtMs);
+        if (fpsSamples.length > 90) fpsSamples.shift();
+        if (nowMs - fpsCheckedAt > 2000 && fpsSamples.length >= 60) {
+            const avg = fpsSamples.reduce((a, b) => a + b, 0) / fpsSamples.length;
+            const fps = 1000 / avg;
+            fpsCheckedAt = nowMs;
+            if (fps < 38 && post.bloomPass) {
+                // Soften bloom or kill DoF — the cheapest meaningful drop
+                if (post.dofPass) {
+                    const idx = post.composer.passes.indexOf(post.dofPass);
+                    if (idx >= 0) post.composer.passes.splice(idx, 1);
+                    post.dofPass = null;
+                    fpsSamples = [];
+                } else if (post.bloomPass.strength > 0.6) {
+                    post.bloomPass.strength *= 0.7;
+                    fpsSamples = [];
+                } else {
+                    degradeTriggered = true;
+                }
+            }
+        }
+    }
+    firstFrameDone = true;
+}
+
+// Prime a brief warmup so the network has visible activity by frame 1
+for (let i = 0; i < 80; i++) network.step();
+
+requestAnimationFrame(tick);

--- a/apps/cortex/postprocessing.js
+++ b/apps/cortex/postprocessing.js
@@ -1,0 +1,230 @@
+// Postprocessing pipeline:
+//   (external) render scene → sceneRT (HDR + depth)
+//   composer:  TexturePass(sceneRT) → DoF → Bloom → Final → Output
+//
+// We render the scene to our own sceneRT (HDR + depth) and feed that into
+// the composer via TexturePass. This is the only way to safely sample
+// scene depth from a downstream pass — if we let EffectComposer own the
+// depth-equipped RT it would ping-pong it as both read and write target,
+// triggering a "feedback loop" GL_INVALID_OPERATION the moment any pass
+// (e.g. DoF) bound the depth texture as a uniform.
+//
+// Bloom threshold sits above baseline neuron glow so only spikes /
+// pulses bloom — that's what makes them feel hot rather than fuzzy.
+
+import * as THREE from 'three';
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
+import { TexturePass } from 'three/addons/postprocessing/TexturePass.js';
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+
+const DOF_SHADER = {
+    uniforms: {
+        tDiffuse: { value: null },
+        tDepth: { value: null },
+        uCameraNear: { value: 0.1 },
+        uCameraFar: { value: 1000.0 },
+        uFocusDistance: { value: 220 },
+        uFocusRange: { value: 60 },
+        uMaxBlur: { value: 1.6 },     // pixels at peak blur
+        uResolution: { value: new THREE.Vector2(1, 1) },
+    },
+    vertexShader: /* glsl */`
+        varying vec2 vUv;
+        void main() {
+            vUv = uv;
+            gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        }
+    `,
+    fragmentShader: /* glsl */`
+        uniform sampler2D tDiffuse;
+        uniform sampler2D tDepth;
+        uniform float uCameraNear;
+        uniform float uCameraFar;
+        uniform float uFocusDistance;
+        uniform float uFocusRange;
+        uniform float uMaxBlur;
+        uniform vec2 uResolution;
+        varying vec2 vUv;
+
+        float linearizeDepth(float d) {
+            float z = d * 2.0 - 1.0;
+            return (2.0 * uCameraNear * uCameraFar) / (uCameraFar + uCameraNear - z * (uCameraFar - uCameraNear));
+        }
+
+        void main() {
+            float depth = texture2D(tDepth, vUv).x;
+            float linDepth = linearizeDepth(depth);
+            float coc = clamp(abs(linDepth - uFocusDistance) / uFocusRange, 0.0, 1.0);
+            float blurPx = coc * uMaxBlur;
+            vec2 texel = blurPx / uResolution;
+
+            // 7-tap soft disk: center + ring of 6
+            vec3 sum = texture2D(tDiffuse, vUv).rgb * 1.0;
+            float wsum = 1.0;
+            const float TAU = 6.2831853;
+            for (int k = 0; k < 6; k++) {
+                float a = float(k) / 6.0 * TAU;
+                vec2 off = vec2(cos(a), sin(a)) * texel;
+                sum += texture2D(tDiffuse, vUv + off).rgb;
+                wsum += 1.0;
+            }
+            gl_FragColor = vec4(sum / wsum, 1.0);
+        }
+    `,
+};
+
+const FINAL_SHADER = {
+    uniforms: {
+        tDiffuse: { value: null },
+        uTime: { value: 0 },
+        uResolution: { value: new THREE.Vector2(1, 1) },
+        uCAStrength: { value: 0.0030 },
+        uCABloomGate: { value: 0.6 },
+        uGrainStrength: { value: 0.040 },
+        uVignetteStrength: { value: 0.55 },
+    },
+    vertexShader: /* glsl */`
+        varying vec2 vUv;
+        void main() {
+            vUv = uv;
+            gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        }
+    `,
+    fragmentShader: /* glsl */`
+        uniform sampler2D tDiffuse;
+        uniform float uTime;
+        uniform vec2 uResolution;
+        uniform float uCAStrength;
+        uniform float uCABloomGate;
+        uniform float uGrainStrength;
+        uniform float uVignetteStrength;
+        varying vec2 vUv;
+
+        float hash(vec2 p) {
+            p = fract(p * vec2(443.897, 441.423));
+            p += dot(p, p.yx + 19.19);
+            return fract((p.x + p.y) * p.x);
+        }
+
+        void main() {
+            vec3 center = texture2D(tDiffuse, vUv).rgb;
+            float lum = dot(center, vec3(0.299, 0.587, 0.114));
+            float gate = smoothstep(uCABloomGate, uCABloomGate + 0.6, lum);
+
+            vec2 dir = vUv - 0.5;
+            float r = length(dir);
+            vec2 caOff = normalize(dir + vec2(0.0001)) * uCAStrength * (0.4 + r) * gate;
+            float rCh = texture2D(tDiffuse, vUv + caOff).r;
+            float gCh = center.g;
+            float bCh = texture2D(tDiffuse, vUv - caOff).b;
+            vec3 col = vec3(rCh, gCh, bCh);
+
+            float vig = 1.0 - smoothstep(0.55, 1.0, r) * uVignetteStrength;
+            col *= vig;
+
+            float n = hash(vUv * uResolution + vec2(uTime * 60.0));
+            col += (n - 0.5) * uGrainStrength;
+
+            col = col / (1.0 + col * 0.5);
+
+            gl_FragColor = vec4(col, 1.0);
+        }
+    `,
+};
+
+export class CortexPostprocessor {
+    constructor(renderer, scene, camera, opts = {}) {
+        this.renderer = renderer;
+        this.scene = scene;
+        this.camera = camera;
+        this.opts = Object.assign({
+            bloomStrength: 1.05,
+            bloomRadius: 0.85,
+            bloomThreshold: 0.42,
+            enableDoF: true,
+            enableBloom: true,
+        }, opts);
+
+        const size = renderer.getDrawingBufferSize(new THREE.Vector2());
+
+        // Our own scene RT — owns the depth texture. Composer never touches this.
+        const dt = new THREE.DepthTexture(size.x, size.y);
+        dt.type = THREE.UnsignedShortType;
+        this.sceneRT = new THREE.WebGLRenderTarget(size.x, size.y, {
+            type: THREE.HalfFloatType,
+            depthBuffer: true,
+            depthTexture: dt,
+        });
+        this.depthTexture = dt;
+
+        // Composer RTs — HDR but no depth attachment, so no feedback risk.
+        const composerRT = new THREE.WebGLRenderTarget(size.x, size.y, {
+            type: THREE.HalfFloatType,
+            depthBuffer: false,
+        });
+        this.composer = new EffectComposer(renderer, composerRT);
+        this.composer.setSize(size.x, size.y);
+
+        // Pass 1: bring scene color into the composer pipeline
+        this.scenePass = new TexturePass(this.sceneRT.texture);
+        this.composer.addPass(this.scenePass);
+
+        // Pass 2: DoF — reads color from readBuffer (= scenePass output),
+        // depth from sceneRT.depthTexture as a separate uniform.
+        if (this.opts.enableDoF) {
+            this.dofPass = new ShaderPass(DOF_SHADER);
+            this.dofPass.uniforms.tDepth.value = dt;
+            this.dofPass.uniforms.uCameraNear.value = camera.near;
+            this.dofPass.uniforms.uCameraFar.value = camera.far;
+            this.dofPass.uniforms.uResolution.value.copy(size);
+            this.composer.addPass(this.dofPass);
+        }
+
+        // Pass 3: bloom
+        if (this.opts.enableBloom) {
+            this.bloomPass = new UnrealBloomPass(
+                size,
+                this.opts.bloomStrength,
+                this.opts.bloomRadius,
+                this.opts.bloomThreshold,
+            );
+            this.composer.addPass(this.bloomPass);
+        }
+
+        // Pass 4: final composite (CA + grain + vignette + tone curve)
+        this.finalPass = new ShaderPass(FINAL_SHADER);
+        this.finalPass.uniforms.uResolution.value.copy(size);
+        this.composer.addPass(this.finalPass);
+
+        // Pass 5: output (sRGB conversion)
+        this.outputPass = new OutputPass();
+        this.composer.addPass(this.outputPass);
+    }
+
+    setSize(width, height) {
+        this.composer.setSize(width, height);
+        this.sceneRT.setSize(width, height);
+        if (this.dofPass) this.dofPass.uniforms.uResolution.value.set(width, height);
+        this.finalPass.uniforms.uResolution.value.set(width, height);
+        if (this.bloomPass) this.bloomPass.setSize(width, height);
+    }
+
+    setFocusDistance(d) {
+        if (this.dofPass) this.dofPass.uniforms.uFocusDistance.value = d;
+    }
+
+    render(timeMs) {
+        // Step 1: render scene into our depth-equipped RT
+        const prevTarget = this.renderer.getRenderTarget();
+        this.renderer.setRenderTarget(this.sceneRT);
+        this.renderer.clear(true, true, true);
+        this.renderer.render(this.scene, this.camera);
+        this.renderer.setRenderTarget(prevTarget);
+
+        // Step 2: run the composer (uses sceneRT.texture as input)
+        this.finalPass.uniforms.uTime.value = timeMs * 0.001;
+        this.composer.render();
+    }
+}

--- a/apps/cortex/rendering.js
+++ b/apps/cortex/rendering.js
@@ -1,0 +1,571 @@
+// Three.js rendering layers for the cortex visualization.
+//
+// Three discrete layers, each with its own material, all blending into a
+// shared HDR float framebuffer that postprocessing.js then bloom-passes:
+//
+//   1. Static synapse skeleton — faint subsampled line segments.
+//      Always-on faint backbone so the architecture stays perceptible.
+//   2. Neurons — instanced point sprites with per-neuron brightness.
+//      Brightness is a Float32Array shared with simulation, flagged
+//      needsUpdate every frame.
+//   3. Pulses — instanced billboard strips. Each instance owns a
+//      (srcPos, dstPos, tStart, tEnd, color) tuple; the vertex shader
+//      computes the current head position from `now` and bills the strip
+//      along the synapse direction. Self-culls degenerate instances.
+//
+// Plus a small additive fog billboard at each cluster centroid so the
+// dense regions glow softly through the field.
+
+import * as THREE from 'three';
+import { CLUSTER_COUNT, MAX_ACTIVE_PULSES } from './simulation.js';
+
+// ---------- Shaders ----------
+
+const NEURON_VERT = /* glsl */`
+attribute float aType;        // 0 = E, 1 = I
+attribute float aBrightness;  // 0..N
+attribute float aFlash;       // coincidence-flash 0..1
+
+uniform float uPixelRatio;
+uniform float uBaseSize;
+uniform float uPeakSizeBoost;
+uniform vec3 uColorE;
+uniform vec3 uColorI;
+uniform vec3 uColorFlash;
+
+varying vec3 vColor;
+varying float vIntensity;
+
+void main() {
+    vec4 mv = modelViewMatrix * vec4(position, 1.0);
+    gl_Position = projectionMatrix * mv;
+
+    float dist = -mv.z;
+    // Size attenuation: closer neurons render larger; brighter ones grow more
+    float size = uBaseSize * (1.0 + aBrightness * uPeakSizeBoost);
+    gl_PointSize = size * uPixelRatio * (220.0 / max(dist, 1.0));
+
+    vec3 col = mix(uColorE, uColorI, aType);
+    // Coincidence flash overrides toward white
+    col = mix(col, uColorFlash, clamp(aFlash, 0.0, 1.0) * 0.85);
+
+    // Intensity: low baseline glow, multiplied up sharply by brightness.
+    // Squared brightness gives the spike a snappier flare.
+    float baseline = 0.13;
+    float spike = aBrightness * aBrightness * 5.5;
+    vIntensity = baseline + spike + aFlash * 1.5;
+
+    vColor = col;
+}
+`;
+
+const NEURON_FRAG = /* glsl */`
+varying vec3 vColor;
+varying float vIntensity;
+
+void main() {
+    vec2 c = gl_PointCoord - 0.5;
+    float r2 = dot(c, c);
+    if (r2 > 0.25) discard;
+    // Soft round profile: bright core + halo
+    float core = smoothstep(0.25, 0.0, r2);
+    float halo = exp(-r2 * 12.0);
+    float a = core * 0.85 + halo * 0.5;
+    vec3 col = vColor * vIntensity * a;
+    gl_FragColor = vec4(col, a);
+}
+`;
+
+const SYNAPSE_VERT = /* glsl */`
+attribute vec3 aColor;
+varying vec3 vColor;
+
+void main() {
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    vColor = aColor;
+}
+`;
+
+const SYNAPSE_FRAG = /* glsl */`
+varying vec3 vColor;
+uniform float uOpacity;
+
+void main() {
+    gl_FragColor = vec4(vColor * uOpacity, uOpacity);
+}
+`;
+
+const PULSE_VERT = /* glsl */`
+// Quad vertex: position.x ∈ [0,1] is along the trail (0=tail, 1=head),
+// position.y ∈ [-0.5, 0.5] is perpendicular for billboard width.
+attribute vec3 aSrc;
+attribute vec3 aDst;
+attribute vec2 aTime;       // tStart, tEnd in ms
+attribute vec3 aColor;
+
+uniform float uNow;          // ms
+uniform float uTrailFraction;
+uniform float uPulseRadius;
+uniform vec3 uCameraPos;
+
+varying float vAlongTrail;
+varying float vCross;
+varying vec3 vColor;
+varying float vFade;
+
+void main() {
+    float duration = max(aTime.y - aTime.x, 1.0);
+    float t = (uNow - aTime.x) / duration;
+
+    if (t < 0.0 || t > 1.0) {
+        // Cull: emit a degenerate vertex outside the clip cube
+        gl_Position = vec4(2.0, 2.0, 2.0, 1.0);
+        vAlongTrail = 0.0;
+        vCross = 0.0;
+        vColor = vec3(0.0);
+        vFade = 0.0;
+        return;
+    }
+
+    vec3 head = mix(aSrc, aDst, t);
+    vec3 dir = aDst - aSrc;
+    float pathLen = length(dir);
+    vec3 dirN = dir / max(pathLen, 0.001);
+    float trailLen = pathLen * uTrailFraction;
+
+    // Perpendicular for billboard, aimed at camera around the synapse axis
+    vec3 toCam = normalize(uCameraPos - head);
+    vec3 perp = cross(dirN, toCam);
+    float perpLen = length(perp);
+    if (perpLen < 0.001) {
+        // Synapse direction nearly parallel to view; fallback perp
+        perp = normalize(cross(dirN, vec3(0.0, 1.0, 0.0) + vec3(0.001)));
+    } else {
+        perp /= perpLen;
+    }
+
+    // Bring tail back from the head along the synapse line
+    vec3 along = head - dirN * trailLen * (1.0 - position.x);
+    vec3 worldPos = along + perp * uPulseRadius * position.y;
+
+    vAlongTrail = position.x;
+    vCross = position.y * 2.0;     // -1..1
+    vColor = aColor;
+    // Fade in/out at the very ends so pulses don't pop
+    vFade = smoothstep(0.0, 0.06, t) * smoothstep(1.0, 0.92, t);
+
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(worldPos, 1.0);
+}
+`;
+
+const PULSE_FRAG = /* glsl */`
+varying float vAlongTrail;
+varying float vCross;
+varying vec3 vColor;
+varying float vFade;
+
+uniform float uIntensity;
+
+void main() {
+    // Cross-section: brightest along centerline
+    float profile = exp(-vCross * vCross * 6.0);
+    // Length: bright at head, fades exponentially to tail
+    float trail = pow(vAlongTrail, 2.6);
+    // Tighten the head into a sharp tip
+    float head = smoothstep(0.85, 1.0, vAlongTrail);
+    float i = (trail * 0.95 + head * 1.4) * profile * vFade * uIntensity;
+    if (i < 0.002) discard;
+    gl_FragColor = vec4(vColor * i, i * 0.85);
+}
+`;
+
+const FOG_VERT = /* glsl */`
+attribute float aSize;
+attribute vec3 aColor;
+varying vec3 vColor;
+uniform float uPixelRatio;
+
+void main() {
+    vec4 mv = modelViewMatrix * vec4(position, 1.0);
+    gl_Position = projectionMatrix * mv;
+    float dist = -mv.z;
+    gl_PointSize = aSize * uPixelRatio * (300.0 / max(dist, 1.0));
+    vColor = aColor;
+}
+`;
+
+const FOG_FRAG = /* glsl */`
+varying vec3 vColor;
+void main() {
+    vec2 c = gl_PointCoord - 0.5;
+    float r = length(c) * 2.0;
+    if (r > 1.0) discard;
+    // Wide, soft falloff — this is a stand-in for raymarched volumetric fog
+    float a = exp(-r * r * 2.5) * 0.06;
+    gl_FragColor = vec4(vColor * a, a);
+}
+`;
+
+// ---------- Renderer ----------
+
+const COLOR_E_VEC = new THREE.Color(0.05, 0.78, 1.0);
+const COLOR_I_VEC = new THREE.Color(1.0, 0.18, 0.58);
+
+export class CortexRenderer {
+    constructor(canvas, network, opts = {}) {
+        this.canvas = canvas;
+        this.network = network;
+        this.opts = Object.assign({
+            synapseSubsample: 0.22,    // fraction of synapses rendered as static skeleton
+            synapseOpacity: 0.045,
+            pulseTrailFraction: 0.28,
+            pulseRadius: 0.55,
+            pulseIntensity: 1.6,
+            neuronBaseSize: 1.6,
+            neuronPeakSizeBoost: 1.8,
+            backgroundColor: 0x05060a,
+        }, opts);
+
+        this.renderer = new THREE.WebGLRenderer({
+            canvas,
+            antialias: false,
+            alpha: false,
+            powerPreference: 'high-performance',
+        });
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+        this.renderer.setClearColor(this.opts.backgroundColor, 1);
+        // We want HDR-ish accumulation for bloom; postprocessing.js sets up
+        // the float render targets. Keep tone mapping off here so values
+        // pass through linearly into the composer.
+        this.renderer.toneMapping = THREE.NoToneMapping;
+        this.renderer.outputColorSpace = THREE.LinearSRGBColorSpace;
+
+        this.scene = new THREE.Scene();
+        this.scene.background = new THREE.Color(this.opts.backgroundColor);
+
+        this.camera = new THREE.PerspectiveCamera(52, 1, 0.1, 1000);
+        this.camera.position.set(0, 0, 220);
+        this.camera.lookAt(0, 0, 0);
+
+        this._buildNeurons();
+        this._buildSynapseSkeleton();
+        this._buildPulses();
+        this._buildClusterFog();
+        this._buildBackgroundGradient();
+    }
+
+    _buildNeurons() {
+        const N = this.network.n;
+        const geom = new THREE.BufferGeometry();
+        geom.setAttribute('position', new THREE.BufferAttribute(this.network.positions, 3));
+        const types = new Float32Array(N);
+        for (let i = 0; i < N; i++) types[i] = this.network.types[i];
+        geom.setAttribute('aType', new THREE.BufferAttribute(types, 1));
+        // Brightness and coincidence-flash arrays are shared with the
+        // simulation — we just flag needsUpdate each frame.
+        this.brightnessAttr = new THREE.BufferAttribute(this.network.brightness, 1);
+        this.brightnessAttr.setUsage(THREE.DynamicDrawUsage);
+        geom.setAttribute('aBrightness', this.brightnessAttr);
+
+        this.flashAttr = new THREE.BufferAttribute(this.network.coincidenceFlash, 1);
+        this.flashAttr.setUsage(THREE.DynamicDrawUsage);
+        geom.setAttribute('aFlash', this.flashAttr);
+
+        const mat = new THREE.ShaderMaterial({
+            vertexShader: NEURON_VERT,
+            fragmentShader: NEURON_FRAG,
+            transparent: true,
+            depthWrite: false,
+            depthTest: true,
+            blending: THREE.AdditiveBlending,
+            uniforms: {
+                uPixelRatio: { value: this.renderer.getPixelRatio() },
+                uBaseSize: { value: this.opts.neuronBaseSize },
+                uPeakSizeBoost: { value: this.opts.neuronPeakSizeBoost },
+                uColorE: { value: new THREE.Vector3().copy(COLOR_E_VEC) },
+                uColorI: { value: new THREE.Vector3().copy(COLOR_I_VEC) },
+                uColorFlash: { value: new THREE.Vector3(1.6, 1.6, 1.6) },
+            },
+        });
+
+        this.neuronPoints = new THREE.Points(geom, mat);
+        this.neuronPoints.frustumCulled = false;
+        this.scene.add(this.neuronPoints);
+        this.neuronMaterial = mat;
+    }
+
+    _buildSynapseSkeleton() {
+        // Subsample synapses for the static layer so we don't drown in lines.
+        const net = this.network;
+        const subsample = this.opts.synapseSubsample;
+        const totalSyn = net.synapseCount;
+        const drawCount = Math.floor(totalSyn * subsample);
+
+        const positions = new Float32Array(drawCount * 6);
+        const colors = new Float32Array(drawCount * 6);
+
+        // Walk synapses in order, accept ~`subsample` of them.
+        let written = 0;
+        const everyN = Math.max(1, Math.round(1 / subsample));
+        // Simple deterministic stride; jitter the start so we don't always
+        // hit the same neurons' first synapses.
+        let cursor = 0;
+        for (let i = 0; i < net.n && written < drawCount; i++) {
+            const start = net.synOutStart[i];
+            const end = net.synOutStart[i + 1];
+            const sx = net.positions[i * 3 + 0];
+            const sy = net.positions[i * 3 + 1];
+            const sz = net.positions[i * 3 + 2];
+            const t = net.types[i];
+            const cR = t === 0 ? COLOR_E_VEC.r : COLOR_I_VEC.r;
+            const cG = t === 0 ? COLOR_E_VEC.g : COLOR_I_VEC.g;
+            const cB = t === 0 ? COLOR_E_VEC.b : COLOR_I_VEC.b;
+            for (let s = start; s < end; s++) {
+                if ((cursor++ % everyN) !== 0) continue;
+                if (written >= drawCount) break;
+                const dst = net.synDst[s];
+                const o = written * 6;
+                positions[o + 0] = sx;
+                positions[o + 1] = sy;
+                positions[o + 2] = sz;
+                positions[o + 3] = net.positions[dst * 3 + 0];
+                positions[o + 4] = net.positions[dst * 3 + 1];
+                positions[o + 5] = net.positions[dst * 3 + 2];
+                colors[o + 0] = cR; colors[o + 1] = cG; colors[o + 2] = cB;
+                colors[o + 3] = cR; colors[o + 4] = cG; colors[o + 5] = cB;
+                written++;
+            }
+        }
+
+        const geom = new THREE.BufferGeometry();
+        geom.setAttribute('position', new THREE.BufferAttribute(positions.subarray(0, written * 6), 3));
+        geom.setAttribute('aColor', new THREE.BufferAttribute(colors.subarray(0, written * 6), 3));
+
+        const mat = new THREE.ShaderMaterial({
+            vertexShader: SYNAPSE_VERT,
+            fragmentShader: SYNAPSE_FRAG,
+            transparent: true,
+            depthWrite: false,
+            blending: THREE.AdditiveBlending,
+            uniforms: {
+                uOpacity: { value: this.opts.synapseOpacity },
+            },
+        });
+
+        this.synapseLines = new THREE.LineSegments(geom, mat);
+        this.synapseLines.frustumCulled = false;
+        this.scene.add(this.synapseLines);
+        this.synapseMaterial = mat;
+    }
+
+    _buildPulses() {
+        // Build a small quad strip with a few segments along its length,
+        // so the trail has internal vertices the GPU can interpolate.
+        const SEGMENTS = 8;
+        const baseGeom = new THREE.BufferGeometry();
+        const positions = new Float32Array((SEGMENTS + 1) * 2 * 3);
+        const indices = [];
+        for (let i = 0; i <= SEGMENTS; i++) {
+            const x = i / SEGMENTS;
+            positions[(i * 2 + 0) * 3 + 0] = x;
+            positions[(i * 2 + 0) * 3 + 1] = -0.5;
+            positions[(i * 2 + 0) * 3 + 2] = 0;
+            positions[(i * 2 + 1) * 3 + 0] = x;
+            positions[(i * 2 + 1) * 3 + 1] = 0.5;
+            positions[(i * 2 + 1) * 3 + 2] = 0;
+            if (i < SEGMENTS) {
+                const a = i * 2, b = i * 2 + 1, c = (i + 1) * 2, d = (i + 1) * 2 + 1;
+                indices.push(a, b, c, b, d, c);
+            }
+        }
+        baseGeom.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+        baseGeom.setIndex(indices);
+
+        const instGeom = new THREE.InstancedBufferGeometry();
+        instGeom.setAttribute('position', baseGeom.attributes.position);
+        instGeom.setIndex(baseGeom.index);
+
+        // One InstancedBufferAttribute per dynamic per-pulse field.
+        // We allocate to the maximum capacity once; each frame we copy in
+        // the alive subset and update geometry.instanceCount.
+        this.pulseSrc = new THREE.InstancedBufferAttribute(new Float32Array(MAX_ACTIVE_PULSES * 3), 3);
+        this.pulseDst = new THREE.InstancedBufferAttribute(new Float32Array(MAX_ACTIVE_PULSES * 3), 3);
+        this.pulseTime = new THREE.InstancedBufferAttribute(new Float32Array(MAX_ACTIVE_PULSES * 2), 2);
+        this.pulseColor = new THREE.InstancedBufferAttribute(new Float32Array(MAX_ACTIVE_PULSES * 3), 3);
+        this.pulseSrc.setUsage(THREE.DynamicDrawUsage);
+        this.pulseDst.setUsage(THREE.DynamicDrawUsage);
+        this.pulseTime.setUsage(THREE.DynamicDrawUsage);
+        this.pulseColor.setUsage(THREE.DynamicDrawUsage);
+        instGeom.setAttribute('aSrc', this.pulseSrc);
+        instGeom.setAttribute('aDst', this.pulseDst);
+        instGeom.setAttribute('aTime', this.pulseTime);
+        instGeom.setAttribute('aColor', this.pulseColor);
+        instGeom.instanceCount = 0;
+
+        const mat = new THREE.ShaderMaterial({
+            vertexShader: PULSE_VERT,
+            fragmentShader: PULSE_FRAG,
+            transparent: true,
+            depthWrite: false,
+            depthTest: true,
+            blending: THREE.AdditiveBlending,
+            uniforms: {
+                uNow: { value: 0 },
+                uTrailFraction: { value: this.opts.pulseTrailFraction },
+                uPulseRadius: { value: this.opts.pulseRadius },
+                uIntensity: { value: this.opts.pulseIntensity },
+                uCameraPos: { value: new THREE.Vector3() },
+            },
+        });
+
+        this.pulseMesh = new THREE.Mesh(instGeom, mat);
+        this.pulseMesh.frustumCulled = false;
+        this.scene.add(this.pulseMesh);
+        this.pulseMaterial = mat;
+        this.pulseGeom = instGeom;
+    }
+
+    _buildClusterFog() {
+        // One soft additive billboard per cluster. Cheap stand-in for
+        // raymarched volumetric fog — gives the eye depth cues in the
+        // densest regions without paying for a low-res raymarcher.
+        const positions = new Float32Array(CLUSTER_COUNT * 3);
+        const sizes = new Float32Array(CLUSTER_COUNT);
+        const colors = new Float32Array(CLUSTER_COUNT * 3);
+        // Tint each cluster slightly differently, biased toward cool/warm
+        const palette = [
+            [0.18, 0.30, 0.55],
+            [0.42, 0.18, 0.50],
+            [0.12, 0.40, 0.50],
+            [0.50, 0.20, 0.35],
+            [0.22, 0.34, 0.62],
+            [0.36, 0.22, 0.46],
+            [0.18, 0.42, 0.40],
+        ];
+        for (let c = 0; c < CLUSTER_COUNT; c++) {
+            positions[c * 3 + 0] = this.network.clusterCenters[c * 3 + 0];
+            positions[c * 3 + 1] = this.network.clusterCenters[c * 3 + 1];
+            positions[c * 3 + 2] = this.network.clusterCenters[c * 3 + 2];
+            sizes[c] = 95;
+            const p = palette[c % palette.length];
+            colors[c * 3 + 0] = p[0];
+            colors[c * 3 + 1] = p[1];
+            colors[c * 3 + 2] = p[2];
+        }
+        const geom = new THREE.BufferGeometry();
+        geom.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+        geom.setAttribute('aSize', new THREE.BufferAttribute(sizes, 1));
+        geom.setAttribute('aColor', new THREE.BufferAttribute(colors, 3));
+        const mat = new THREE.ShaderMaterial({
+            vertexShader: FOG_VERT,
+            fragmentShader: FOG_FRAG,
+            transparent: true,
+            depthWrite: false,
+            blending: THREE.AdditiveBlending,
+            uniforms: {
+                uPixelRatio: { value: this.renderer.getPixelRatio() },
+            },
+        });
+        this.fogPoints = new THREE.Points(geom, mat);
+        this.fogPoints.frustumCulled = false;
+        this.scene.add(this.fogPoints);
+        this.fogMaterial = mat;
+    }
+
+    _buildBackgroundGradient() {
+        // Subtle radial gradient sphere behind everything so pure-black
+        // doesn't kill the bloom mood. Rendered as a giant inverted sphere
+        // with a soft radial shader and depth disabled.
+        const geom = new THREE.SphereGeometry(700, 32, 16);
+        const mat = new THREE.ShaderMaterial({
+            side: THREE.BackSide,
+            depthWrite: false,
+            depthTest: false,
+            uniforms: {},
+            vertexShader: /* glsl */`
+                varying vec3 vDir;
+                void main() {
+                    vDir = normalize(position);
+                    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+                }
+            `,
+            fragmentShader: /* glsl */`
+                varying vec3 vDir;
+                void main() {
+                    // Brighter near the horizon-y midline, darker at poles
+                    float band = 1.0 - abs(vDir.y);
+                    vec3 cool = vec3(0.018, 0.022, 0.034) * (0.45 + 0.55 * band);
+                    gl_FragColor = vec4(cool, 1.0);
+                }
+            `,
+        });
+        const sphere = new THREE.Mesh(geom, mat);
+        sphere.renderOrder = -1000;
+        this.scene.add(sphere);
+        this.backgroundSphere = sphere;
+    }
+
+    // Per-frame hook: push simulation state into GPU buffers.
+    syncFromSimulation(activePulses) {
+        // Neuron brightness and flash already share the same Float32Array
+        // as the simulation; just flag for upload.
+        this.brightnessAttr.needsUpdate = true;
+        this.flashAttr.needsUpdate = true;
+
+        // Rewrite pulse instance attributes from the simulation pool.
+        // We compact alive pulses into the front of each instanced array.
+        const stride = this.network.pulseStride;
+        const src = this.network.pulseData;
+        const alive = this.network.pulseAlive;
+
+        const srcBuf = this.pulseSrc.array;
+        const dstBuf = this.pulseDst.array;
+        const timeBuf = this.pulseTime.array;
+        const colBuf = this.pulseColor.array;
+
+        let w = 0;
+        for (let i = 0, n = alive.length; i < n; i++) {
+            if (!alive[i]) continue;
+            const o = i * stride;
+            const wo3 = w * 3;
+            const wo2 = w * 2;
+            srcBuf[wo3 + 0] = src[o + 0];
+            srcBuf[wo3 + 1] = src[o + 1];
+            srcBuf[wo3 + 2] = src[o + 2];
+            dstBuf[wo3 + 0] = src[o + 3];
+            dstBuf[wo3 + 1] = src[o + 4];
+            dstBuf[wo3 + 2] = src[o + 5];
+            timeBuf[wo2 + 0] = src[o + 6];
+            timeBuf[wo2 + 1] = src[o + 7];
+            colBuf[wo3 + 0] = src[o + 8];
+            colBuf[wo3 + 1] = src[o + 9];
+            colBuf[wo3 + 2] = src[o + 10];
+            w++;
+            if (w >= MAX_ACTIVE_PULSES) break;
+        }
+
+        this.pulseGeom.instanceCount = w;
+        // Upload only the prefix that changed
+        this.pulseSrc.addUpdateRange(0, w * 3);   this.pulseSrc.needsUpdate = true;
+        this.pulseDst.addUpdateRange(0, w * 3);   this.pulseDst.needsUpdate = true;
+        this.pulseTime.addUpdateRange(0, w * 2);  this.pulseTime.needsUpdate = true;
+        this.pulseColor.addUpdateRange(0, w * 3); this.pulseColor.needsUpdate = true;
+
+        // Update pulse uniforms
+        this.pulseMaterial.uniforms.uNow.value = this.network.simTimeMs;
+        this.pulseMaterial.uniforms.uCameraPos.value.copy(this.camera.position);
+    }
+
+    setSize(width, height, pixelRatio) {
+        this.renderer.setPixelRatio(pixelRatio);
+        this.renderer.setSize(width, height, false);
+        this.camera.aspect = width / height;
+        this.camera.updateProjectionMatrix();
+        this.neuronMaterial.uniforms.uPixelRatio.value = pixelRatio;
+        this.fogMaterial.uniforms.uPixelRatio.value = pixelRatio;
+    }
+
+    render() {
+        this.renderer.render(this.scene, this.camera);
+    }
+}

--- a/apps/cortex/rendering.js
+++ b/apps/cortex/rendering.js
@@ -232,7 +232,8 @@ export class CortexRenderer {
             alpha: false,
             powerPreference: 'high-performance',
         });
-        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+        // Pixel ratio is owned by the caller (main.js sets it from the
+        // hardware tier).
         this.renderer.setClearColor(this.opts.backgroundColor, 1);
         // We want HDR-ish accumulation for bloom; postprocessing.js sets up
         // the float render targets. Keep tone mapping off here so values
@@ -506,7 +507,7 @@ export class CortexRenderer {
     }
 
     // Per-frame hook: push simulation state into GPU buffers.
-    syncFromSimulation(activePulses) {
+    syncFromSimulation() {
         // Neuron brightness and flash already share the same Float32Array
         // as the simulation; just flag for upload.
         this.brightnessAttr.needsUpdate = true;

--- a/apps/cortex/simulation.js
+++ b/apps/cortex/simulation.js
@@ -1,0 +1,482 @@
+// Leaky integrate-and-fire (LIF) network with synaptic delays.
+//
+// Data layout: structure-of-arrays typed arrays so the hot loops are
+// cache-friendly and the JIT can keep them in monomorphic call sites.
+//
+// Spike delivery uses a slot-per-step ring buffer of accumulated current.
+// When neuron i fires, we iterate i's outgoing synapses and add each
+// weight into ring[(now + delay) mod ringSize][target]. Each step, we
+// drain the current slot into V[] and zero it. This avoids any dynamic
+// allocation in the hot path.
+//
+// Tunables are at the top — these are the knobs that decide whether the
+// network looks dead, looks like static, or sits at the edge of chaos.
+
+// ---------- Tunables ----------
+
+export const NEURON_COUNT = 16384;       // 128² — power of two, fits comfortably in CPU sim budget
+export const CLUSTER_COUNT = 7;
+export const NETWORK_RADIUS = 90;        // overall extent of the cloud
+export const CLUSTER_RADIUS = 22;        // gaussian sigma per cluster
+export const E_FRACTION = 0.8;           // fraction excitatory
+
+// LIF parameters (membrane time in ms, V in dimensionless units, threshold = 1)
+export const SIM_DT_MS = 5;              // 200 Hz simulation
+const V_REST = 0.0;
+const V_THRESHOLD = 1.0;
+const V_RESET = -0.15;                   // hyperpolarized after spike
+const V_TAU_MS = 22;                     // membrane decay time constant
+const REFRACTORY_MS = 6;
+// Per-step noise: (rand + rand - 1) * AMPLITUDE. Tuned so equilibrium V
+// has std dev ≈ 0.27, putting threshold ~4σ away. Spontaneous firings
+// from noise alone bootstrap recurrent activity; the E/I balance below
+// determines whether that recurrence settles, oscillates, or runs away.
+// These three numbers are the most important knobs in the whole file —
+// nudge by ±10% if dynamics drift toward dead or saturated.
+const NOISE_AMPLITUDE = 0.42;
+const E_WEIGHT = 0.14;
+const I_WEIGHT = -0.46;
+const STIMULUS_STRENGTH = 1.4;           // per-neuron current injection on click
+const STIMULUS_RADIUS = 9;               // world-space radius of click cascade
+const STIMULUS_NEIGHBOURS_MAX = 60;
+
+// Connectivity — kept moderate so total in-flight pulse count stays
+// within the render pool budget at edge-of-chaos firing rates.
+const SYN_OUT_E = 34;
+const SYN_OUT_I = 48;
+const LOCAL_FRACTION = 0.86;             // share of synapses to same cluster
+const LOCAL_FALLOFF = 28.0;              // exp(-d/falloff) probability falloff inside cluster
+
+// Delays — in ms, distance-proportional with jitter
+const DELAY_BASE_MS = 80;
+const DELAY_RANGE_MS = 320;
+const DELAY_JITTER_MS = 18;
+const MAX_DELAY_MS = DELAY_BASE_MS + DELAY_RANGE_MS + DELAY_JITTER_MS + SIM_DT_MS;
+
+// Visual brightness decay (separate from V — this is what renderers see)
+const BRIGHTNESS_TAU_MS = 280;
+const BRIGHTNESS_PEAK = 1.0;
+
+// Pulse pool cap — drop excess pulses gracefully if we ever overflow.
+// At ~1 Hz/neuron firing rate × ~40 synapses × 0.2s avg delay this fills
+// to ~130k. We cap at 90k as a render budget — the simulation propagates
+// every spike regardless; only visualization is throttled.
+export const MAX_ACTIVE_PULSES = 90000;
+
+// Colors as packed Float32 R,G,B (linear-ish HDR)
+const COLOR_E = [0.05, 0.78, 1.0];       // cyan
+const COLOR_I = [1.0, 0.18, 0.58];       // hot magenta
+const COLOR_COINCIDENCE = [1.6, 1.6, 1.6]; // bright white flash
+
+// ---------- RNG (deterministic for reproducible builds) ----------
+
+function mulberry32(seed) {
+    let t = seed >>> 0;
+    return function() {
+        t = (t + 0x6D2B79F5) >>> 0;
+        let r = Math.imul(t ^ (t >>> 15), 1 | t);
+        r = (r + Math.imul(r ^ (r >>> 7), 61 | r)) ^ r;
+        return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+function gaussian(rand) {
+    // Box-Muller; one of two samples
+    let u = 0, v = 0;
+    while (u === 0) u = rand();
+    while (v === 0) v = rand();
+    return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}
+
+// ---------- Network ----------
+
+export class Network {
+    constructor(neuronCount = NEURON_COUNT) {
+        this.n = neuronCount;
+        this.rand = mulberry32(0xC07E78);
+
+        // Per-neuron state
+        this.positions = new Float32Array(this.n * 3);
+        this.types = new Uint8Array(this.n);             // 0=E, 1=I
+        this.cluster = new Uint8Array(this.n);
+        this.V = new Float32Array(this.n);
+        this.refractory = new Float32Array(this.n);      // ms remaining
+        this.brightness = new Float32Array(this.n);      // 0..N, decays exponentially
+
+        // For coincidence detection — track recent E and I arrivals per neuron
+        this.recentE = new Float32Array(this.n);
+        this.recentI = new Float32Array(this.n);
+        this.coincidenceFlash = new Float32Array(this.n); // brief 0..1 flash channel
+
+        // Cluster centers (computed during build)
+        this.clusterCenters = new Float32Array(CLUSTER_COUNT * 3);
+
+        // Synapses (CSR-style by source neuron)
+        this.synOutStart = new Uint32Array(this.n + 1);
+        this.synDst = null;     // Uint32Array(M)
+        this.synWeight = null;  // Float32Array(M)
+        this.synDelay = null;   // Float32Array(M)
+        this.synapseCount = 0;
+
+        // Delivery ring buffer: ringSize × n floats of pending current
+        this.ringSize = Math.ceil(MAX_DELAY_MS / SIM_DT_MS) + 1;
+        this.ring = new Array(this.ringSize);
+        for (let s = 0; s < this.ringSize; s++) {
+            this.ring[s] = new Float32Array(this.n);
+        }
+        this.ringIdx = 0;
+        this.simTimeMs = 0;
+
+        // Active pulses: parallel typed arrays for fast renderer upload
+        // Layout: srcXYZ, dstXYZ, tStart, tEnd, colorRGB. 11 floats per pulse.
+        this.pulseStride = 11;
+        this.pulseData = new Float32Array(MAX_ACTIVE_PULSES * this.pulseStride);
+        this.pulseAlive = new Uint8Array(MAX_ACTIVE_PULSES);
+        this.pulseTEnd = new Float32Array(MAX_ACTIVE_PULSES);
+        this.pulseFreeStack = new Int32Array(MAX_ACTIVE_PULSES);
+        for (let i = 0; i < MAX_ACTIVE_PULSES; i++) {
+            this.pulseFreeStack[i] = MAX_ACTIVE_PULSES - 1 - i;
+        }
+        this.pulseFreeTop = MAX_ACTIVE_PULSES;
+        this.activePulseCount = 0;
+
+        this._build();
+    }
+
+    _build() {
+        this._placeClusters();
+        this._placeNeurons();
+        this._assignTypes();
+        this._buildSynapses();
+        this._initState();
+    }
+
+    _placeClusters() {
+        // Distribute cluster centers around a sphere shell with jitter,
+        // so clusters are visually separable but not on a perfect lattice.
+        for (let c = 0; c < CLUSTER_COUNT; c++) {
+            // Fibonacci sphere point + jitter
+            const golden = Math.PI * (3 - Math.sqrt(5));
+            const y = 1 - (c / Math.max(1, CLUSTER_COUNT - 1)) * 2;
+            const r = Math.sqrt(1 - y * y);
+            const theta = golden * c;
+            const x = Math.cos(theta) * r;
+            const z = Math.sin(theta) * r;
+            const radius = NETWORK_RADIUS * (0.55 + 0.25 * this.rand());
+            this.clusterCenters[c * 3 + 0] = x * radius + (this.rand() - 0.5) * 14;
+            this.clusterCenters[c * 3 + 1] = y * radius + (this.rand() - 0.5) * 14;
+            this.clusterCenters[c * 3 + 2] = z * radius + (this.rand() - 0.5) * 14;
+        }
+    }
+
+    _placeNeurons() {
+        // Roughly equal neurons per cluster, with ±10% jitter
+        const baseCount = Math.floor(this.n / CLUSTER_COUNT);
+        const counts = new Array(CLUSTER_COUNT).fill(baseCount);
+        let leftover = this.n - baseCount * CLUSTER_COUNT;
+        for (let c = 0; leftover > 0; c = (c + 1) % CLUSTER_COUNT, leftover--) counts[c]++;
+
+        let idx = 0;
+        for (let c = 0; c < CLUSTER_COUNT; c++) {
+            const cx = this.clusterCenters[c * 3 + 0];
+            const cy = this.clusterCenters[c * 3 + 1];
+            const cz = this.clusterCenters[c * 3 + 2];
+            // Each cluster gets a slightly different sigma — visual variety
+            const sigma = CLUSTER_RADIUS * (0.85 + 0.3 * this.rand());
+            for (let k = 0; k < counts[c]; k++) {
+                this.positions[idx * 3 + 0] = cx + gaussian(this.rand) * sigma;
+                this.positions[idx * 3 + 1] = cy + gaussian(this.rand) * sigma;
+                this.positions[idx * 3 + 2] = cz + gaussian(this.rand) * sigma;
+                this.cluster[idx] = c;
+                idx++;
+            }
+        }
+    }
+
+    _assignTypes() {
+        for (let i = 0; i < this.n; i++) {
+            this.types[i] = this.rand() < E_FRACTION ? 0 : 1;
+        }
+    }
+
+    _buildSynapses() {
+        // First pass: count. Second pass: fill.
+        // For each source we sample target neurons; mostly local (same
+        // cluster, distance-weighted), some long-range to any neuron.
+        const counts = new Uint32Array(this.n);
+        for (let i = 0; i < this.n; i++) {
+            counts[i] = this.types[i] === 0 ? SYN_OUT_E : SYN_OUT_I;
+        }
+
+        // Build cluster -> neuron index list for fast local sampling
+        const clusterMembers = [];
+        for (let c = 0; c < CLUSTER_COUNT; c++) clusterMembers.push([]);
+        for (let i = 0; i < this.n; i++) clusterMembers[this.cluster[i]].push(i);
+
+        // CSR offsets
+        let total = 0;
+        for (let i = 0; i < this.n; i++) {
+            this.synOutStart[i] = total;
+            total += counts[i];
+        }
+        this.synOutStart[this.n] = total;
+        this.synapseCount = total;
+
+        this.synDst = new Uint32Array(total);
+        this.synWeight = new Float32Array(total);
+        this.synDelay = new Float32Array(total);
+
+        const TWO_PI = Math.PI * 2;
+
+        for (let i = 0; i < this.n; i++) {
+            const sx = this.positions[i * 3 + 0];
+            const sy = this.positions[i * 3 + 1];
+            const sz = this.positions[i * 3 + 2];
+            const myCluster = this.cluster[i];
+            const myType = this.types[i];
+            const baseW = myType === 0 ? E_WEIGHT : I_WEIGHT;
+            const localPool = clusterMembers[myCluster];
+
+            const start = this.synOutStart[i];
+            const k = counts[i];
+
+            for (let s = 0; s < k; s++) {
+                let tgt;
+                let attempts = 0;
+                if (this.rand() < LOCAL_FRACTION) {
+                    // Local: rejection-sample by distance
+                    do {
+                        tgt = localPool[(this.rand() * localPool.length) | 0];
+                        const dx = this.positions[tgt * 3 + 0] - sx;
+                        const dy = this.positions[tgt * 3 + 1] - sy;
+                        const dz = this.positions[tgt * 3 + 2] - sz;
+                        const d = Math.sqrt(dx * dx + dy * dy + dz * dz);
+                        const accept = Math.exp(-d / LOCAL_FALLOFF);
+                        if (this.rand() < accept && tgt !== i) break;
+                        attempts++;
+                    } while (attempts < 8);
+                } else {
+                    // Long-range: any neuron in any cluster
+                    do {
+                        tgt = (this.rand() * this.n) | 0;
+                        attempts++;
+                    } while (tgt === i && attempts < 4);
+                }
+
+                this.synDst[start + s] = tgt;
+                // Per-synapse weight jitter ±25%
+                this.synWeight[start + s] = baseW * (0.75 + 0.5 * this.rand());
+
+                // Distance-proportional delay
+                const dx = this.positions[tgt * 3 + 0] - sx;
+                const dy = this.positions[tgt * 3 + 1] - sy;
+                const dz = this.positions[tgt * 3 + 2] - sz;
+                const d = Math.sqrt(dx * dx + dy * dy + dz * dz);
+                const norm = Math.min(1, d / (NETWORK_RADIUS * 1.6));
+                let delay = DELAY_BASE_MS + DELAY_RANGE_MS * norm;
+                delay += (this.rand() - 0.5) * 2 * DELAY_JITTER_MS;
+                if (delay < SIM_DT_MS) delay = SIM_DT_MS;
+                this.synDelay[start + s] = delay;
+            }
+        }
+    }
+
+    _initState() {
+        // Start with V near rest with small spread so the network doesn't
+        // fire all-at-once on the first step.
+        for (let i = 0; i < this.n; i++) {
+            this.V[i] = V_REST + (this.rand() - 0.5) * 0.4;
+            this.refractory[i] = 0;
+            this.brightness[i] = 0;
+        }
+    }
+
+    // Inject stimulus near a 3D point. Returns count of stimulated neurons.
+    stimulate(px, py, pz, radius = STIMULUS_RADIUS, strength = STIMULUS_STRENGTH) {
+        let count = 0;
+        const r2 = radius * radius;
+        // First pass — find candidates
+        const candidates = [];
+        for (let i = 0; i < this.n; i++) {
+            const dx = this.positions[i * 3 + 0] - px;
+            const dy = this.positions[i * 3 + 1] - py;
+            const dz = this.positions[i * 3 + 2] - pz;
+            const d2 = dx * dx + dy * dy + dz * dz;
+            if (d2 < r2) candidates.push([i, d2]);
+        }
+        // Sort by distance, take up to STIMULUS_NEIGHBOURS_MAX closest
+        candidates.sort((a, b) => a[1] - b[1]);
+        const take = Math.min(candidates.length, STIMULUS_NEIGHBOURS_MAX);
+        for (let k = 0; k < take; k++) {
+            const i = candidates[k][0];
+            // Stronger near the click point
+            const falloff = 1 - candidates[k][1] / r2;
+            this.V[i] += strength * (0.5 + 0.5 * falloff);
+            count++;
+        }
+        return count;
+    }
+
+    // Step the simulation by SIM_DT_MS. Spikes generated this step push
+    // pulses into the pulse pool for rendering.
+    step() {
+        const N = this.n;
+        const dt = SIM_DT_MS;
+        const decayV = Math.exp(-dt / V_TAU_MS);
+        const decayB = Math.exp(-dt / BRIGHTNESS_TAU_MS);
+        const decayCoincidence = Math.exp(-dt / 60);
+
+        // 1. Drain current ring slot into V, then zero it.
+        const slot = this.ring[this.ringIdx];
+        for (let i = 0; i < N; i++) {
+            const c = slot[i];
+            if (c !== 0) {
+                if (c > 0) this.recentE[i] += c;
+                else this.recentI[i] += -c;
+                this.V[i] += c;
+                slot[i] = 0;
+            }
+        }
+
+        // 2. Decay V toward rest, decrement refractory, decay brightness.
+        // 3. Add background noise to non-refractory neurons.
+        // 4. Threshold detection — mark spikes.
+        const spikes = []; // indices that fired this step
+        const noiseScale = NOISE_AMPLITUDE;
+        const rand = this.rand;
+        for (let i = 0; i < N; i++) {
+            // Recent E/I tracking
+            this.recentE[i] *= decayCoincidence;
+            this.recentI[i] *= decayCoincidence;
+
+            this.brightness[i] *= decayB;
+            this.coincidenceFlash[i] *= decayCoincidence;
+
+            if (this.refractory[i] > 0) {
+                this.refractory[i] -= dt;
+                this.V[i] = V_RESET; // hold at reset during refractory
+                continue;
+            }
+
+            // Membrane decay
+            this.V[i] = V_REST + (this.V[i] - V_REST) * decayV;
+            // Noise — cheap uniform-ish; std ≈ NOISE_AMPLITUDE/√3
+            const u1 = rand() - 0.5;
+            const u2 = rand() - 0.5;
+            this.V[i] += (u1 + u2) * noiseScale;
+
+            if (this.V[i] >= V_THRESHOLD) {
+                // Fire
+                this.V[i] = V_RESET;
+                this.refractory[i] = REFRACTORY_MS;
+                this.brightness[i] = BRIGHTNESS_PEAK;
+                spikes.push(i);
+
+                // Coincidence flash if both E and I arrived recently
+                if (this.recentE[i] > 0.4 && this.recentI[i] > 0.4) {
+                    this.coincidenceFlash[i] = 1.0;
+                }
+            }
+        }
+
+        // 5. For each spike, queue deliveries and emit pulses for rendering.
+        const ringSize = this.ringSize;
+        const ringIdx = this.ringIdx;
+        const tStart = this.simTimeMs;
+        for (let k = 0; k < spikes.length; k++) {
+            const src = spikes[k];
+            const start = this.synOutStart[src];
+            const end = this.synOutStart[src + 1];
+            const srcType = this.types[src];
+            const sx = this.positions[src * 3 + 0];
+            const sy = this.positions[src * 3 + 1];
+            const sz = this.positions[src * 3 + 2];
+            const color = srcType === 0 ? COLOR_E : COLOR_I;
+
+            for (let s = start; s < end; s++) {
+                const dst = this.synDst[s];
+                const w = this.synWeight[s];
+                const delay = this.synDelay[s];
+                // Slot to deliver into
+                const slotsAhead = Math.max(1, Math.round(delay / dt));
+                const targetSlot = (ringIdx + slotsAhead) % ringSize;
+                this.ring[targetSlot][dst] += w;
+
+                // Emit pulse for rendering
+                this._spawnPulse(
+                    sx, sy, sz,
+                    this.positions[dst * 3 + 0],
+                    this.positions[dst * 3 + 1],
+                    this.positions[dst * 3 + 2],
+                    tStart, tStart + delay,
+                    color
+                );
+            }
+        }
+
+        // 6. Advance time and prune expired pulses.
+        this.simTimeMs += dt;
+        this.ringIdx = (this.ringIdx + 1) % this.ringSize;
+        this._prunePulses();
+
+        return spikes.length;
+    }
+
+    _spawnPulse(sx, sy, sz, dx, dy, dz, tStart, tEnd, color) {
+        if (this.pulseFreeTop === 0) return; // overflow — drop silently
+        const slot = this.pulseFreeStack[--this.pulseFreeTop];
+        const o = slot * this.pulseStride;
+        this.pulseData[o + 0] = sx;
+        this.pulseData[o + 1] = sy;
+        this.pulseData[o + 2] = sz;
+        this.pulseData[o + 3] = dx;
+        this.pulseData[o + 4] = dy;
+        this.pulseData[o + 5] = dz;
+        this.pulseData[o + 6] = tStart;
+        this.pulseData[o + 7] = tEnd;
+        this.pulseData[o + 8] = color[0];
+        this.pulseData[o + 9] = color[1];
+        this.pulseData[o + 10] = color[2];
+        this.pulseAlive[slot] = 1;
+        this.pulseTEnd[slot] = tEnd;
+        this.activePulseCount++;
+    }
+
+    _prunePulses() {
+        // Walk all slots and free expired. Cheap because we only check
+        // the alive bit and the tEnd float — fits in cache.
+        const now = this.simTimeMs;
+        const alive = this.pulseAlive;
+        const tEndArr = this.pulseTEnd;
+        const free = this.pulseFreeStack;
+        let top = this.pulseFreeTop;
+        let count = this.activePulseCount;
+        for (let i = 0, n = alive.length; i < n; i++) {
+            if (alive[i] && tEndArr[i] <= now) {
+                alive[i] = 0;
+                free[top++] = i;
+                count--;
+            }
+        }
+        this.pulseFreeTop = top;
+        this.activePulseCount = count;
+    }
+
+    // Build a contiguous Float32Array of just the active pulses for
+    // upload to the GPU. Returns {data, count}.
+    snapshotActivePulses() {
+        const stride = this.pulseStride;
+        const out = new Float32Array(this.activePulseCount * stride);
+        const alive = this.pulseAlive;
+        const src = this.pulseData;
+        let w = 0;
+        for (let i = 0, n = alive.length; i < n; i++) {
+            if (alive[i]) {
+                const o = i * stride;
+                for (let k = 0; k < stride; k++) out[w + k] = src[o + k];
+                w += stride;
+            }
+        }
+        return { data: out, count: this.activePulseCount };
+    }
+}

--- a/apps/cortex/simulation.js
+++ b/apps/cortex/simulation.js
@@ -118,6 +118,11 @@ export class Network {
         this.synDelay = null;   // Float32Array(M)
         this.synapseCount = 0;
 
+        // Per-step spike list — pre-allocated to worst case (all neurons
+        // fire) so the hot loop never touches the JS allocator.
+        this.spikeBuffer = new Int32Array(this.n);
+        this.spikeCount = 0;
+
         // Delivery ring buffer: ringSize × n floats of pending current
         this.ringSize = Math.ceil(MAX_DELAY_MS / SIM_DT_MS) + 1;
         this.ring = new Array(this.ringSize);
@@ -340,8 +345,9 @@ export class Network {
 
         // 2. Decay V toward rest, decrement refractory, decay brightness.
         // 3. Add background noise to non-refractory neurons.
-        // 4. Threshold detection — mark spikes.
-        const spikes = []; // indices that fired this step
+        // 4. Threshold detection — append spike indices to pre-allocated buffer.
+        const spikeBuf = this.spikeBuffer;
+        let spikeCount = 0;
         const noiseScale = NOISE_AMPLITUDE;
         const rand = this.rand;
         for (let i = 0; i < N; i++) {
@@ -370,7 +376,7 @@ export class Network {
                 this.V[i] = V_RESET;
                 this.refractory[i] = REFRACTORY_MS;
                 this.brightness[i] = BRIGHTNESS_PEAK;
-                spikes.push(i);
+                spikeBuf[spikeCount++] = i;
 
                 // Coincidence flash if both E and I arrived recently
                 if (this.recentE[i] > 0.4 && this.recentI[i] > 0.4) {
@@ -378,13 +384,14 @@ export class Network {
                 }
             }
         }
+        this.spikeCount = spikeCount;
 
         // 5. For each spike, queue deliveries and emit pulses for rendering.
         const ringSize = this.ringSize;
         const ringIdx = this.ringIdx;
         const tStart = this.simTimeMs;
-        for (let k = 0; k < spikes.length; k++) {
-            const src = spikes[k];
+        for (let k = 0; k < spikeCount; k++) {
+            const src = spikeBuf[k];
             const start = this.synOutStart[src];
             const end = this.synOutStart[src + 1];
             const srcType = this.types[src];
@@ -419,7 +426,7 @@ export class Network {
         this.ringIdx = (this.ringIdx + 1) % this.ringSize;
         this._prunePulses();
 
-        return spikes.length;
+        return spikeCount;
     }
 
     _spawnPulse(sx, sy, sz, dx, dy, dz, tStart, tEnd, color) {
@@ -462,21 +469,4 @@ export class Network {
         this.activePulseCount = count;
     }
 
-    // Build a contiguous Float32Array of just the active pulses for
-    // upload to the GPU. Returns {data, count}.
-    snapshotActivePulses() {
-        const stride = this.pulseStride;
-        const out = new Float32Array(this.activePulseCount * stride);
-        const alive = this.pulseAlive;
-        const src = this.pulseData;
-        let w = 0;
-        for (let i = 0, n = alive.length; i < n; i++) {
-            if (alive[i]) {
-                const o = i * stride;
-                for (let k = 0; k < stride; k++) out[w + k] = src[o + k];
-                w += stride;
-            }
-        }
-        return { data: out, count: this.activePulseCount };
-    }
 }

--- a/apps/index.html
+++ b/apps/index.html
@@ -337,6 +337,7 @@
         .app-tides { background: linear-gradient(135deg, #0a1628, #1a6b7a); }
         .app-360 { background: linear-gradient(135deg, #0a0a1a, #00574a); }
         .app-dam { background: linear-gradient(135deg, #d9b77f, #6ba5c0); }
+        .app-cortex { background: linear-gradient(135deg, #05060a, #2d0a4a 60%, #b8246b); }
     </style>
 </head>
 <body>
@@ -427,6 +428,11 @@
         <a href="countdown/" class="app-link">
             <div class="app-icon app-countdown">📅</div>
             <span class="app-name">Countdown</span>
+        </a>
+
+        <a href="cortex/" class="app-link">
+            <div class="app-icon app-cortex">🧠</div>
+            <span class="app-name">Cortex</span>
         </a>
 
         <a href="cycle/" class="app-link">


### PR DESCRIPTION
## Summary

A new \`/apps/cortex/\` app: a continuously-active leaky integrate-and-fire neural network rendered as a dim, organic 3D field. ~16k neurons in 7 small-world clusters, ~600k synapses with distance-proportional delays (80–400 ms) so spikes visibly travel as bright pulses with fading trails. Click anywhere to inject a stimulus and watch a localized cascade ripple out and interact with the ongoing dynamics. Camera autonomously orbits when idle; drag/pinch to override, drift resumes 3 s after input.

### Architecture

- **WebGL2 + Three.js** for breadth (Safari/iOS PWA path).
- **CPU-side LIF simulation** at 200 Hz with a per-step delay ring buffer of accumulated current. The synapse-fanout scatter-write pattern is exactly the access pattern GPGPU is bad at, so this runs faster on the CPU and frees the GPU for rendering quality.
- **GPU-instanced rendering**: neurons as point sprites with per-neuron brightness updated via a shared \`Float32Array\`; pulses as instanced billboard strips that the vertex shader interpolates from \`(tStart, tEnd)\` against \`uNow\`.
- **Postprocessing**: scene → external depth-equipped HDR target → composer (TexturePass → DoF → UnrealBloom → CA + grain + vignette + tone curve → output). The scene is rendered to its own RT so the DoF pass can sample depth without forming a feedback loop with the composer's ping-pong RTs.
- **Hardware tier detection** at startup (mobile / cores / GPU renderer) sizes neuron count, pixel ratio, and post-processing. Live FPS monitor peels off DoF, then softens bloom, if the frame budget slips.

### Files

- \`apps/cortex/index.html\` — minimal canvas + import map (Three.js r161 from unpkg, no build step)
- \`apps/cortex/main.js\` — entry, fixed-step sim loop, click raycast, FPS-based degradation
- \`apps/cortex/simulation.js\` — LIF dynamics, topology, delay ring buffer, pulse pool
- \`apps/cortex/rendering.js\` — neurons / synapse skeleton / pulses / cluster fog / background
- \`apps/cortex/postprocessing.js\` — scene RT + composer pipeline
- \`apps/cortex/camera.js\` — drift + drag/pinch + smooth handoff
- \`apps/index.html\` — added Cortex tile (🧠) in alphabetical position

## Test plan

- [ ] Open https://polkiewicz.com/apps/cortex/ — within ~1 s see scattered cyan/magenta flashes with pulses traveling along faint connection lines
- [ ] After ~5 s, observe small waves and occasional larger cascades crossing clusters
- [ ] Camera slowly orbits and breathes (parallax depth)
- [ ] Click anywhere → a clearly-localized cascade erupts and ripples through the topology
- [ ] Drag to orbit, pinch / scroll to zoom; let go and after ~3 s drift resumes smoothly
- [ ] Holds up to 60+ seconds of watching without feeling looped or scripted
- [ ] On laptop GPU: ~60 fps with all effects
- [ ] On mobile: tier detection drops neuron count + DoF; remains responsive
- [ ] Check from launcher: Cortex tile appears between Countdown and Cycle, opens cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)