### PR TITLE
Cortex: harden init for iOS Safari black-screen reports

### DIFF
--- a/apps/cortex/index.html
+++ b/apps/cortex/index.html
@@ -26,7 +26,21 @@
             height: 100vh;
             cursor: crosshair;
         }
+        #err {
+            position: fixed;
+            top: 0; left: 0; right: 0;
+            padding: env(safe-area-inset-top, 12px) 16px 16px;
+            font: 13px/1.4 -apple-system, BlinkMacSystemFont, "Helvetica Neue", monospace;
+            color: #ff8aa8;
+            background: rgba(8, 4, 12, 0.92);
+            border-bottom: 1px solid #5a1240;
+            z-index: 10;
+            white-space: pre-wrap;
+            display: none;
+        }
     </style>
+    <!-- importmap polyfill for iOS Safari < 16.4 -->
+    <script async src="https://ga.jspm.io/npm:es-module-shims@1.10.0/dist/es-module-shims.js"></script>
     <script type="importmap">
     {
         "imports": {
@@ -38,6 +52,18 @@
 </head>
 <body>
     <canvas id="cortex"></canvas>
+    <div id="err"></div>
     <script type="module" src="./main.js"></script>
+    <script>
+        // Surface load-time errors that happen before main.js sets up its
+        // own handlers (e.g. importmap not supported, module 404, parse fail).
+        window.addEventListener('error', function (ev) {
+            var el = document.getElementById('err');
+            if (!el) return;
+            el.style.display = 'block';
+            el.textContent = 'cortex error: ' + (ev.message || ev.error || 'unknown')
+                + '\nat ' + (ev.filename || '?') + ':' + (ev.lineno || '?');
+        }, true);
+    </script>
 </body>
 </html>

--- a/apps/cortex/main.js
+++ b/apps/cortex/main.js
@@ -59,6 +59,10 @@ function detectTier() {
             bloomStrength: 0.85,
             pixelRatio: Math.min(dpr, 1.5),
             synapseSubsample: 0.14,
+            // iOS Safari has been historically flaky with HalfFloat color
+            // attachments — falling back to UnsignedByte costs a bit of HDR
+            // headroom for bloom but is much more reliably renderable.
+            useHalfFloat: false,
         };
     }
     if (cores < 8) {
@@ -70,6 +74,7 @@ function detectTier() {
             bloomStrength: 1.0,
             pixelRatio: Math.min(dpr, 1.75),
             synapseSubsample: 0.20,
+            useHalfFloat: true,
         };
     }
     return {
@@ -80,7 +85,17 @@ function detectTier() {
         bloomStrength: 1.05,
         pixelRatio: Math.min(dpr, 2),
         synapseSubsample: 0.22,
+        useHalfFloat: true,
     };
+}
+
+function showFatal(msg) {
+    const el = document.getElementById('err');
+    if (el) {
+        el.style.display = 'block';
+        el.textContent = 'cortex error: ' + msg;
+    }
+    console.error('[cortex]', msg);
 }
 
 // ---------- Init ----------
@@ -88,31 +103,45 @@ function detectTier() {
 const canvas = document.getElementById('cortex');
 const tier = detectTier();
 
-const network = new Network(tier.neuronCount);
-const renderer = new CortexRenderer(canvas, network, {
-    synapseSubsample: tier.synapseSubsample,
-});
-renderer.renderer.setPixelRatio(tier.pixelRatio);
+let network, renderer, post, camCtl;
+try {
+    network = new Network(tier.neuronCount);
+    renderer = new CortexRenderer(canvas, network, {
+        synapseSubsample: tier.synapseSubsample,
+    });
+    renderer.renderer.setPixelRatio(tier.pixelRatio);
 
-const post = new CortexPostprocessor(renderer.renderer, renderer.scene, renderer.camera, {
-    bloomStrength: tier.bloomStrength,
-    bloomRadius: 0.85,
-    bloomThreshold: 0.42,
-    enableDoF: tier.enableDoF,
-    enableBloom: tier.enableBloom,
-});
+    post = new CortexPostprocessor(renderer.renderer, renderer.scene, renderer.camera, {
+        bloomStrength: tier.bloomStrength,
+        bloomRadius: 0.85,
+        bloomThreshold: 0.42,
+        enableDoF: tier.enableDoF,
+        enableBloom: tier.enableBloom,
+        useHalfFloat: tier.useHalfFloat,
+    });
 
-const camCtl = new CortexCamera(renderer.camera, canvas, {
-    initialDistance: 230,
-    initialTheta: 0.4,
-    initialPhi: 0.18,
-});
+    camCtl = new CortexCamera(renderer.camera, canvas, {
+        initialDistance: 230,
+        initialTheta: 0.4,
+        initialPhi: 0.18,
+    });
+} catch (e) {
+    showFatal((e && e.message ? e.message : String(e)) + ' [tier=' + tier.tier + ']');
+    throw e;
+}
 
 // ---------- Resize ----------
 
 function resize() {
     const w = window.innerWidth;
     const h = window.innerHeight;
+    if (w === 0 || h === 0) {
+        // iOS standalone PWA can briefly report a 0×0 viewport during
+        // launch; retry on the next animation frame instead of building
+        // zero-sized render targets.
+        requestAnimationFrame(resize);
+        return;
+    }
     const dpr = renderer.renderer.getPixelRatio();
     renderer.setSize(w, h, dpr);
     // Round so the composer's render targets get integer dimensions even
@@ -180,7 +209,9 @@ let fpsSamples = [];
 let fpsCheckedAt = 0;
 let degradeTriggered = false;
 
+let loopFatal = false;
 function tick(nowMs) {
+    if (loopFatal) return;
     requestAnimationFrame(tick);
 
     const dtMs = Math.min(100, nowMs - lastFrameMs); // clamp big gaps (tab switch)
@@ -199,12 +230,16 @@ function tick(nowMs) {
         simAccumulatorMs = 0;
     }
 
-    // Camera + state sync + render
-    camCtl.update(nowMs);
-    renderer.syncFromSimulation();
-    // Keep DoF focus on the network's near edge so the front feels sharp
-    if (post.dofPass) post.setFocusDistance(camCtl.getDistanceToTarget() * 0.75);
-    post.render(nowMs);
+    try {
+        camCtl.update(nowMs);
+        renderer.syncFromSimulation();
+        if (post.dofPass) post.setFocusDistance(camCtl.getDistanceToTarget() * 0.75);
+        post.render(nowMs);
+    } catch (e) {
+        loopFatal = true;
+        showFatal('frame: ' + (e && e.message ? e.message : String(e)));
+        throw e;
+    }
 
     // FPS-based live degradation
     if (firstFrameDone && !degradeTriggered) {

--- a/apps/cortex/postprocessing.js
+++ b/apps/cortex/postprocessing.js
@@ -145,23 +145,29 @@ export class CortexPostprocessor {
             bloomThreshold: 0.42,
             enableDoF: true,
             enableBloom: true,
+            useHalfFloat: true,
         }, opts);
 
         const size = renderer.getDrawingBufferSize(new THREE.Vector2());
+        // iOS Safari has had recurring issues with HalfFloat color
+        // attachments — fall back to UnsignedByte when the caller asks
+        // (typically on mobile). Costs HDR bloom headroom but produces
+        // a renderable framebuffer.
+        const rtType = this.opts.useHalfFloat ? THREE.HalfFloatType : THREE.UnsignedByteType;
 
         // Our own scene RT — owns the depth texture. Composer never touches this.
         const dt = new THREE.DepthTexture(size.x, size.y);
         dt.type = THREE.UnsignedShortType;
         this.sceneRT = new THREE.WebGLRenderTarget(size.x, size.y, {
-            type: THREE.HalfFloatType,
+            type: rtType,
             depthBuffer: true,
             depthTexture: dt,
         });
         this.depthTexture = dt;
 
-        // Composer RTs — HDR but no depth attachment, so no feedback risk.
+        // Composer RTs — same precision as scene, no depth attachment.
         const composerRT = new THREE.WebGLRenderTarget(size.x, size.y, {
-            type: THREE.HalfFloatType,
+            type: rtType,
             depthBuffer: false,
         });
         this.composer = new EffectComposer(renderer, composerRT);

--- a/apps/cortex/rendering.js
+++ b/apps/cortex/rendering.js
@@ -546,11 +546,14 @@ export class CortexRenderer {
         }
 
         this.pulseGeom.instanceCount = w;
-        // Upload only the prefix that changed
-        this.pulseSrc.addUpdateRange(0, w * 3);   this.pulseSrc.needsUpdate = true;
-        this.pulseDst.addUpdateRange(0, w * 3);   this.pulseDst.needsUpdate = true;
-        this.pulseTime.addUpdateRange(0, w * 2);  this.pulseTime.needsUpdate = true;
-        this.pulseColor.addUpdateRange(0, w * 3); this.pulseColor.needsUpdate = true;
+        // Upload only the prefix that changed. Skip when w=0 — some
+        // drivers throw on bufferSubData with count=0.
+        if (w > 0) {
+            this.pulseSrc.addUpdateRange(0, w * 3);   this.pulseSrc.needsUpdate = true;
+            this.pulseDst.addUpdateRange(0, w * 3);   this.pulseDst.needsUpdate = true;
+            this.pulseTime.addUpdateRange(0, w * 2);  this.pulseTime.needsUpdate = true;
+            this.pulseColor.addUpdateRange(0, w * 3); this.pulseColor.needsUpdate = true;
+        }
 
         // Update pulse uniforms
         this.pulseMaterial.uniforms.uNow.value = this.network.simTimeMs;


### PR DESCRIPTION
## Summary

The merged Cortex PR shows a black screen on at least one iPhone. Several plausible iOS-specific failure modes don't surface a visible error, so this PR makes them either survive or speak up.

- **HalfFloat fallback**: on the low (mobile) tier we now use \`UnsignedByteType\` for both the scene RT and the composer RTs. iOS Safari has had recurring issues creating complete framebuffers with HalfFloat color attachments. We lose some HDR bloom headroom but gain a renderable framebuffer.
- **Visible error overlay**: a \`#err\` div now shows the actual exception text if init or the per-frame loop throws. So if the next iteration still fails, the user can read what failed instead of guessing.
- **importmap polyfill**: \`es-module-shims\` is loaded (async) so iOS Safari < 16.4 can load the module entry.
- **Empty pulse buffer guard**: skip \`bufferSubData\` when the active pulse count is 0; some drivers throw on count=0.
- **0×0 viewport retry**: iOS standalone PWA launch can briefly report \`window.innerWidth/Height\` as 0; retry on the next animation frame instead of building zero-sized RTs.

## Test plan

- [ ] Reload \`/apps/cortex/\` on iPhone — visualization renders, or a red error message appears at the top of the screen with the actual failure
- [ ] Desktop still renders identically (high tier still uses HalfFloat + DoF)
- [ ] If the error overlay appears, share what it says so we can fix it directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)