### PR TITLE
Add markdown preview app

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -338,6 +338,7 @@
         .app-360 { background: linear-gradient(135deg, #0a0a1a, #00574a); }
         .app-dam { background: linear-gradient(135deg, #d9b77f, #6ba5c0); }
         .app-cortex { background: linear-gradient(135deg, #05060a, #2d0a4a 60%, #b8246b); }
+        .app-markdown { background: linear-gradient(135deg, #1e293b, #3b82f6); }
     </style>
 </head>
 <body>
@@ -463,6 +464,11 @@
         <a href="lunar/" class="app-link">
             <div class="app-icon app-lunar">🌙</div>
             <span class="app-name">Lunar</span>
+        </a>
+
+        <a href="markdown/" class="app-link">
+            <div class="app-icon app-markdown">📝</div>
+            <span class="app-name">Markdown</span>
         </a>
 
         <a href="network/" class="app-link">

--- a/apps/markdown/index.html
+++ b/apps/markdown/index.html
@@ -1,0 +1,402 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="theme-color" content="#1e293b">
+    <title>Markdown</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked@14.1.3/marked.min.js"></script>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        html, body {
+            height: 100%;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: #0f172a;
+            color: #e2e8f0;
+            display: flex;
+            flex-direction: column;
+            padding-top: env(safe-area-inset-top);
+            padding-bottom: env(safe-area-inset-bottom);
+            padding-left: env(safe-area-inset-left);
+            padding-right: env(safe-area-inset-right);
+            -webkit-tap-highlight-color: transparent;
+            overflow: hidden;
+        }
+
+        .toolbar {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 12px 16px;
+            background: #1e293b;
+            border-bottom: 1px solid #334155;
+            flex-shrink: 0;
+        }
+
+        .title {
+            font-size: 17px;
+            font-weight: 600;
+            color: #f1f5f9;
+            margin-right: auto;
+        }
+
+        .tabs {
+            display: flex;
+            background: #0f172a;
+            border-radius: 8px;
+            padding: 3px;
+            gap: 2px;
+        }
+
+        .tab {
+            padding: 6px 14px;
+            border: none;
+            background: transparent;
+            color: #94a3b8;
+            font-size: 13px;
+            font-weight: 600;
+            border-radius: 6px;
+            cursor: pointer;
+            font-family: inherit;
+            transition: background-color 0.15s ease, color 0.15s ease;
+        }
+
+        .tab.active {
+            background: #3b82f6;
+            color: #fff;
+        }
+
+        .btn-copy {
+            padding: 6px 14px;
+            background: #334155;
+            color: #e2e8f0;
+            border: none;
+            border-radius: 8px;
+            font-size: 13px;
+            font-weight: 600;
+            cursor: pointer;
+            font-family: inherit;
+            transition: background-color 0.15s ease;
+        }
+
+        .btn-copy:hover {
+            background: #475569;
+        }
+
+        .btn-copy:active {
+            transform: scale(0.96);
+        }
+
+        .btn-copy.copied {
+            background: #16a34a;
+            color: #fff;
+        }
+
+        .btn-copy:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        main {
+            flex: 1;
+            overflow: hidden;
+            position: relative;
+        }
+
+        .pane {
+            position: absolute;
+            inset: 0;
+            display: none;
+            overflow-y: auto;
+            -webkit-overflow-scrolling: touch;
+        }
+
+        .pane.active {
+            display: block;
+        }
+
+        #editor {
+            width: 100%;
+            height: 100%;
+            padding: 16px;
+            background: #0f172a;
+            color: #e2e8f0;
+            border: none;
+            outline: none;
+            resize: none;
+            font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+            font-size: 14px;
+            line-height: 1.6;
+            -webkit-appearance: none;
+        }
+
+        #editor::placeholder {
+            color: #64748b;
+        }
+
+        #preview {
+            padding: 24px 20px;
+            background: #fff;
+            color: #1e293b;
+            min-height: 100%;
+            font-size: 16px;
+            line-height: 1.65;
+            word-wrap: break-word;
+        }
+
+        #preview:empty::before {
+            content: 'Preview will appear here...';
+            color: #94a3b8;
+            font-style: italic;
+        }
+
+        /* Markdown content styles */
+        #preview h1, #preview h2, #preview h3, #preview h4, #preview h5, #preview h6 {
+            margin-top: 1.5em;
+            margin-bottom: 0.5em;
+            font-weight: 600;
+            line-height: 1.25;
+            color: #0f172a;
+        }
+
+        #preview h1:first-child, #preview h2:first-child, #preview h3:first-child {
+            margin-top: 0;
+        }
+
+        #preview h1 { font-size: 2em; border-bottom: 1px solid #e2e8f0; padding-bottom: 0.3em; }
+        #preview h2 { font-size: 1.5em; border-bottom: 1px solid #e2e8f0; padding-bottom: 0.3em; }
+        #preview h3 { font-size: 1.25em; }
+        #preview h4 { font-size: 1em; }
+        #preview h5 { font-size: 0.875em; }
+        #preview h6 { font-size: 0.85em; color: #64748b; }
+
+        #preview p {
+            margin-bottom: 1em;
+        }
+
+        #preview a {
+            color: #2563eb;
+            text-decoration: underline;
+        }
+
+        #preview strong {
+            font-weight: 600;
+        }
+
+        #preview em {
+            font-style: italic;
+        }
+
+        #preview ul, #preview ol {
+            margin-bottom: 1em;
+            padding-left: 2em;
+        }
+
+        #preview li {
+            margin-bottom: 0.25em;
+        }
+
+        #preview li > ul, #preview li > ol {
+            margin-bottom: 0;
+        }
+
+        #preview blockquote {
+            margin: 0 0 1em;
+            padding: 0 1em;
+            color: #64748b;
+            border-left: 4px solid #e2e8f0;
+        }
+
+        #preview code {
+            font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+            font-size: 0.9em;
+            background: #f1f5f9;
+            padding: 0.2em 0.4em;
+            border-radius: 4px;
+            color: #be185d;
+        }
+
+        #preview pre {
+            background: #0f172a;
+            color: #e2e8f0;
+            padding: 14px 16px;
+            border-radius: 8px;
+            overflow-x: auto;
+            margin-bottom: 1em;
+            font-size: 13px;
+            line-height: 1.5;
+        }
+
+        #preview pre code {
+            background: transparent;
+            color: inherit;
+            padding: 0;
+            font-size: inherit;
+        }
+
+        #preview table {
+            border-collapse: collapse;
+            margin-bottom: 1em;
+            display: block;
+            overflow-x: auto;
+            max-width: 100%;
+        }
+
+        #preview th, #preview td {
+            border: 1px solid #e2e8f0;
+            padding: 8px 12px;
+            text-align: left;
+        }
+
+        #preview th {
+            background: #f8fafc;
+            font-weight: 600;
+        }
+
+        #preview tr:nth-child(even) td {
+            background: #f8fafc;
+        }
+
+        #preview hr {
+            border: none;
+            border-top: 1px solid #e2e8f0;
+            margin: 1.5em 0;
+        }
+
+        #preview img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 6px;
+        }
+
+        #preview input[type="checkbox"] {
+            margin-right: 6px;
+        }
+
+        #preview ul:has(input[type="checkbox"]) {
+            list-style: none;
+            padding-left: 1em;
+        }
+
+        #preview del {
+            color: #94a3b8;
+        }
+    </style>
+</head>
+<body>
+    <div class="toolbar">
+        <span class="title">Markdown</span>
+        <div class="tabs">
+            <button class="tab active" id="tab-edit" onclick="showPane('edit')">Edit</button>
+            <button class="tab" id="tab-preview" onclick="showPane('preview')">Preview</button>
+        </div>
+        <button class="btn-copy" id="btn-copy" onclick="copyRichText()">Copy</button>
+    </div>
+
+    <main>
+        <div class="pane active" id="pane-edit">
+            <textarea id="editor" placeholder="# Hello&#10;&#10;Paste or type **markdown** here..." autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false"></textarea>
+        </div>
+        <div class="pane" id="pane-preview">
+            <div id="preview"></div>
+        </div>
+    </main>
+
+    <script>
+        const editor = document.getElementById('editor');
+        const preview = document.getElementById('preview');
+        const tabEdit = document.getElementById('tab-edit');
+        const tabPreview = document.getElementById('tab-preview');
+        const paneEdit = document.getElementById('pane-edit');
+        const panePreview = document.getElementById('pane-preview');
+        const btnCopy = document.getElementById('btn-copy');
+
+        marked.setOptions({
+            gfm: true,
+            breaks: true,
+        });
+
+        function render() {
+            const md = editor.value;
+            preview.innerHTML = md ? marked.parse(md) : '';
+        }
+
+        function showPane(which) {
+            const isEdit = which === 'edit';
+            tabEdit.classList.toggle('active', isEdit);
+            tabPreview.classList.toggle('active', !isEdit);
+            paneEdit.classList.toggle('active', isEdit);
+            panePreview.classList.toggle('active', !isEdit);
+            if (!isEdit) render();
+        }
+
+        editor.addEventListener('input', () => {
+            if (panePreview.classList.contains('active')) render();
+        });
+
+        async function copyRichText() {
+            render();
+            const html = preview.innerHTML;
+            const plain = preview.innerText;
+
+            if (!html.trim()) {
+                flashCopyState('Empty', false);
+                return;
+            }
+
+            try {
+                if (navigator.clipboard && window.ClipboardItem) {
+                    await navigator.clipboard.write([
+                        new ClipboardItem({
+                            'text/html': new Blob([html], { type: 'text/html' }),
+                            'text/plain': new Blob([plain], { type: 'text/plain' }),
+                        }),
+                    ]);
+                } else {
+                    await navigator.clipboard.writeText(plain);
+                }
+                flashCopyState('Copied!', true);
+            } catch (err) {
+                console.error('Copy failed:', err);
+                try {
+                    selectAndExecCopy();
+                    flashCopyState('Copied!', true);
+                } catch (fallbackErr) {
+                    console.error('Fallback copy failed:', fallbackErr);
+                    flashCopyState('Failed', false);
+                }
+            }
+        }
+
+        function selectAndExecCopy() {
+            const range = document.createRange();
+            range.selectNodeContents(preview);
+            const sel = window.getSelection();
+            sel.removeAllRanges();
+            sel.addRange(range);
+            const ok = document.execCommand('copy');
+            sel.removeAllRanges();
+            if (!ok) throw new Error('execCommand returned false');
+        }
+
+        function flashCopyState(label, success) {
+            btnCopy.textContent = label;
+            btnCopy.classList.toggle('copied', success);
+            setTimeout(() => {
+                btnCopy.textContent = 'Copy';
+                btnCopy.classList.remove('copied');
+            }, 1500);
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- New `/apps/markdown/` utility: paste markdown into the editor, toggle to **Preview**, hit **Copy** to grab the rendered output as rich text.
- Uses [marked](https://marked.js.org) from a CDN with GFM + line breaks. No sanitization — pasted raw HTML renders as-is.
- Copy writes both `text/html` and `text/plain` to the clipboard so pasting into Gmail/Docs/Slack keeps formatting; falls back to `execCommand('copy')` on a selection of the preview if the Clipboard API rejects.
- Single-pane Edit/Preview toggle (mobile-friendly), dark toolbar + light preview surface, iOS PWA meta + safe-area padding.
- Added a Markdown tile to `/apps/index.html` (alphabetically between Lunar and Network).

## Test plan
- [ ] Open `/apps/markdown/` on desktop, paste GFM (headings, list, table, code block, task list, link) — preview renders correctly.
- [ ] Click Copy, paste into Gmail compose — formatting is preserved (rich text, not markdown source).
- [ ] Paste into a plain-text field — falls back to plain text cleanly.
- [ ] On iPhone (Safari + standalone PWA), toggle Edit/Preview, copy, paste into Mail/Notes — formatting preserved, safe areas respected.
- [ ] Launcher tile appears in the right alphabetical slot and navigates to the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)