### PR TITLE
Tone down racing boost intensity

### DIFF
--- a/apps/racing/config.js
+++ b/apps/racing/config.js
@@ -22,14 +22,14 @@ export const CAM_RISE = 2.6;             // toward tube center from the craft (+
 export const CAM_LOOK_AHEAD = 22;        // look target distance ahead (-Z)
 export const CAM_LOOK_RISE = 1.1;        // look slightly up from the craft
 export const FOV_BASE = 78;
-export const FOV_BOOST = 100;            // FOV punch at peak boost
+export const FOV_BOOST = 88;             // FOV punch at peak boost
 
 // Speeds are in world units / second.
 export const SPEED_START = 78;
 export const SPEED_MAX = 188;            // base cruising speed cap (grows with distance)
 export const SPEED_RAMP_DIST = 9000;     // distance over which base speed climbs to max
-export const BOOST_SPEED = 320;          // peak speed right after hitting a ramp
-export const BOOST_DECAY = 0.62;         // higher = boost fades faster
+export const BOOST_SPEED = 205;          // peak speed right after hitting a ramp
+export const BOOST_DECAY = 1.7;          // speed ease rate; higher = boost fades faster
 export const HIT_SLOWDOWN = 0.55;        // speed multiplier applied on a crash
 
 // Collision tolerances (radians). HIT_MARGIN widens an obstacle's hit arc by

--- a/apps/racing/main.js
+++ b/apps/racing/main.js
@@ -14,7 +14,7 @@
 
 import * as THREE from 'three';
 import {
-    SPEED_START, SPEED_MAX, SPEED_RAMP_DIST, BOOST_SPEED, HIT_SLOWDOWN,
+    SPEED_START, SPEED_MAX, SPEED_RAMP_DIST, BOOST_SPEED, BOOST_DECAY, HIT_SLOWDOWN,
     FOV_BASE, FOV_BOOST, MAX_ANG_VEL, STEER_SMOOTH,
     START_SHIELDS, INVULN_TIME, CRAFT_RADIUS, CAM_RISE, CAM_BACK,
 } from './config.js';
@@ -183,7 +183,7 @@ const api = {
     },
     onBoost() {
         game.speed = Math.max(game.speed, BOOST_SPEED);
-        game.shakeT = 0.5; game.shakeAmp = 0.7;
+        game.shakeT = 0.32; game.shakeAmp = 0.4;
         hud.flashBoost();
     },
 };
@@ -265,7 +265,7 @@ function step(dt) {
     else if (game.state === STATE.DEAD) cruise = 0;
     else cruise = cruiseSpeed();
     // ease speed toward cruise (this is how boost bleeds off and crashes recover)
-    game.speed += (cruise - game.speed) * Math.min(1, dt * 1.1);
+    game.speed += (cruise - game.speed) * Math.min(1, dt * BOOST_DECAY);
 
     if (playing) {
         game.distance += game.speed * dt;


### PR DESCRIPTION
## Summary
The boost felt overwhelming, so this softens it across the board:
- **Peak speed spike: 320 → 205** — early game is now a ~2.6x surge instead of ~4x
- **FOV punch: 100° → 88°** — less disorienting fish-eye on boost
- **Shorter surge** — speed eases back to cruise faster (decay rate 1.1 → 1.7), so the boost lasts roughly half as long
- **Lighter camera shake** on the ramp hit

All values live in `config.js` (`BOOST_SPEED`, `BOOST_DECAY`, `FOV_BOOST`) and `main.js` (shake on `onBoost`).

## Test plan
- [ ] Hit a green ramp on iPhone: surge should feel punchy but controlled, not jarring
- [ ] Confirm you can still react to obstacles right after boosting
- [ ] Verify boost visuals (streaks, hue shift, BOOST flash) still read clearly

https://claude.ai/code/session_01F8nbpvX8JxrBstBkJ7UCWH

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8nbpvX8JxrBstBkJ7UCWH)_