### PR TITLE
Redesign racing ship and keep boost lanes clear

### DIFF
--- a/apps/racing/entities.js
+++ b/apps/racing/entities.js
@@ -29,6 +29,13 @@ function angDist(a, b) {
 // only uses the small ones; bigger arcs unlock with difficulty.
 const OBSTACLE_ARCS = [0.5, 0.72, 0.98, 1.28];
 
+// Keep the lane right behind a boost ramp clear of obstacles so you don't get
+// slammed into a barrier the instant you boost. An obstacle within this z-window
+// behind a ramp and within this angle of the ramp's lane gets shoved aside.
+const RAMP_CLEAR_Z = 135;       // units behind the ramp to protect
+const RAMP_CLEAR_AHEAD = 25;    // small buffer in front of the ramp too
+const RAMP_CLEAR_ANGLE = 0.75;  // how close (rad) counts as "in the boost lane"
+
 export class EntityField {
     constructor() {
         this.group = new THREE.Group();
@@ -125,6 +132,10 @@ export class EntityField {
     reset() {
         this.distance = 0;
         this.diff = 0;
+        // Ramps first, so obstacle placement can steer clear of their lanes.
+        for (let i = 0; i < this.rampCount; i++) {
+            this._placeRamp(this.ramps[i], SPAWN_Z - i * this.rampSpacing);
+        }
         // Give the player runway: nearest obstacle well down the tube, and force
         // the first couple of slots clear so the run never opens on a wall.
         for (let i = 0; i < this.obCount; i++) {
@@ -132,9 +143,6 @@ export class EntityField {
         }
         for (let i = 0; i < this.orbCount; i++) {
             this._placeOrb(this.orbs[i], -70 - i * this.orbSpacing);
-        }
-        for (let i = 0; i < this.rampCount; i++) {
-            this._placeRamp(this.ramps[i], SPAWN_Z - i * this.rampSpacing);
         }
     }
 
@@ -149,6 +157,24 @@ export class EntityField {
         return Math.floor(Math.random() * (maxIdx + 1));
     }
 
+    _setObstacleAngle(o, center) {
+        o.center = center;
+        o.mesh.rotation.z = center - o.half; // arc spans [center-half, center+half]
+    }
+
+    // If (z, center) sits in a boost ramp's protected lane, return that ramp's
+    // angle so the caller can shove the obstacle to the opposite side.
+    _rampLaneAngle(z, center) {
+        for (const r of this.ramps) {
+            const dz = r.z - z; // >0 when the obstacle is behind (arrives after) the ramp
+            if (dz > -RAMP_CLEAR_AHEAD && dz < RAMP_CLEAR_Z &&
+                angDist(center, r.angle) < RAMP_CLEAR_ANGLE) {
+                return r.angle;
+            }
+        }
+        return null;
+    }
+
     _placeObstacle(o, z, forceEmpty = false) {
         o.z = z;
         o.prevZ = z;
@@ -159,10 +185,11 @@ export class EntityField {
             const idx = this._arcIndexForDiff();
             const arc = OBSTACLE_ARCS[idx];
             o.half = arc / 2;
-            o.center = Math.random() * TWO_PI;
             o.mesh.geometry = this.obGeos[idx];
-            // torus arc spans local [0, arc]; centre it on o.center
-            o.mesh.rotation.z = o.center - arc / 2;
+            let center = Math.random() * TWO_PI;
+            const lane = this._rampLaneAngle(z, center);
+            if (lane !== null) center = lane + Math.PI + (Math.random() - 0.5) * 1.4;
+            this._setObstacleAngle(o, center);
         }
         o.mesh.position.z = z;
     }
@@ -188,6 +215,16 @@ export class EntityField {
         // so its midpoint sits at 0.31. Rotate to centre the pad on r.angle.
         r.mesh.position.set(0, 0, z);
         r.mesh.rotation.z = r.angle - 0.31;
+
+        // Shove any obstacles already sitting in this ramp's lane out of the way.
+        for (const o of this.obstacles) {
+            if (!o.active) continue;
+            const dz = z - o.z;
+            if (dz > -RAMP_CLEAR_AHEAD && dz < RAMP_CLEAR_Z &&
+                angDist(o.center, r.angle) < RAMP_CLEAR_ANGLE) {
+                this._setObstacleAngle(o, r.angle + Math.PI + (Math.random() - 0.5) * 1.4);
+            }
+        }
     }
 
     // ---------------- per-frame ----------------

--- a/apps/racing/player.js
+++ b/apps/racing/player.js
@@ -1,11 +1,17 @@
 // The player's craft. Its angular position around the tube is game state held
 // in main.js (the *world* rotates to put the craft at the bottom of the
-// screen). This module only owns the craft's *appearance*: a low-poly hull at
-// a fixed spot just inside the wall that banks into turns, pulses its thruster
-// with speed/boost, and strobes during post-crash invulnerability.
+// screen). This module only owns the craft's *appearance*: a faceted anti-grav
+// racer at a fixed spot just inside the wall that banks into turns, flares its
+// engines with speed/boost, and strobes during post-crash invulnerability.
+//
+// The hull is a low-poly octahedral dart (sharp nose forward, faceted body),
+// with a tinted glass canopy, a swept delta wing, twin engine pods, and glowing
+// neon edge trim that pops under the bloom pass — Wipeout / F-Zero styling.
 
 import * as THREE from 'three';
 import { CRAFT_RADIUS, PLAYER_Z, COL_CRAFT, COL_CRAFT_GLOW } from './config.js';
+
+const TRIM_COLOR = 0x6cf3ff;
 
 export class Player {
     constructor() {
@@ -14,50 +20,84 @@ export class Player {
 
         const hullMat = new THREE.MeshStandardMaterial({
             color: COL_CRAFT,
+            metalness: 0.9,
+            roughness: 0.32,
+            emissive: new THREE.Color(COL_CRAFT_GLOW),
+            emissiveIntensity: 0.16,
+            flatShading: true,
+        });
+        const wingMat = new THREE.MeshStandardMaterial({
+            color: 0xaab8d6,
             metalness: 0.85,
-            roughness: 0.28,
-            emissive: new THREE.Color(COL_CRAFT_GLOW),
-            emissiveIntensity: 0.22,
+            roughness: 0.42,
+            flatShading: true,
         });
-        const trimMat = new THREE.MeshStandardMaterial({
-            color: COL_CRAFT_GLOW,
-            metalness: 0.4,
-            roughness: 0.3,
-            emissive: new THREE.Color(COL_CRAFT_GLOW),
-            emissiveIntensity: 2.4,
+        const podMat = new THREE.MeshStandardMaterial({
+            color: 0x2a3038,
+            metalness: 0.8,
+            roughness: 0.5,
         });
+        const trimMat = new THREE.LineBasicMaterial({ color: TRIM_COLOR });
 
-        // Main fuselage: a stretched, tapered wedge pointing forward (-Z).
-        const body = new THREE.Mesh(new THREE.ConeGeometry(0.62, 2.6, 4), hullMat);
-        body.rotation.x = -Math.PI / 2;   // point the cone down -Z
-        body.rotation.z = Math.PI / 4;    // diamond cross-section
-        body.scale.set(1.0, 0.5, 1.0);    // flatten it
-        this.group.add(body);
+        // ---- fuselage: an octahedron stretched into a sharp dart (nose -Z) ----
+        const hullGeo = new THREE.OctahedronGeometry(1, 0);
+        hullGeo.scale(0.52, 0.34, 1.5);
+        const hull = new THREE.Mesh(hullGeo, hullMat);
+        this.group.add(hull);
+        hull.add(new THREE.LineSegments(new THREE.EdgesGeometry(hullGeo, 1), trimMat));
 
-        // Swept wings.
-        const wingGeo = new THREE.BoxGeometry(1.9, 0.08, 0.7);
-        const wing = new THREE.Mesh(wingGeo, hullMat);
-        wing.position.z = 0.55;
+        // ---- glass canopy: a low tinted dome over the front-top ----
+        const canopyGeo = new THREE.SphereGeometry(0.25, 18, 12);
+        canopyGeo.scale(1.0, 0.7, 1.8);
+        const canopy = new THREE.Mesh(canopyGeo, new THREE.MeshStandardMaterial({
+            color: 0x0a1622,
+            metalness: 0.5,
+            roughness: 0.08,
+            emissive: new THREE.Color(0x1b4a7a),
+            emissiveIntensity: 0.5,
+        }));
+        canopy.position.set(0, 0.17, -0.28);
+        this.group.add(canopy);
+
+        // ---- swept delta wing (arrowhead with a twin-tail notch) ----
+        const wingShape = new THREE.Shape();
+        wingShape.moveTo(0, -1.1);     // nose apex (forward)
+        wingShape.lineTo(1.02, 0.82);  // right tip
+        wingShape.lineTo(0.34, 0.56);  // inner right (notch)
+        wingShape.lineTo(-0.34, 0.56); // inner left (notch)
+        wingShape.lineTo(-1.02, 0.82); // left tip
+        wingShape.closePath();
+        const wingGeo = new THREE.ExtrudeGeometry(wingShape, { depth: 0.12, bevelEnabled: false });
+        wingGeo.translate(0, 0, -0.06);
+        wingGeo.rotateX(Math.PI / 2);  // lay flat: shape-y -> world -z (forward), depth -> world y
+        const wing = new THREE.Mesh(wingGeo, wingMat);
+        wing.position.set(0, -0.05, 0.18);
         this.group.add(wing);
-        const wingTrim = new THREE.Mesh(new THREE.BoxGeometry(2.0, 0.05, 0.12), trimMat);
-        wingTrim.position.set(0, 0.02, 0.9);
-        this.group.add(wingTrim);
+        wing.add(new THREE.LineSegments(new THREE.EdgesGeometry(wingGeo, 20), trimMat));
 
-        // Glowing thruster block at the tail (+Z).
-        this.thruster = new THREE.Mesh(
-            new THREE.CylinderGeometry(0.26, 0.16, 0.5, 12),
-            new THREE.MeshStandardMaterial({
-                color: 0xffffff,
-                emissive: new THREE.Color(0x49e9ff),
-                emissiveIntensity: 3.0,
-                metalness: 0.1, roughness: 0.5,
-            }),
-        );
-        this.thruster.rotation.x = Math.PI / 2;
-        this.thruster.position.z = 1.15;
-        this.group.add(this.thruster);
+        // ---- twin engine pods + glowing exhausts at the tail (+Z) ----
+        this.engineMat = new THREE.MeshStandardMaterial({
+            color: 0xffffff,
+            emissive: new THREE.Color(0x49e9ff),
+            emissiveIntensity: 2.6,
+            metalness: 0.1,
+            roughness: 0.5,
+        });
+        this.engines = [];
+        for (const sx of [-1, 1]) {
+            const pod = new THREE.Mesh(new THREE.CylinderGeometry(0.15, 0.13, 0.6, 14), podMat);
+            pod.rotation.x = Math.PI / 2;     // align length with Z
+            pod.position.set(sx * 0.34, -0.02, 1.0);
+            this.group.add(pod);
 
-        // Soft additive glow sprite trailing the engine.
+            const exhaust = new THREE.Mesh(new THREE.CylinderGeometry(0.13, 0.09, 0.22, 14), this.engineMat);
+            exhaust.rotation.x = Math.PI / 2; // local Y (height) -> world Z, so scale.y = flare
+            exhaust.position.set(sx * 0.34, -0.02, 1.32);
+            this.group.add(exhaust);
+            this.engines.push(exhaust);
+        }
+
+        // Soft additive glow sprite trailing the engines.
         const glowTex = makeGlowTexture();
         this.glow = new THREE.Sprite(new THREE.SpriteMaterial({
             map: glowTex,
@@ -66,8 +106,8 @@ export class Player {
             depthWrite: false,
             transparent: true,
         }));
-        this.glow.scale.set(3.2, 3.2, 1);
-        this.glow.position.z = 1.7;
+        this.glow.scale.set(3.0, 3.0, 1);
+        this.glow.position.set(0, -0.02, 1.7);
         this.group.add(this.glow);
 
         // A light that travels with the craft so the tunnel near it reads.
@@ -94,11 +134,12 @@ export class Player {
         const hover = alive ? 0 : Math.sin(this._bob * 1.6) * 0.18;
         this.group.position.y = -CRAFT_RADIUS + hover;
 
-        // Thruster flare scales with speed and punches on boost.
-        const flare = 0.7 + speed01 * 0.8 + boost * 1.6;
-        this.thruster.scale.set(1, flare, 1);
-        this.thruster.material.emissiveIntensity = 2.2 + boost * 5.0;
-        const glowScale = 2.6 + speed01 * 1.4 + boost * 3.2;
+        // Engine flare scales with speed and punches on boost.
+        const flare = 0.7 + speed01 * 0.9 + boost * 1.8;
+        for (const e of this.engines) e.scale.y = flare;
+        this.engineMat.emissiveIntensity = 2.2 + boost * 5.0;
+
+        const glowScale = 2.4 + speed01 * 1.4 + boost * 3.2;
         this.glow.scale.set(glowScale, glowScale, 1);
         this.glow.material.opacity = 0.55 + boost * 0.45;
         this.glow.material.color.setHex(boost > 0.25 ? 0x39ff9e : 0x49e9ff);


### PR DESCRIPTION
## Summary
Two pieces of feedback addressed:

### Ship redesign
The old craft was a rotated/flattened cone that read as an odd shape. Rebuilt it as a proper faceted anti-grav racer:
- **Octahedral dart hull** — sharp nose forward, faceted body (flat-shaded)
- **Tinted glass canopy** over the front
- **Swept delta wing** (arrowhead with a twin-tail notch)
- **Twin engine pods** with glowing exhausts that flare on boost
- **Neon edge trim** (glowing wireframe over the hull + wing) that pops under bloom

Same overall size as before, just a much cleaner silhouette.

### Fairer boost ramps
Sometimes an obstacle spawned directly behind a boost ramp in the same lane, so you'd boost straight into a barrier with no time to react. Now obstacles within a z-window behind a ramp and near its angle get shoved to the opposite side of the tunnel. Enforced from **both** ramp and obstacle placement so it holds regardless of spawn order, and the relocation happens far out in the fog so nothing visibly jumps.

Knobs: `RAMP_CLEAR_Z`, `RAMP_CLEAR_AHEAD`, `RAMP_CLEAR_ANGLE` in `entities.js`.

## Test plan
- [ ] Ship looks like a sleek racer from the chase cam; engines/trim glow correctly; banks into turns
- [ ] Boost into a ramp — no obstacle immediately ahead in the same lane
- [ ] Obstacles, orbs, and boosts still register; difficulty still ramps with distance

https://claude.ai/code/session_01F8nbpvX8JxrBstBkJ7UCWH

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8nbpvX8JxrBstBkJ7UCWH)_