### PR TITLE
Remove the on-screen BOOST text flash

### DIFF
--- a/apps/racing/hud.js
+++ b/apps/racing/hud.js
@@ -12,7 +12,6 @@ export class Hud {
         this.elHud = document.getElementById('hud');
         this.elSpeedWrap = document.getElementById('speed-wrap');
         this.elSpeedFill = document.getElementById('speed-fill');
-        this.elBoost = document.getElementById('boost-flash');
         this.elStart = document.getElementById('screen-start');
         this.elOver = document.getElementById('screen-over');
         this.elOverScore = document.getElementById('over-score');
@@ -77,12 +76,5 @@ export class Hud {
 
     setSpeed(frac) {
         this.elSpeedFill.style.width = Math.max(0, Math.min(1, frac)) * 100 + '%';
-    }
-
-    flashBoost() {
-        this.elBoost.classList.remove('go');
-        // force reflow so the animation restarts even on rapid re-trigger
-        void this.elBoost.offsetWidth;
-        this.elBoost.classList.add('go');
     }
 }

--- a/apps/racing/index.html
+++ b/apps/racing/index.html
@@ -116,30 +116,6 @@
             transition: width 0.12s linear;
         }
 
-        /* boost flash text */
-        #boost-flash {
-            position: absolute;
-            top: 40%;
-            left: 0; right: 0;
-            text-align: center;
-            font-size: 40px;
-            font-weight: 900;
-            letter-spacing: 6px;
-            color: #39ff9e;
-            text-shadow: 0 0 14px rgba(57, 255, 158, 0.95), 0 0 40px rgba(57, 255, 158, 0.6);
-            opacity: 0;
-            transform: scale(0.7);
-        }
-        #boost-flash.go {
-            animation: boostPop 0.9s ease-out forwards;
-        }
-        @keyframes boostPop {
-            0%   { opacity: 0; transform: scale(0.6); }
-            18%  { opacity: 1; transform: scale(1.12); }
-            55%  { opacity: 1; transform: scale(1.0); }
-            100% { opacity: 0; transform: scale(1.25); }
-        }
-
         /* full-screen panels (start / game over) */
         .panel {
             position: absolute;
@@ -264,7 +240,6 @@
         </div>
 
         <div id="speed-wrap"><div id="speed-fill"></div></div>
-        <div id="boost-flash">BOOST</div>
 
         <!-- start panel -->
         <div id="screen-start" class="panel">

--- a/apps/racing/main.js
+++ b/apps/racing/main.js
@@ -184,7 +184,6 @@ const api = {
     onBoost() {
         game.speed = Math.max(game.speed, BOOST_SPEED);
         game.shakeT = 0.32; game.shakeAmp = 0.4;
-        hud.flashBoost();
     },
 };
 


### PR DESCRIPTION
## Summary
Removes the redundant on-screen "BOOST" text flash. The boost is still clearly communicated by the speed surge, FOV punch, speed streaks, engine flare, hue shift, and camera shake — the text was unnecessary.

Cleaned up the `#boost-flash` element, its CSS + `boostPop` keyframes, the `flashBoost()` HUD method and its element reference, and the `onBoost` call. No change to the boost mechanic itself.

## Test plan
- [ ] Hit a green ramp — boost still feels punchy, just no "BOOST" text appears
- [ ] No console errors; HUD (score, shields, speed bar) still works

https://claude.ai/code/session_01F8nbpvX8JxrBstBkJ7UCWH

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8nbpvX8JxrBstBkJ7UCWH)_