### PR TITLE
Add Kart racer app (milestone 1: single-player driving feel)

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -340,6 +340,7 @@
         .app-cortex { background: linear-gradient(135deg, #05060a, #2d0a4a 60%, #b8246b); }
         .app-markdown { background: linear-gradient(135deg, #1e293b, #3b82f6); }
         .app-racing { background: linear-gradient(135deg, #12c2e9, #c471ed); }
+        .app-kart { background: linear-gradient(135deg, #2ecc40, #0074d9); }
     </style>
 </head>
 <body>
@@ -455,6 +456,11 @@
         <a href="feedback/" class="app-link">
             <div class="app-icon app-feedback">💬</div>
             <span class="app-name">Feedback</span>
+        </a>
+
+        <a href="kart/" class="app-link">
+            <div class="app-icon app-kart">🏁</div>
+            <span class="app-name">Kart</span>
         </a>
 
         <a href="kv/" class="app-link">

--- a/apps/kart/config.js
+++ b/apps/kart/config.js
@@ -1,0 +1,118 @@
+// Central tuning for the kart racer. EVERY feel-related number lives here so the
+// driving model can be tweaked in one place. The simulation reads `TUNING`; the
+// renderer reads `TUNING` + `COLORS`. Nothing in here imports anything — it is
+// plain data so it can be shared with a future authoritative host.
+//
+// Units: distances are "world units" (roughly metres), speeds are units/second,
+// turn rates are radians/second, times are seconds. The plane is XZ with +Y up.
+//
+// Coordinate convention used by the simulation:
+//   heading 0  -> kart faces +Z. forward = (sin h, cos h), right = (cos h, -sin h)
+//   positive `steer` (and positive heading delta) turns the kart to its right.
+
+export const TUNING = {
+    // ---------------------------------------------------------------- speed
+    // Exponential eases: `vForward += (target - vForward) * rate * dt`. A higher
+    // rate snaps harder. This doubles as the acceleration curve (fast off the
+    // line, tapering as you approach top speed) and the boost bleed-off.
+    topSpeed: 34,            // normal forward top speed (units/s)
+    accel: 2.4,              // ramp-up rate toward target while accelerating
+    engineBrake: 1.7,        // ramp-down rate when above target (how boost bleeds off)
+    brakeStrength: 3.6,      // ramp rate toward 0 / reverse while braking
+    coastDrag: 0.7,          // ramp toward 0 when neither accelerating nor braking
+    reverseSpeed: 9,         // top reverse speed when holding brake from a stop
+
+    // ---------------------------------------------------------------- steering
+    // Turn authority scales with speed so the kart is sluggish when slow and
+    // responsive at pace, and CANNOT pivot on the spot.
+    maxTurnRate: 2.7,        // rad/s at full steer + full authority
+    steerSpeedGain: 3.4,     // how fast authority climbs with speed (higher = reaches full sooner)
+    turnTopSpeedFalloff: 0.18, // fraction of turn authority shed at very top speed (twitch guard)
+    steerEase: 9.0,          // smoothing of raw steer input toward the target (-1..1)
+
+    // ---------------------------------------------------------------- grip / slide
+    // Lateral (sideways) velocity is bled off each step: `vLat += (0-vLat)*grip*dt`.
+    // High grip = planted; low grip = the kart slides, which is what makes a drift
+    // carve a wide arc.
+    normalGrip: 9.0,
+    driftGrip: 2.4,
+
+    // ---------------------------------------------------------------- drift
+    driftMinSpeed: 13,        // must be going at least this fast to start a drift
+    driftSteerThreshold: 0.18,// must be turning at least this hard to start a drift
+    // While drifting, yaw rate = baseTurnRate * (a multiplier between min and max,
+    // chosen by how hard the player steers INTO the drift). Countersteering widens
+    // the arc (min); steering hard inward tightens it (max).
+    driftYawMin: 0.55,
+    driftYawMax: 1.20,
+    // Seconds of continuous drift needed to reach each charge stage.
+    // [stage1 (blue), stage2 (orange), stage3 (purple)]
+    driftStageTimes: [0.55, 1.30, 2.20],
+
+    // ---------------------------------------------------------------- boost
+    // Indexed by the highest stage reached when drift is released (0 = released
+    // before stage 1 -> nothing). Boost adds a decaying bonus on top of topSpeed.
+    boostStageBonus: [0, 8, 13, 19],     // extra units/s above top speed
+    boostStageDuration: [0, 0.75, 1.15, 1.6], // seconds the bonus takes to decay to 0
+
+    // ---------------------------------------------------------------- off-track
+    offTrackMaxSpeed: 14,    // hard speed ceiling on the grass
+    offTrackDrag: 4.5,       // strong decel toward the ceiling when off-track
+    offTrackGrip: 5.5,       // grass is a little loose underfoot
+
+    // ---------------------------------------------------------------- camera
+    camDistance: 7.4,        // how far behind the kart the camera sits
+    camHeight: 3.3,          // camera height above the ground
+    camLookAhead: 7.0,       // look target distance ahead of the kart
+    camLookHeight: 0.9,      // look slightly down toward the kart
+    camFollowLag: 6.5,       // position follow rate (higher = tighter, less lag)
+    camFovBase: 72,
+    camFovBoost: 82,         // FOV widens on boost to sell speed
+    camFovLag: 4.0,
+    camBoostPullback: 1.6,   // extra distance the camera drops back at full boost
+
+    // ---------------------------------------------------------------- visual feel
+    kartBodyRoll: 0.45,      // radians the body leans into a drift at full slide
+    kartBoostSquash: 0.12,   // body stretch on boost (0 = none)
+
+    // ---------------------------------------------------------------- race
+    totalLaps: 3,
+    countdownSeconds: 3,
+};
+
+// Track geometry. Centerline control points (closed Catmull-Rom loop) and the
+// half-width of the drivable ribbon. Two tight-ish corners and a couple of
+// sweepers so drift pays off. Kept here (not in render) because the simulation
+// needs the same geometry for the on-track test and lap progress.
+export const TRACK = {
+    halfWidth: 6.5,
+    // [x, z] control points, traversed in order. Closed loop.
+    controlPoints: [
+        [0, -52],
+        [42, -46],
+        [58, -8],
+        [30, 12],     // chicane-ish kink
+        [48, 42],
+        [8, 58],
+        [-34, 48],
+        [-54, 10],
+        [-36, -22],   // hairpin-ish
+        [-12, -42],
+    ],
+    samplesPerSegment: 26,   // spline resolution for the on-track test + mesh
+};
+
+export const COLORS = {
+    sky: 0x9fd3ff,
+    fog: 0xbfe0ff,
+    grass: 0x3f7a4a,
+    grassDark: 0x356b40,
+    track: 0x3a3d46,
+    trackEdge: 0xf4f4f8,
+    centerLine: 0xf4d03f,
+    startLine: 0xffffff,
+    kartBody: 0xff5a4d,
+    kartAccent: 0x1a1a22,
+    wheel: 0x14141a,
+    driftStage: [0x39d0ff, 0xff9f1c, 0xb06bff], // blue, orange, purple sparks/glow
+};

--- a/apps/kart/hud.js
+++ b/apps/kart/hud.js
@@ -1,0 +1,96 @@
+// DOM HUD overlay: speed, drift-charge meter (staged colours), lap counter and
+// times, the 3-2-1-GO countdown, the start screen, and the results panel. Kept
+// as HTML (not in-canvas text) so it stays crisp on retina and is easy to style.
+
+import { COLORS, TUNING as T } from './config.js';
+
+const STAGE_CSS = ['#39d0ff', '#ff9f1c', '#b06bff'];
+
+export class Hud {
+    constructor() {
+        this.elSpeed = document.getElementById('speed-val');
+        this.elDriftFill = document.getElementById('drift-fill');
+        this.elDriftWrap = document.getElementById('drift-wrap');
+        this.elLap = document.getElementById('lap-val');
+        this.elLapTime = document.getElementById('laptime-val');
+        this.elCountdown = document.getElementById('countdown');
+        this.elStart = document.getElementById('screen-start');
+        this.elResults = document.getElementById('screen-results');
+        this.elResultsBody = document.getElementById('results-body');
+        this.elHud = document.getElementById('hud');
+    }
+
+    showStart() {
+        this.elStart.classList.remove('hidden');
+        this.elResults.classList.add('hidden');
+        this.elHud.classList.remove('live');
+        this.elCountdown.classList.add('hidden');
+    }
+
+    showPlaying() {
+        this.elStart.classList.add('hidden');
+        this.elResults.classList.add('hidden');
+        this.elHud.classList.add('live');
+    }
+
+    setCountdown(text) {
+        if (text === null) {
+            this.elCountdown.classList.add('hidden');
+            return;
+        }
+        this.elCountdown.classList.remove('hidden');
+        this.elCountdown.textContent = text;
+        // restart the pop animation
+        this.elCountdown.style.animation = 'none';
+        void this.elCountdown.offsetWidth;
+        this.elCountdown.style.animation = '';
+    }
+
+    setSpeed(speed) {
+        this.elSpeed.textContent = Math.round(Math.max(0, speed));
+    }
+
+    // charge: 0..1 within the current path to max. stage: 0..3. boostActive: bool
+    setDrift(charge, stage, boostActive) {
+        this.elDriftFill.style.width = Math.max(0, Math.min(1, charge)) * 100 + '%';
+        if (stage > 0) {
+            const c = STAGE_CSS[Math.min(stage, 3) - 1];
+            this.elDriftFill.style.background = c;
+            this.elDriftWrap.style.boxShadow = `0 0 12px ${c}`;
+        } else if (boostActive) {
+            this.elDriftWrap.style.boxShadow = '0 0 14px #fff';
+        } else {
+            this.elDriftFill.style.background = '#7fa8c9';
+            this.elDriftWrap.style.boxShadow = 'none';
+        }
+    }
+
+    setLap(current, total) {
+        this.elLap.textContent = `${Math.min(current, total)}/${total}`;
+    }
+
+    setLapTime(seconds) {
+        this.elLapTime.textContent = formatTime(seconds);
+    }
+
+    showResults(lapTimes, total) {
+        this.elHud.classList.remove('live');
+        this.elResults.classList.remove('hidden');
+        let rows = '';
+        lapTimes.forEach((t, i) => {
+            const best = t === Math.min(...lapTimes);
+            rows += `<div class="result-row${best ? ' best' : ''}">`
+                + `<span>Lap ${i + 1}</span><span>${formatTime(t)}</span></div>`;
+        });
+        rows += `<div class="result-row total"><span>Total</span><span>${formatTime(total)}</span></div>`;
+        this.elResultsBody.innerHTML = rows;
+    }
+}
+
+export function formatTime(seconds) {
+    if (!isFinite(seconds)) return '--:--';
+    const m = Math.floor(seconds / 60);
+    const s = Math.floor(seconds % 60);
+    const ms = Math.floor((seconds * 1000) % 1000);
+    return `${m}:${String(s).padStart(2, '0')}.${String(ms).padStart(3, '0')}`;
+}

--- a/apps/kart/index.html
+++ b/apps/kart/index.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="theme-color" content="#1a1a2e">
+    <link rel="apple-touch-icon" href="../icon.png">
+    <title>Kart</title>
+    <style>
+        html, body {
+            margin: 0; padding: 0; width: 100%; height: 100%;
+            overflow: hidden; background: #1a1a2e; color: #f4f8ff;
+            font-family: 'Helvetica Neue', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+            -webkit-tap-highlight-color: transparent;
+            -webkit-user-select: none; user-select: none;
+            touch-action: none; overscroll-behavior: none;
+        }
+        canvas {
+            display: block; position: fixed; inset: 0;
+            width: 100vw; height: 100vh;
+        }
+
+        #ui {
+            position: fixed; inset: 0; z-index: 5; pointer-events: none;
+            padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+        }
+
+        /* ---- top HUD bar ---- */
+        #hud {
+            position: absolute;
+            top: calc(env(safe-area-inset-top) + 10px);
+            left: calc(env(safe-area-inset-left) + 14px);
+            right: calc(env(safe-area-inset-right) + 14px);
+            display: flex; justify-content: space-between; align-items: flex-start;
+            opacity: 0; transition: opacity 0.3s ease;
+        }
+        #hud.live { opacity: 1; }
+        .hud-box {
+            background: rgba(10, 12, 24, 0.5);
+            border-radius: 10px; padding: 6px 12px; min-width: 70px;
+            text-align: center; backdrop-filter: blur(4px);
+        }
+        .hud-label {
+            font-size: 10px; letter-spacing: 2px; text-transform: uppercase;
+            opacity: 0.6; margin-bottom: 2px;
+        }
+        .hud-big {
+            font-size: 24px; font-weight: 800; line-height: 1;
+            font-variant-numeric: tabular-nums;
+        }
+
+        /* ---- drift charge meter ---- */
+        #drift-wrap {
+            position: absolute;
+            top: calc(env(safe-area-inset-top) + 64px);
+            left: 50%; transform: translateX(-50%);
+            width: 180px; height: 8px; border-radius: 5px;
+            background: rgba(10, 12, 24, 0.5); overflow: hidden;
+            opacity: 0; transition: opacity 0.3s ease, box-shadow 0.15s ease;
+        }
+        #hud.live ~ #drift-wrap, #drift-wrap.live { opacity: 1; }
+        #drift-fill {
+            height: 100%; width: 0%; border-radius: 5px; background: #7fa8c9;
+            transition: width 0.08s linear, background 0.15s ease;
+        }
+
+        /* ---- countdown ---- */
+        #countdown {
+            position: absolute; inset: 0;
+            display: flex; align-items: center; justify-content: center;
+            font-size: 120px; font-weight: 900; color: #fff;
+            text-shadow: 0 0 30px rgba(0,0,0,0.6);
+            animation: pop 0.4s ease;
+        }
+        #countdown.hidden { display: none; }
+        @keyframes pop {
+            0% { transform: scale(0.4); opacity: 0; }
+            40% { transform: scale(1.15); opacity: 1; }
+            100% { transform: scale(1); opacity: 1; }
+        }
+
+        /* ---- touch controls ---- */
+        #touch { position: absolute; inset: 0; pointer-events: none; }
+        #steer-zone {
+            position: absolute; left: 0; bottom: 0;
+            width: 42%; height: 60%;
+            pointer-events: auto;
+            display: flex; align-items: flex-end; justify-content: center;
+            padding-bottom: calc(env(safe-area-inset-bottom) + 18px);
+        }
+        .steer-hint {
+            font-size: 13px; letter-spacing: 3px; opacity: 0.35;
+            text-transform: uppercase;
+        }
+        #btn-cluster {
+            position: absolute;
+            right: calc(env(safe-area-inset-right) + 22px);
+            bottom: calc(env(safe-area-inset-bottom) + 22px);
+            display: flex; align-items: flex-end; gap: 14px;
+        }
+        .ctl-btn {
+            pointer-events: auto;
+            display: flex; align-items: center; justify-content: center;
+            border-radius: 50%;
+            font-size: 13px; font-weight: 800; letter-spacing: 1px;
+            text-transform: uppercase;
+            background: rgba(20, 24, 44, 0.55);
+            border: 2px solid rgba(255,255,255,0.25);
+            backdrop-filter: blur(4px);
+            transition: transform 0.06s ease, background 0.06s ease;
+            width: 78px; height: 78px;
+        }
+        .ctl-btn.accel {
+            width: 104px; height: 104px;
+            background: rgba(46, 204, 64, 0.35);
+            border-color: rgba(46, 204, 64, 0.7);
+        }
+        .ctl-btn.small { width: 66px; height: 66px; font-size: 11px; }
+        #btn-drift {
+            background: rgba(57, 208, 255, 0.32);
+            border-color: rgba(57, 208, 255, 0.7);
+        }
+        .ctl-btn.pressed { transform: scale(0.9); background: rgba(255,255,255,0.45); }
+
+        /* ---- panels ---- */
+        .panel {
+            position: absolute; inset: 0; pointer-events: auto;
+            display: flex; flex-direction: column; align-items: center; justify-content: center;
+            text-align: center; gap: 6px; padding: 24px;
+            background: radial-gradient(ellipse at center, rgba(26,26,46,0.5) 0%, rgba(15,15,30,0.9) 80%);
+        }
+        .panel.hidden { display: none; }
+        .title {
+            font-size: 76px; font-weight: 900; letter-spacing: 12px; margin: 0 0 0 12px;
+            background: linear-gradient(180deg, #fff 0%, #6db3ff 60%, #c471ed 100%);
+            -webkit-background-clip: text; background-clip: text; color: transparent;
+            filter: drop-shadow(0 0 16px rgba(86,180,255,0.5));
+        }
+        .subtitle {
+            font-size: 12px; letter-spacing: 4px; text-transform: uppercase; opacity: 0.7;
+        }
+        .cta {
+            margin-top: 24px; font-size: 16px; font-weight: 700; letter-spacing: 3px;
+            text-transform: uppercase; color: #f4f8ff;
+            border: 1.5px solid rgba(57,208,255,0.7); border-radius: 999px;
+            padding: 13px 32px; box-shadow: 0 0 16px rgba(57,208,255,0.4);
+            animation: pulse 1.8s ease-in-out infinite;
+        }
+        @keyframes pulse {
+            0%,100% { box-shadow: 0 0 12px rgba(57,208,255,0.35); }
+            50% { box-shadow: 0 0 24px rgba(57,208,255,0.7); }
+        }
+        .hint {
+            font-size: 12px; line-height: 1.7; letter-spacing: 1px; opacity: 0.6;
+            max-width: 340px; margin-top: 22px;
+        }
+        .results-title {
+            font-size: 34px; font-weight: 900; letter-spacing: 8px; color: #39d0ff;
+            text-shadow: 0 0 16px rgba(57,208,255,0.6); margin-bottom: 10px;
+        }
+        #results-body {
+            display: flex; flex-direction: column; gap: 6px;
+            font-variant-numeric: tabular-nums; min-width: 220px;
+        }
+        .result-row {
+            display: flex; justify-content: space-between; gap: 30px;
+            font-size: 17px; padding: 4px 0; opacity: 0.85;
+        }
+        .result-row.best { color: #2ecc40; opacity: 1; }
+        .result-row.total {
+            border-top: 1px solid rgba(255,255,255,0.2); margin-top: 6px;
+            padding-top: 10px; font-weight: 800; font-size: 20px; opacity: 1;
+        }
+
+        /* ---- rotate-to-landscape overlay ---- */
+        #rotate {
+            position: fixed; inset: 0; z-index: 30; display: none;
+            align-items: center; justify-content: center; text-align: center;
+            background: #1a1a2e; font-size: 18px; letter-spacing: 2px; padding: 30px;
+        }
+        @media (orientation: portrait) {
+            #rotate { display: flex; }
+        }
+
+        /* hide touch controls where there's a real pointer (desktop dev) */
+        @media (hover: hover) and (pointer: fine) {
+            #touch { display: none; }
+        }
+
+        #err {
+            position: fixed; top: 0; left: 0; right: 0; z-index: 40;
+            padding: env(safe-area-inset-top, 12px) 16px 16px;
+            font: 13px/1.4 -apple-system, monospace; color: #ff8aa8;
+            background: rgba(8,4,12,0.92); border-bottom: 1px solid #5a1240;
+            white-space: pre-wrap; display: none;
+        }
+    </style>
+    <!-- importmap polyfill for iOS Safari < 16.4 -->
+    <script async src="https://ga.jspm.io/npm:es-module-shims@1.10.0/dist/es-module-shims.js"></script>
+    <script type="importmap">
+    {
+        "imports": {
+            "three": "https://unpkg.com/three@0.161.0/build/three.module.js",
+            "three/addons/": "https://unpkg.com/three@0.161.0/examples/jsm/"
+        }
+    }
+    </script>
+</head>
+<body>
+    <canvas id="game"></canvas>
+
+    <div id="ui">
+        <!-- top HUD -->
+        <div id="hud">
+            <div class="hud-box"><div class="hud-label">Speed</div><div id="speed-val" class="hud-big">0</div></div>
+            <div class="hud-box"><div class="hud-label">Lap</div><div id="lap-val" class="hud-big">1/3</div></div>
+            <div class="hud-box"><div class="hud-label">Time</div><div id="laptime-val" class="hud-big">0:00.000</div></div>
+        </div>
+
+        <div id="drift-wrap"><div id="drift-fill"></div></div>
+
+        <div id="countdown" class="hidden">3</div>
+
+        <!-- touch controls -->
+        <div id="touch">
+            <div id="steer-zone"><span class="steer-hint">&#9664; steer &#9654;</span></div>
+            <div id="btn-cluster">
+                <div id="btn-brake" class="ctl-btn small">Brake</div>
+                <div id="btn-drift" class="ctl-btn">Drift</div>
+                <div id="btn-accel" class="ctl-btn accel">Gas</div>
+            </div>
+        </div>
+
+        <!-- start screen -->
+        <div id="screen-start" class="panel">
+            <h1 class="title">KART</h1>
+            <div class="subtitle">milestone 1 &middot; driving feel</div>
+            <div class="cta" id="btn-start">Tap to start</div>
+            <div class="hint" id="start-hint">
+                Hold <b>Gas</b>, steer with your left thumb, and hold <b>Drift</b>
+                while turning to charge a boost &mdash; release for a speed burst.<br>
+                Desktop: arrows / WASD to drive, <b>Space</b> to drift.
+            </div>
+        </div>
+
+        <!-- results -->
+        <div id="screen-results" class="panel hidden">
+            <div class="results-title">FINISH</div>
+            <div id="results-body"></div>
+            <div class="cta" id="btn-restart">Race again</div>
+        </div>
+    </div>
+
+    <div id="rotate">Rotate your device to landscape to race &#128260;</div>
+    <div id="err"></div>
+
+    <script type="module" src="./main.js"></script>
+    <script>
+        // Surface load-time errors before main.js installs its own handler.
+        window.addEventListener('error', function (ev) {
+            var el = document.getElementById('err');
+            if (!el) return;
+            el.style.display = 'block';
+            el.textContent = 'kart error: ' + (ev.message || ev.error || 'unknown')
+                + '\nat ' + (ev.filename || '?') + ':' + (ev.lineno || '?');
+        }, true);
+    </script>
+</body>
+</html>

--- a/apps/kart/input/input.js
+++ b/apps/kart/input/input.js
@@ -1,0 +1,113 @@
+// Input device layer. The ONLY job here is to turn keyboards and touches into
+// the device-agnostic input struct the simulation consumes:
+//   { steer: -1..1, accelerate: bool, brake: bool, drift: bool }
+//
+// This file is intentionally the only place that knows about pointers and keys.
+// The simulation never sees any of it — which is what lets the sim run remotely
+// later. Touch layout (landscape): left thumb = analog steering drag zone,
+// right thumb = accelerate / drift / brake buttons.
+
+const STEER_TRAVEL = 70; // px of horizontal drag from touch-down for full lock
+
+export class Input {
+    constructor(els) {
+        // touch state
+        this._touchSteer = 0;
+        this._steerId = null;
+        this._steerStartX = 0;
+        this._accel = false;
+        this._brake = false;
+        this._drift = false;
+
+        // keyboard state (digital)
+        this._keyLeft = false;
+        this._keyRight = false;
+        this._keyAccel = false;
+        this._keyBrake = false;
+        this._keyDrift = false;
+        this._usingKeyboard = false;
+
+        this._installKeyboard();
+        if (els) this._installTouch(els);
+    }
+
+    _installKeyboard() {
+        const set = (e, down) => {
+            switch (e.key) {
+                case 'ArrowLeft': case 'a': case 'A': this._keyLeft = down; break;
+                case 'ArrowRight': case 'd': case 'D': this._keyRight = down; break;
+                case 'ArrowUp': case 'w': case 'W': this._keyAccel = down; break;
+                case 'ArrowDown': case 's': case 'S': this._keyBrake = down; break;
+                case ' ': case 'Shift': this._keyDrift = down; break;
+                default: return;
+            }
+            this._usingKeyboard = true;
+            e.preventDefault();
+        };
+        window.addEventListener('keydown', (e) => set(e, true));
+        window.addEventListener('keyup', (e) => set(e, false));
+    }
+
+    _installTouch(els) {
+        const { steerZone, accel, brake, drift } = els;
+
+        // analog steering: drag horizontally from wherever the thumb lands
+        steerZone.addEventListener('pointerdown', (e) => {
+            this._steerId = e.pointerId;
+            this._steerStartX = e.clientX;
+            this._touchSteer = 0;
+            steerZone.setPointerCapture(e.pointerId);
+            e.preventDefault();
+        });
+        steerZone.addEventListener('pointermove', (e) => {
+            if (e.pointerId !== this._steerId) return;
+            const dx = e.clientX - this._steerStartX;
+            this._touchSteer = clamp(dx / STEER_TRAVEL, -1, 1);
+            e.preventDefault();
+        });
+        const endSteer = (e) => {
+            if (e.pointerId !== this._steerId) return;
+            this._steerId = null;
+            this._touchSteer = 0;
+        };
+        steerZone.addEventListener('pointerup', endSteer);
+        steerZone.addEventListener('pointercancel', endSteer);
+
+        // momentary buttons
+        bindButton(accel, (v) => { this._accel = v; });
+        bindButton(brake, (v) => { this._brake = v; });
+        bindButton(drift, (v) => { this._drift = v; });
+    }
+
+    // Device-agnostic snapshot handed to the simulation.
+    sample() {
+        let steer = this._touchSteer;
+        let accelerate = this._accel;
+        let brake = this._brake;
+        let drift = this._drift;
+
+        // keyboard overlays (so desktop testing works even with touch els present)
+        if (this._keyLeft) steer = -1;
+        if (this._keyRight) steer = 1;
+        if (this._keyAccel) accelerate = true;
+        if (this._keyBrake) brake = true;
+        if (this._keyDrift) drift = true;
+
+        if (Math.abs(steer) < 0.04) steer = 0; // tiny deadzone
+        return { steer, accelerate, brake, drift };
+    }
+}
+
+function bindButton(el, set) {
+    if (!el) return;
+    const down = (e) => { set(true); el.classList.add('pressed'); el.setPointerCapture?.(e.pointerId); e.preventDefault(); };
+    const up = (e) => { set(false); el.classList.remove('pressed'); e.preventDefault(); };
+    el.addEventListener('pointerdown', down);
+    el.addEventListener('pointerup', up);
+    el.addEventListener('pointercancel', up);
+    el.addEventListener('pointerleave', up);
+}
+
+function clamp(v, lo, hi) {
+    return v < lo ? lo : v > hi ? hi : v;
+}

--- a/apps/kart/main.js
+++ b/apps/kart/main.js
@@ -1,0 +1,267 @@
+// Kart racer — Milestone 1 entry point.
+//
+// Architecture (built for multiplayer later, single-player now):
+//   - FIXED-TIMESTEP simulation at 60Hz, fully decoupled from rendering. The
+//     renderer interpolates between the last two sim states. This is the part
+//     multiplayer prediction/reconciliation will depend on, so it is in place
+//     from day one even though there's only one local kart.
+//   - The kart sim (simulation/kart.js) is a PURE (state, input) -> state
+//     function with no rendering/input-device code, so it can run on a remote
+//     host unchanged.
+//   - render/* is all Three.js; input/* is the only place that knows about
+//     keys/touches. main.js wires them together and owns the race/lap rules.
+
+import { stepKart, createKartState } from './simulation/kart.js';
+import { createTrack } from './simulation/track.js';
+import { Stage } from './render/scene.js';
+import { buildTrackView } from './render/trackView.js';
+import { KartView } from './render/kartView.js';
+import { ChaseCamera } from './render/chaseCamera.js';
+import { Input } from './input/input.js';
+import { Hud } from './hud.js';
+import { TUNING as T } from './config.js';
+
+const STEP = 1 / 60;
+const MAX_BOOST_BONUS = Math.max(...T.boostStageBonus);
+const SLIP_REF = 12;            // lateral speed that reads as "full slide" (visual only)
+const SPEED_DISPLAY_SCALE = 3;  // raw units/s -> punchier HUD number (display only)
+
+function showFatal(msg) {
+    const el = document.getElementById('err');
+    if (el) { el.style.display = 'block'; el.textContent = 'kart error: ' + msg; }
+    console.error('[kart]', msg);
+}
+
+function detectTier() {
+    const ua = navigator.userAgent || '';
+    const isMobile = /iPhone|iPad|iPod|Android/.test(ua);
+    const dpr = window.devicePixelRatio || 1;
+    const cores = navigator.hardwareConcurrency || 4;
+    if (isMobile || cores < 4) {
+        return { pixelRatio: Math.min(dpr, 1.5), antialias: false };
+    }
+    return { pixelRatio: Math.min(dpr, 2), antialias: true };
+}
+
+// ---------------------------------------------------------------- boot
+const canvas = document.getElementById('game');
+let stage, kartView, chase, hud, input, track;
+try {
+    track = createTrack();
+    stage = new Stage(canvas, detectTier());
+    stage.scene.add(buildTrackView(track));
+    kartView = new KartView();
+    stage.scene.add(kartView.group);
+    chase = new ChaseCamera(stage.camera);
+    hud = new Hud();
+    input = new Input({
+        steerZone: document.getElementById('steer-zone'),
+        accel: document.getElementById('btn-accel'),
+        brake: document.getElementById('btn-brake'),
+        drift: document.getElementById('btn-drift'),
+    });
+} catch (e) {
+    showFatal((e && e.message) ? e.message : String(e));
+    throw e;
+}
+
+// ---------------------------------------------------------------- resize
+function resize() {
+    const w = window.innerWidth, h = window.innerHeight;
+    if (w === 0 || h === 0) { requestAnimationFrame(resize); return; }
+    stage.setSize(w, h);
+}
+window.addEventListener('resize', resize);
+resize();
+
+// ---------------------------------------------------------------- game state
+const STATE = { READY: 0, COUNTDOWN: 1, RACING: 2, FINISHED: 3 };
+const game = {
+    state: STATE.READY,
+    prev: null,        // sim state at start of the last fixed step (for interpolation)
+    curr: null,        // sim state after the last fixed step
+    countdown: 0,
+    raceTime: 0,
+    lapStart: 0,
+    lapsCompleted: 0,
+    lapTimes: [],
+    prevProgress: 0,
+    passedHalf: false,
+};
+
+function freshSim() {
+    const s = createKartState(track.startPose);
+    game.prev = s;
+    game.curr = { ...s };
+}
+
+function resetRace() {
+    freshSim();
+    game.raceTime = 0;
+    game.lapStart = 0;
+    game.lapsCompleted = 0;
+    game.lapTimes = [];
+    game.prevProgress = track.progressAt(game.curr.x, game.curr.z);
+    game.passedHalf = false;
+    chase.reset();
+    hud.setLap(1, T.totalLaps);
+    hud.setLapTime(0);
+    hud.setSpeed(0);
+    hud.setDrift(0, 0, false);
+}
+
+// ---------------------------------------------------------------- wake lock
+let wakeLock = null;
+async function requestWakeLock() {
+    try {
+        if ('wakeLock' in navigator) wakeLock = await navigator.wakeLock.request('screen');
+    } catch (e) { /* ignore */ }
+}
+function releaseWakeLock() {
+    try { wakeLock && wakeLock.release(); } catch (e) { /* ignore */ }
+    wakeLock = null;
+}
+document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible' && game.state === STATE.RACING) requestWakeLock();
+});
+
+// ---------------------------------------------------------------- start / restart
+function startRace() {
+    resetRace();
+    game.state = STATE.COUNTDOWN;
+    game.countdown = T.countdownSeconds;
+    hud.showPlaying();
+    hud.setCountdown(String(T.countdownSeconds));
+    requestWakeLock();
+}
+
+document.getElementById('btn-start').addEventListener('click', startRace);
+document.getElementById('btn-restart').addEventListener('click', startRace);
+
+// ---------------------------------------------------------------- lap tracking
+function trackLaps() {
+    const p = track.progressAt(game.curr.x, game.curr.z);
+    if (p > 0.45 && p < 0.55) game.passedHalf = true;
+    // forward crossing of the start line (high progress -> low progress)
+    if (game.passedHalf && game.prevProgress > 0.7 && p < 0.3) {
+        const lapTime = game.raceTime - game.lapStart;
+        game.lapTimes.push(lapTime);
+        game.lapStart = game.raceTime;
+        game.lapsCompleted++;
+        game.passedHalf = false;
+        if (game.lapsCompleted >= T.totalLaps) {
+            finishRace();
+        } else {
+            hud.setLap(game.lapsCompleted + 1, T.totalLaps);
+        }
+    }
+    game.prevProgress = p;
+}
+
+function finishRace() {
+    game.state = STATE.FINISHED;
+    releaseWakeLock();
+    hud.showResults(game.lapTimes, game.lapTimes.reduce((a, b) => a + b, 0));
+}
+
+// ---------------------------------------------------------------- fixed-step sim
+const NEUTRAL = { steer: 0, accelerate: false, brake: false, drift: false };
+
+function simStep() {
+    const cmd = game.state === STATE.RACING ? input.sample() : NEUTRAL;
+    game.prev = game.curr;
+    game.curr = stepKart(game.curr, cmd, STEP, track);
+    if (game.state === STATE.RACING) {
+        game.raceTime += STEP;
+        trackLaps();
+    }
+}
+
+// ---------------------------------------------------------------- render helpers
+function angleLerp(a, b, t) {
+    let d = b - a;
+    while (d > Math.PI) d -= 2 * Math.PI;
+    while (d < -Math.PI) d += 2 * Math.PI;
+    return a + d * t;
+}
+
+function interpolated(alpha) {
+    const p = game.prev, c = game.curr;
+    // feel scalars come from the authoritative latest state
+    const fx = Math.sin(c.heading), fz = Math.cos(c.heading);
+    const rx = Math.cos(c.heading), rz = -Math.sin(c.heading);
+    const vLat = c.vx * rx + c.vz * rz;
+    const boost = clamp((c.forwardSpeed - T.topSpeed) / (MAX_BOOST_BONUS || 1), 0, 1);
+    return {
+        x: p.x + (c.x - p.x) * alpha,
+        z: p.z + (c.z - p.z) * alpha,
+        heading: angleLerp(p.heading, c.heading, alpha),
+        slip: clamp(vLat / SLIP_REF, -1, 1),
+        boost,
+        driftStage: c.driftStage,
+        boostStage: c.boostStage,
+    };
+}
+
+// ---------------------------------------------------------------- main loop
+let last = performance.now();
+let acc = 0;
+let loopFatal = false;
+
+function frame(now) {
+    if (loopFatal) return;
+    requestAnimationFrame(frame);
+    let dt = (now - last) / 1000;
+    last = now;
+    if (dt > 0.25) dt = 0.25; // avoid spiral of death after a tab stall
+
+    try {
+        // countdown advances in real time
+        if (game.state === STATE.COUNTDOWN) {
+            game.countdown -= dt;
+            if (game.countdown > 0) {
+                hud.setCountdown(String(Math.ceil(game.countdown)));
+            } else if (game.countdown > -0.7) {
+                hud.setCountdown('GO!');
+            } else {
+                hud.setCountdown(null);
+                game.state = STATE.RACING;
+                game.lapStart = game.raceTime;
+            }
+        }
+
+        // fixed-timestep simulation
+        acc += dt;
+        let steps = 0;
+        while (acc >= STEP && steps < 5) { simStep(); acc -= STEP; steps++; }
+        if (steps === 5) acc = 0; // dropped frames: don't let the backlog explode
+
+        // render with interpolation
+        const r = interpolated(acc / STEP);
+        kartView.update(r);
+        chase.update(r, r.boost, dt);
+
+        // HUD (live values from latest sim state)
+        if (game.state === STATE.RACING) {
+            hud.setSpeed(Math.max(0, game.curr.forwardSpeed) * SPEED_DISPLAY_SCALE);
+            const stage = game.curr.driftStage;
+            const charge = game.curr.driftCharge / T.driftStageTimes[T.driftStageTimes.length - 1];
+            hud.setDrift(charge, stage, game.curr.boostTimer > 0);
+            hud.setLapTime(game.raceTime - game.lapStart);
+        }
+
+        stage.render();
+    } catch (e) {
+        loopFatal = true;
+        showFatal('frame: ' + ((e && e.message) ? e.message : String(e)));
+        throw e;
+    }
+}
+
+function clamp(v, lo, hi) { return v < lo ? lo : v > hi ? hi : v; }
+
+// initial state
+freshSim();
+game.prevProgress = track.progressAt(game.curr.x, game.curr.z);
+hud.showStart();
+requestAnimationFrame(frame);

--- a/apps/kart/render/chaseCamera.js
+++ b/apps/kart/render/chaseCamera.js
@@ -1,0 +1,61 @@
+// Chase camera: sits behind the kart, follows with a little lag, looks slightly
+// down, and on boost widens its FOV and pulls back a touch to sell speed. It is
+// driven off the interpolated render state, and smooths in real (frame) time, so
+// it never feeds back into the simulation.
+
+import * as THREE from 'three';
+import { TUNING as T } from '../config.js';
+
+export class ChaseCamera {
+    constructor(camera) {
+        this.camera = camera;
+        this._pos = new THREE.Vector3();
+        this._look = new THREE.Vector3();
+        this._fov = T.camFovBase;
+        this._init = false;
+    }
+
+    // r: interpolated render state. boost: 0..1. dt: real seconds since last frame.
+    update(r, boost, dt) {
+        const fx = Math.sin(r.heading), fz = Math.cos(r.heading);
+        const dist = T.camDistance + T.camBoostPullback * boost;
+
+        // desired camera position: behind + above the kart
+        const dx = r.x - fx * dist;
+        const dz = r.z - fz * dist;
+        const dy = T.camHeight;
+
+        // desired look target: ahead of and slightly above the kart
+        const lx = r.x + fx * T.camLookAhead;
+        const lz = r.z + fz * T.camLookAhead;
+        const ly = T.camLookHeight;
+
+        if (!this._init) {
+            this._pos.set(dx, dy, dz);
+            this._look.set(lx, ly, lz);
+            this._init = true;
+        } else {
+            const k = Math.min(1, T.camFollowLag * dt);
+            this._pos.x += (dx - this._pos.x) * k;
+            this._pos.y += (dy - this._pos.y) * k;
+            this._pos.z += (dz - this._pos.z) * k;
+            this._look.x += (lx - this._look.x) * k;
+            this._look.y += (ly - this._look.y) * k;
+            this._look.z += (lz - this._look.z) * k;
+        }
+
+        this.camera.position.copy(this._pos);
+        this.camera.lookAt(this._look);
+
+        const targetFov = T.camFovBase + (T.camFovBoost - T.camFovBase) * boost;
+        this._fov += (targetFov - this._fov) * Math.min(1, T.camFovLag * dt);
+        if (Math.abs(this.camera.fov - this._fov) > 0.02) {
+            this.camera.fov = this._fov;
+            this.camera.updateProjectionMatrix();
+        }
+    }
+
+    reset() {
+        this._init = false;
+    }
+}

--- a/apps/kart/render/kartView.js
+++ b/apps/kart/render/kartView.js
@@ -1,0 +1,94 @@
+// Visual kart, built from primitives (art doesn't matter this milestone). It
+// reads an interpolated render state and adds feel: it leans into drifts,
+// squashes forward on boost, and shows a charge glow whose colour tracks the
+// drift stage. Purely cosmetic — no influence on the simulation.
+
+import * as THREE from 'three';
+import { COLORS, TUNING as T } from '../config.js';
+
+export class KartView {
+    constructor() {
+        this.group = new THREE.Group();
+
+        // body shell — a wedge-ish box so "forward" reads at a glance
+        this.body = new THREE.Group();
+        this.group.add(this.body);
+
+        const chassis = new THREE.Mesh(
+            new THREE.BoxGeometry(1.5, 0.5, 2.4),
+            new THREE.MeshLambertMaterial({ color: COLORS.kartBody })
+        );
+        chassis.position.y = 0.45;
+        this.body.add(chassis);
+
+        const nose = new THREE.Mesh(
+            new THREE.BoxGeometry(1.1, 0.35, 0.9),
+            new THREE.MeshLambertMaterial({ color: COLORS.kartBody })
+        );
+        nose.position.set(0, 0.32, 1.4);
+        this.body.add(nose);
+
+        const seat = new THREE.Mesh(
+            new THREE.BoxGeometry(0.9, 0.5, 0.9),
+            new THREE.MeshLambertMaterial({ color: COLORS.kartAccent })
+        );
+        seat.position.set(0, 0.8, -0.4);
+        this.body.add(seat);
+
+        // wheels
+        const wheelGeo = new THREE.CylinderGeometry(0.42, 0.42, 0.35, 14);
+        wheelGeo.rotateZ(Math.PI / 2);
+        const wheelMat = new THREE.MeshLambertMaterial({ color: COLORS.wheel });
+        const wheelPos = [
+            [-0.85, 0.42, 1.0], [0.85, 0.42, 1.0],
+            [-0.9, 0.42, -1.0], [0.9, 0.42, -1.0],
+        ];
+        for (const p of wheelPos) {
+            const w = new THREE.Mesh(wheelGeo, wheelMat);
+            w.position.set(p[0], p[1], p[2]);
+            this.body.add(w);
+        }
+
+        // drift charge glow — a disc under the kart that brightens/colours by stage
+        const glowGeo = new THREE.CircleGeometry(1.4, 24);
+        glowGeo.rotateX(-Math.PI / 2);
+        this.glowMat = new THREE.MeshBasicMaterial({
+            color: COLORS.driftStage[0],
+            transparent: true,
+            opacity: 0,
+            depthWrite: false,
+        });
+        this.glow = new THREE.Mesh(glowGeo, this.glowMat);
+        this.glow.position.y = 0.05;
+        this.group.add(this.glow);
+    }
+
+    // r: interpolated render state from main (position, heading, feel scalars)
+    update(r) {
+        this.group.position.set(r.x, 0, r.z);
+        this.group.rotation.y = r.heading;
+
+        // lean into the slide: roll proportional to lateral slip, biased by drift
+        const roll = -clamp(r.slip, -1, 1) * T.kartBodyRoll;
+        this.body.rotation.z = roll;
+
+        // boost squash: stretch forward, flatten slightly
+        const sq = r.boost * T.kartBoostSquash;
+        this.body.scale.set(1 - sq * 0.5, 1 - sq * 0.5, 1 + sq);
+
+        // drift charge glow
+        if (r.driftStage > 0) {
+            this.glowMat.color.setHex(COLORS.driftStage[r.driftStage - 1]);
+            this.glowMat.opacity = 0.35 + 0.2 * Math.sin(performance.now() * 0.02);
+        } else if (r.boost > 0.01) {
+            this.glowMat.color.setHex(COLORS.driftStage[Math.max(0, r.boostStage - 1)]);
+            this.glowMat.opacity = 0.4 * r.boost;
+        } else {
+            this.glowMat.opacity = 0;
+        }
+    }
+}
+
+function clamp(v, lo, hi) {
+    return v < lo ? lo : v > hi ? hi : v;
+}

--- a/apps/kart/render/scene.js
+++ b/apps/kart/render/scene.js
@@ -1,0 +1,57 @@
+// Renderer + scene + lights + ground plane. Pure presentation: it reads the
+// simulation's state but never changes it. Keeping all Three.js behind render/*
+// means the simulation stays portable.
+
+import * as THREE from 'three';
+import { COLORS } from '../config.js';
+
+export class Stage {
+    constructor(canvas, tier) {
+        this.renderer = new THREE.WebGLRenderer({
+            canvas,
+            antialias: tier.antialias,
+            powerPreference: 'high-performance',
+        });
+        this.renderer.setPixelRatio(tier.pixelRatio);
+        this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+        this.renderer.shadowMap.enabled = false;
+
+        this.scene = new THREE.Scene();
+        this.scene.background = new THREE.Color(COLORS.sky);
+        this.scene.fog = new THREE.Fog(COLORS.fog, 90, 320);
+
+        this.camera = new THREE.PerspectiveCamera(72, 1, 0.1, 600);
+        this.camera.position.set(0, 6, -10);
+
+        // lighting — flat and bright; art doesn't matter this milestone
+        this.scene.add(new THREE.HemisphereLight(0xffffff, 0x4a6a3a, 1.0));
+        const sun = new THREE.DirectionalLight(0xffffff, 1.1);
+        sun.position.set(40, 80, 30);
+        this.scene.add(sun);
+
+        // ground (grass) — large plane under everything
+        const groundGeo = new THREE.PlaneGeometry(1200, 1200);
+        groundGeo.rotateX(-Math.PI / 2);
+        const groundMat = new THREE.MeshLambertMaterial({ color: COLORS.grass });
+        this.ground = new THREE.Mesh(groundGeo, groundMat);
+        this.ground.position.y = -0.02;
+        this.scene.add(this.ground);
+    }
+
+    setSize(w, h) {
+        this.renderer.setSize(w, h, false);
+        this.camera.aspect = w / h;
+        this.camera.updateProjectionMatrix();
+    }
+
+    setFov(fov) {
+        if (Math.abs(this.camera.fov - fov) > 0.01) {
+            this.camera.fov = fov;
+            this.camera.updateProjectionMatrix();
+        }
+    }
+
+    render() {
+        this.renderer.render(this.scene, this.camera);
+    }
+}

--- a/apps/kart/render/trackView.js
+++ b/apps/kart/render/trackView.js
@@ -1,0 +1,130 @@
+// Builds the visible track from the simulation's sampled centerline: a flat
+// asphalt ribbon, bright edge lines, a dashed center line, and a checkered
+// start/finish stripe. Geometry only — no per-frame work.
+
+import * as THREE from 'three';
+import { COLORS } from '../config.js';
+
+export function buildTrackView(track) {
+    const group = new THREE.Group();
+    const n = track.samples.length;
+
+    // ---- asphalt ribbon (two triangles per segment, left/right edges) ----
+    const positions = [];
+    const indices = [];
+    for (let i = 0; i < n; i++) {
+        const l = track.leftEdge[i];
+        const r = track.rightEdge[i];
+        positions.push(l.x, 0, l.z, r.x, 0, r.z);
+    }
+    for (let i = 0; i < n; i++) {
+        const a = i * 2;          // left i
+        const b = i * 2 + 1;      // right i
+        const ni = (i + 1) % n;
+        const c = ni * 2;         // left i+1
+        const d = ni * 2 + 1;     // right i+1
+        indices.push(a, b, c, b, d, c);
+    }
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    geo.setIndex(indices);
+    geo.computeVertexNormals();
+    const road = new THREE.Mesh(geo, new THREE.MeshLambertMaterial({ color: COLORS.track }));
+    road.position.y = 0;
+    group.add(road);
+
+    // ---- edge lines (closed loops slightly inset so they sit on the asphalt) ----
+    group.add(edgeLine(track.leftEdge, track.samples, 0.85, COLORS.trackEdge));
+    group.add(edgeLine(track.rightEdge, track.samples, 0.85, COLORS.trackEdge));
+
+    // ---- dashed center line ----
+    group.add(centerDashes(track));
+
+    // ---- start/finish checkered stripe across the track at sample 0 ----
+    group.add(startStripe(track));
+
+    return group;
+}
+
+// A thin quad strip running along an edge, nudged toward the centerline so it
+// renders on the asphalt rather than the grass.
+function edgeLine(edge, center, blend, color) {
+    const n = edge.length;
+    const width = 0.45;
+    const positions = [];
+    const indices = [];
+    for (let i = 0; i < n; i++) {
+        // point on the asphalt near the edge
+        const ex = edge[i].x, ez = edge[i].z;
+        const cx = center[i].x, cz = center[i].z;
+        const px = ex + (cx - ex) * (1 - blend);
+        const pz = ez + (cz - ez) * (1 - blend);
+        // inward direction (toward center)
+        let dx = cx - ex, dz = cz - ez;
+        const dl = Math.hypot(dx, dz) || 1e-6; dx /= dl; dz /= dl;
+        positions.push(px, 0, pz, px + dx * width, 0, pz + dz * width);
+    }
+    for (let i = 0; i < n; i++) {
+        const a = i * 2, b = i * 2 + 1;
+        const ni = (i + 1) % n;
+        const c = ni * 2, d = ni * 2 + 1;
+        indices.push(a, b, c, b, d, c);
+    }
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    geo.setIndex(indices);
+    geo.computeVertexNormals();
+    const mesh = new THREE.Mesh(geo, new THREE.MeshBasicMaterial({ color }));
+    mesh.position.y = 0.02;
+    return mesh;
+}
+
+function centerDashes(track) {
+    const g = new THREE.Group();
+    const n = track.samples.length;
+    const mat = new THREE.MeshBasicMaterial({ color: COLORS.centerLine });
+    const dashGeo = new THREE.PlaneGeometry(0.35, 2.2);
+    dashGeo.rotateX(-Math.PI / 2);
+    for (let i = 0; i < n; i += 3) {
+        const s = track.samples[i];
+        const t = track.tangents[i];
+        const dash = new THREE.Mesh(dashGeo, mat);
+        dash.position.set(s.x, 0.03, s.z);
+        dash.rotation.y = Math.atan2(t.x, t.z);
+        g.add(dash);
+    }
+    return g;
+}
+
+function startStripe(track) {
+    const s = track.samples[0];
+    const t = track.tangents[0];
+    const w = track.halfWidth * 2;
+    const geo = new THREE.PlaneGeometry(w, 2.2);
+    geo.rotateX(-Math.PI / 2);
+    const tex = checkerTexture();
+    const mat = new THREE.MeshBasicMaterial({ map: tex });
+    const stripe = new THREE.Mesh(geo, mat);
+    stripe.position.set(s.x, 0.04, s.z);
+    stripe.rotation.y = Math.atan2(t.x, t.z);
+    return stripe;
+}
+
+function checkerTexture() {
+    const size = 64, cells = 8;
+    const c = document.createElement('canvas');
+    c.width = c.height = size;
+    const ctx = c.getContext('2d');
+    const cs = size / cells;
+    for (let y = 0; y < cells; y++) {
+        for (let x = 0; x < cells; x++) {
+            ctx.fillStyle = (x + y) % 2 ? '#111' : '#fff';
+            ctx.fillRect(x * cs, y * cs, cs, cs);
+        }
+    }
+    const tex = new THREE.CanvasTexture(c);
+    tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+    tex.repeat.set(6, 1);
+    tex.colorSpace = THREE.SRGBColorSpace;
+    return tex;
+}

--- a/apps/kart/simulation/kart.js
+++ b/apps/kart/simulation/kart.js
@@ -1,0 +1,160 @@
+// The kart simulation. This is the core of the milestone and the part that must
+// stay portable: `stepKart` is a PURE function of (previous state, input, dt,
+// track) -> new state. It never touches the DOM, Three.js, or input devices, so
+// the exact same code can later run on an authoritative host for multiplayer.
+//
+// Input is the small struct the rest of the game speaks:
+//   { steer: -1..1, accelerate: bool, brake: bool, drift: bool }
+//
+// State is a flat plain object (cheap to clone, serialize, and interpolate):
+//   x, z          world position on the ground plane
+//   heading       yaw, radians (forward = (sin h, cos h))
+//   vx, vz        world-space velocity
+//   forwardSpeed  signed speed along heading (cached for HUD/render/feel)
+//   steer         smoothed steer actually applied (-1..1)
+//   drifting      bool
+//   driftDir      -1 / +1 committed drift direction
+//   driftCharge   seconds of continuous drift accumulated
+//   driftStage    0..3 highest charge stage reached this drift
+//   boostStage    0..3 stage of the active boost
+//   boostTimer    seconds remaining on the active boost
+//   onTrack       bool (last surface test)
+
+import { TUNING as T } from '../config.js';
+
+export function createKartState(pose) {
+    return {
+        x: pose.x,
+        z: pose.z,
+        heading: pose.heading,
+        vx: 0,
+        vz: 0,
+        forwardSpeed: 0,
+        steer: 0,
+        drifting: false,
+        driftDir: 0,
+        driftCharge: 0,
+        driftStage: 0,
+        boostStage: 0,
+        boostTimer: 0,
+        onTrack: true,
+    };
+}
+
+// Highest stage index (0..3) reached for a given accumulated drift charge.
+function stageForCharge(charge) {
+    const t = T.driftStageTimes;
+    if (charge >= t[2]) return 3;
+    if (charge >= t[1]) return 2;
+    if (charge >= t[0]) return 1;
+    return 0;
+}
+
+// Pure step. `prev` is not mutated.
+export function stepKart(prev, input, dt, track) {
+    const s = { ...prev };
+
+    // ---- smooth the steer input (device/keyboard already gave us -1..1) ----
+    const steerTarget = clamp(input.steer, -1, 1);
+    s.steer += (steerTarget - s.steer) * Math.min(1, T.steerEase * dt);
+
+    // ---- decompose world velocity into the kart's local frame (old heading) ----
+    const fx = Math.sin(s.heading), fz = Math.cos(s.heading);   // forward
+    const rx = Math.cos(s.heading), rz = -Math.sin(s.heading);  // right
+    let vForward = s.vx * fx + s.vz * fz;
+    let vLateral = s.vx * rx + s.vz * rz;
+
+    // ---- surface + boost bookkeeping ----
+    const onTrack = track.isOnTrack(s.x, s.z);
+    s.onTrack = onTrack;
+    if (s.boostTimer > 0) s.boostTimer = Math.max(0, s.boostTimer - dt);
+    const boosting = s.boostTimer > 0;
+
+    // ---- drift state machine ----
+    const wantDrift = input.drift && input.accelerate;
+    if (!s.drifting) {
+        if (wantDrift && vForward > T.driftMinSpeed && Math.abs(s.steer) > T.driftSteerThreshold) {
+            s.drifting = true;
+            s.driftDir = s.steer >= 0 ? 1 : -1;
+            s.driftCharge = 0;
+            s.driftStage = 0;
+        }
+    } else {
+        // keep drifting only while held and still moving with enough pace
+        if (input.drift && vForward > T.driftMinSpeed * 0.6) {
+            s.driftCharge += dt;
+            s.driftStage = Math.max(s.driftStage, stageForCharge(s.driftCharge));
+        } else {
+            // release -> grant boost for the highest stage reached
+            const stage = s.driftStage;
+            if (stage > 0) {
+                s.boostStage = stage;
+                s.boostTimer = T.boostStageDuration[stage];
+            }
+            s.drifting = false;
+            s.driftDir = 0;
+            s.driftCharge = 0;
+            s.driftStage = 0;
+        }
+    }
+
+    // ---- longitudinal: acceleration curve, brake, coast, boost, off-track ----
+    const boostBonus = boosting
+        ? T.boostStageBonus[s.boostStage] * (s.boostTimer / T.boostStageDuration[s.boostStage])
+        : 0;
+    let target = T.topSpeed + boostBonus;
+    let accelRate;
+    if (onTrack) {
+        if (input.accelerate) {
+            accelRate = vForward < target ? T.accel : T.engineBrake;
+        } else if (input.brake) {
+            target = -T.reverseSpeed;
+            accelRate = T.brakeStrength;
+        } else {
+            target = 0;
+            accelRate = T.coastDrag;
+        }
+    } else {
+        // grass: clamp hard toward a low ceiling regardless of throttle
+        target = input.accelerate ? T.offTrackMaxSpeed : 0;
+        accelRate = T.offTrackDrag;
+    }
+    vForward += (target - vForward) * Math.min(1, accelRate * dt);
+
+    // ---- lateral grip (low while drifting / on grass = slide) ----
+    let grip = s.drifting ? T.driftGrip : T.normalGrip;
+    if (!onTrack) grip = Math.min(grip, T.offTrackGrip);
+    vLateral += (0 - vLateral) * Math.min(1, grip * dt);
+
+    // ---- recompose world velocity (still using current heading) ----
+    s.vx = vForward * fx + vLateral * rx;
+    s.vz = vForward * fz + vLateral * rz;
+    s.forwardSpeed = vForward;
+
+    // ---- steering: turn rate scales with speed; karts don't pivot in place ----
+    const speedFrac = clamp(Math.abs(vForward) / T.topSpeed, 0, 1);
+    let authority = clamp(speedFrac * T.steerSpeedGain, 0, 1);
+    authority *= 1 - T.turnTopSpeedFalloff * speedFrac; // shave twitch at the very top
+    let yawRate;
+    if (s.drifting) {
+        // committed arc: steering INTO the drift tightens it, countersteer widens it
+        const inward = clamp(s.steer * s.driftDir, -1, 1); // 1 = hard into drift
+        const mult = T.driftYawMin + (T.driftYawMax - T.driftYawMin) * (inward + 1) * 0.5;
+        yawRate = s.driftDir * T.maxTurnRate * authority * mult;
+    } else {
+        yawRate = s.steer * T.maxTurnRate * authority;
+    }
+    // reverse: steering inverts when actually rolling backwards (feels natural)
+    if (vForward < 0) yawRate = -yawRate;
+    s.heading += yawRate * dt;
+
+    // ---- integrate position ----
+    s.x += s.vx * dt;
+    s.z += s.vz * dt;
+
+    return s;
+}
+
+function clamp(v, lo, hi) {
+    return v < lo ? lo : v > hi ? hi : v;
+}

--- a/apps/kart/simulation/track.js
+++ b/apps/kart/simulation/track.js
@@ -1,0 +1,118 @@
+// Track geometry + queries. Pure data/math, no Three.js, no DOM — the renderer
+// and a future authoritative host both build off the same sampled centerline.
+//
+// Builds a closed Catmull-Rom loop from the control points, samples it into a
+// dense polyline, and exposes:
+//   - samples / leftEdge / rightEdge  (for the renderer to build the ribbon)
+//   - isOnTrack(x, z)                  (off-track penalty test)
+//   - progressAt(x, z)                 (nearest-point lap progress, 0..1)
+//   - startPose                        (where/which-way the kart starts)
+
+import { TRACK } from '../config.js';
+
+// Centripetal-ish Catmull-Rom point at parameter t (0..1) between p1 and p2.
+function catmull(p0, p1, p2, p3, t) {
+    const t2 = t * t;
+    const t3 = t2 * t;
+    return [
+        0.5 * ((2 * p1[0]) + (-p0[0] + p2[0]) * t +
+            (2 * p0[0] - 5 * p1[0] + 4 * p2[0] - p3[0]) * t2 +
+            (-p0[0] + 3 * p1[0] - 3 * p2[0] + p3[0]) * t3),
+        0.5 * ((2 * p1[1]) + (-p0[1] + p2[1]) * t +
+            (2 * p0[1] - 5 * p1[1] + 4 * p2[1] - p3[1]) * t2 +
+            (-p0[1] + 3 * p1[1] - 3 * p2[1] + p3[1]) * t3),
+    ];
+}
+
+export function createTrack() {
+    const cps = TRACK.controlPoints;
+    const n = cps.length;
+    const sub = TRACK.samplesPerSegment;
+    const hw = TRACK.halfWidth;
+
+    const samples = [];   // {x, z}
+    const tangents = [];  // {x, z} unit
+    for (let i = 0; i < n; i++) {
+        const p0 = cps[(i - 1 + n) % n];
+        const p1 = cps[i];
+        const p2 = cps[(i + 1) % n];
+        const p3 = cps[(i + 2) % n];
+        for (let j = 0; j < sub; j++) {
+            const t = j / sub;
+            const p = catmull(p0, p1, p2, p3, t);
+            samples.push({ x: p[0], z: p[1] });
+        }
+    }
+
+    const count = samples.length;
+    // Tangents + edge points (left/right offsets) + cumulative arc length.
+    const leftEdge = [];
+    const rightEdge = [];
+    const cumLen = new Float32Array(count + 1);
+    for (let i = 0; i < count; i++) {
+        const a = samples[i];
+        const b = samples[(i + 1) % count];
+        let tx = b.x - a.x;
+        let tz = b.z - a.z;
+        const segLen = Math.hypot(tx, tz) || 1e-6;
+        tx /= segLen; tz /= segLen;
+        tangents.push({ x: tx, z: tz });
+        // right-hand normal of the tangent
+        const nx = tz;
+        const nz = -tx;
+        leftEdge.push({ x: a.x - nx * hw, z: a.z - nz * hw });
+        rightEdge.push({ x: a.x + nx * hw, z: a.z + nz * hw });
+        cumLen[i + 1] = cumLen[i] + segLen;
+    }
+    const totalLen = cumLen[count];
+
+    // Nearest point on the polyline to (x,z). Returns squared distance, the
+    // segment index, and the param t along that segment.
+    function nearest(x, z) {
+        let best = Infinity, bestSeg = 0, bestT = 0;
+        for (let i = 0; i < count; i++) {
+            const a = samples[i];
+            const b = samples[(i + 1) % count];
+            const abx = b.x - a.x, abz = b.z - a.z;
+            const apx = x - a.x, apz = z - a.z;
+            const len2 = abx * abx + abz * abz || 1e-6;
+            let t = (apx * abx + apz * abz) / len2;
+            if (t < 0) t = 0; else if (t > 1) t = 1;
+            const cx = a.x + abx * t, cz = a.z + abz * t;
+            const dx = x - cx, dz = z - cz;
+            const d2 = dx * dx + dz * dz;
+            if (d2 < best) { best = d2; bestSeg = i; bestT = t; }
+        }
+        return { dist2: best, seg: bestSeg, t: bestT };
+    }
+
+    function isOnTrack(x, z) {
+        return nearest(x, z).dist2 <= hw * hw;
+    }
+
+    // Normalized lap progress 0..1 along the loop at the nearest centerline point.
+    function progressAt(x, z) {
+        const nr = nearest(x, z);
+        const segLen = cumLen[nr.seg + 1] - cumLen[nr.seg];
+        return (cumLen[nr.seg] + nr.t * segLen) / totalLen;
+    }
+
+    // Start pose: on the centerline at the first sample, facing along the tangent.
+    const startPose = {
+        x: samples[0].x,
+        z: samples[0].z,
+        heading: Math.atan2(tangents[0].x, tangents[0].z),
+    };
+
+    return {
+        halfWidth: hw,
+        samples,
+        leftEdge,
+        rightEdge,
+        tangents,
+        totalLen,
+        isOnTrack,
+        progressAt,
+        startPose,
+    };
+}


### PR DESCRIPTION
New /apps/kart utility: an arcade kart prototype focused on game feel,
structured for future characters/karts/maps/multiplayer.

- Fixed-timestep 60Hz simulation decoupled from rendering, with render
  interpolation between the last two states (multiplayer-ready)
- Pure (state, input) -> state kart sim with drift-to-boost staging,
  speed-scaled steering, acceleration curve, and off-track penalty
- Clean simulation/ render/ input/ separation; all feel numbers in one
  tunable config object
- Closed Catmull-Rom track with varied corners, chase camera, touch +
  keyboard controls, landscape lock, wake lock, lap timing and results

https://claude.ai/code/session_011FJ8jDY7WMXJFZSbi9cPeh