### PR TITLE
Kart racer (milestone 1): cartoon visuals + auto-drive controls

### DIFF
--- a/apps/kart/config.js
+++ b/apps/kart/config.js
@@ -38,8 +38,8 @@ export const TUNING = {
     driftGrip: 2.4,
 
     // ---------------------------------------------------------------- drift
-    driftMinSpeed: 13,        // must be going at least this fast to start a drift
-    driftSteerThreshold: 0.18,// must be turning at least this hard to start a drift
+    driftMinSpeed: 11,        // must be going at least this fast to start a drift
+    driftSteerThreshold: 0.16,// must be turning at least this hard to start a drift
     // While drifting, yaw rate = baseTurnRate * (a multiplier between min and max,
     // chosen by how hard the player steers INTO the drift). Countersteering widens
     // the arc (min); steering hard inward tightens it (max).
@@ -72,8 +72,12 @@ export const TUNING = {
     camBoostPullback: 1.6,   // extra distance the camera drops back at full boost
 
     // ---------------------------------------------------------------- visual feel
-    kartBodyRoll: 0.45,      // radians the body leans into a drift at full slide
+    kartBodyRoll: 0.42,      // radians the body leans into a drift at full slide
     kartBoostSquash: 0.12,   // body stretch on boost (0 = none)
+    kartDriftHop: 0.35,      // little hop height when a drift kicks off
+    wheelSteerMaxDeg: 26,    // visual front-wheel turn at full steer
+    camShakeBoost: 0.22,     // camera shake amplitude at full boost
+    camShakeStageUp: 0.5,    // shake kick when a drift charge stage levels up
 
     // ---------------------------------------------------------------- race
     totalLaps: 3,
@@ -86,33 +90,58 @@ export const TUNING = {
 // needs the same geometry for the on-track test and lap progress.
 export const TRACK = {
     halfWidth: 6.5,
-    // [x, z] control points, traversed in order. Closed loop.
+    // [x, z] control points, traversed in order. Closed loop. This curve was
+    // validated offline to be free of self-overlap (min self-distance ~52u) while
+    // featuring one tight corner (turn radius ~12u), several medium corners, and
+    // long sweepers — so drift pays off differently around the lap. Start/finish
+    // sits on the straightest section.
     controlPoints: [
-        [0, -52],
-        [42, -46],
-        [58, -8],
-        [30, 12],     // chicane-ish kink
-        [48, 42],
-        [8, 58],
-        [-34, 48],
-        [-54, 10],
-        [-36, -22],   // hairpin-ish
-        [-12, -42],
+        [-29.1, 36.5], [-47.5, 22.9], [-63.1, 0], [-60, -28.9],
+        [-35.7, -44.8], [-8.8, -38.4], [5.5, -24.3], [15.4, -19.4],
+        [36.6, -17.6], [63.1, 0], [71, 34.2], [49.4, 61.9],
+        [14.8, 65], [-11.6, 50.9],
     ],
     samplesPerSegment: 26,   // spline resolution for the on-track test + mesh
 };
 
 export const COLORS = {
-    sky: 0x9fd3ff,
-    fog: 0xbfe0ff,
-    grass: 0x3f7a4a,
-    grassDark: 0x356b40,
-    track: 0x3a3d46,
+    skyTop: 0x3f9bff,        // zenith
+    skyBottom: 0xcdecff,     // horizon
+    fog: 0xd2ecff,
+    sun: 0xfff4dc,
+    grass: 0x67c24f,         // bright cartoon lawn
+    grassDark: 0x57b341,     // mown stripe
+    track: 0x565b6b,         // asphalt
     trackEdge: 0xf4f4f8,
-    centerLine: 0xf4d03f,
+    kerbRed: 0xe8473f,
+    kerbWhite: 0xf6f6f6,
+    centerLine: 0xf4d23f,
     startLine: 0xffffff,
+    bannerPost: 0xf24e4e,
+    bannerCloth: 0x2a2f3a,
     kartBody: 0xff5a4d,
-    kartAccent: 0x1a1a22,
-    wheel: 0x14141a,
+    kartBody2: 0xffd23f,     // accent stripe / spoiler
+    kartAccent: 0x23252e,
+    driver: 0xffd9b3,        // skin
+    helmet: 0x2f7bdc,
+    wheel: 0x1b1b22,
+    hubcap: 0xe6e6ec,
+    cone: 0xff7a1e,
+    treeTrunk: 0x8a5a2b,
+    treeLeaf: 0x47b04a,
+    treeLeaf2: 0x5fc95f,
+    cloud: 0xffffff,
+    hill: 0x7fd06a,
     driftStage: [0x39d0ff, 0xff9f1c, 0xb06bff], // blue, orange, purple sparks/glow
+};
+
+// Counts / sizes for set dressing and effects. Bumped down on mobile by the tier.
+export const VISUALS = {
+    trees: 46,
+    clouds: 14,
+    hills: 9,
+    conesPerSide: 26,        // pylons spaced along each track edge
+    smokeMax: 90,            // drift smoke particle pool
+    skidMax: 140,            // skid-mark quad pool
+    sparkMax: 60,            // boost / stage-up spark pool
 };

--- a/apps/kart/index.html
+++ b/apps/kart/index.html
@@ -5,13 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <meta name="theme-color" content="#1a1a2e">
+    <meta name="theme-color" content="#3f9bff">
     <link rel="apple-touch-icon" href="../icon.png">
     <title>Kart</title>
     <style>
         html, body {
             margin: 0; padding: 0; width: 100%; height: 100%;
-            overflow: hidden; background: #1a1a2e; color: #f4f8ff;
+            overflow: hidden; background: #bfe6ff; color: #f4f8ff;
             font-family: 'Helvetica Neue', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
             -webkit-tap-highlight-color: transparent;
             -webkit-user-select: none; user-select: none;
@@ -112,17 +112,14 @@
             transition: transform 0.06s ease, background 0.06s ease;
             width: 78px; height: 78px;
         }
-        .ctl-btn.accel {
-            width: 104px; height: 104px;
-            background: rgba(46, 204, 64, 0.35);
-            border-color: rgba(46, 204, 64, 0.7);
-        }
-        .ctl-btn.small { width: 66px; height: 66px; font-size: 11px; }
+        .ctl-btn.big { width: 120px; height: 120px; font-size: 16px; }
+        .ctl-btn.small { width: 70px; height: 70px; font-size: 11px; }
         #btn-drift {
-            background: rgba(57, 208, 255, 0.32);
-            border-color: rgba(57, 208, 255, 0.7);
+            background: rgba(57, 208, 255, 0.4);
+            border-color: rgba(57, 208, 255, 0.85);
+            box-shadow: 0 0 16px rgba(57,208,255,0.4);
         }
-        .ctl-btn.pressed { transform: scale(0.9); background: rgba(255,255,255,0.45); }
+        .ctl-btn.pressed { transform: scale(0.9); background: rgba(255,255,255,0.5); }
 
         /* ---- panels ---- */
         .panel {
@@ -178,7 +175,8 @@
         #rotate {
             position: fixed; inset: 0; z-index: 30; display: none;
             align-items: center; justify-content: center; text-align: center;
-            background: #1a1a2e; font-size: 18px; letter-spacing: 2px; padding: 30px;
+            background: linear-gradient(180deg, #3f9bff, #cdecff); color: #14324f;
+            font-size: 18px; font-weight: 700; letter-spacing: 2px; padding: 30px;
         }
         @media (orientation: portrait) {
             #rotate { display: flex; }
@@ -228,8 +226,7 @@
             <div id="steer-zone"><span class="steer-hint">&#9664; steer &#9654;</span></div>
             <div id="btn-cluster">
                 <div id="btn-brake" class="ctl-btn small">Brake</div>
-                <div id="btn-drift" class="ctl-btn">Drift</div>
-                <div id="btn-accel" class="ctl-btn accel">Gas</div>
+                <div id="btn-drift" class="ctl-btn big">Drift</div>
             </div>
         </div>
 
@@ -239,9 +236,11 @@
             <div class="subtitle">milestone 1 &middot; driving feel</div>
             <div class="cta" id="btn-start">Tap to start</div>
             <div class="hint" id="start-hint">
-                Hold <b>Gas</b>, steer with your left thumb, and hold <b>Drift</b>
-                while turning to charge a boost &mdash; release for a speed burst.<br>
-                Desktop: arrows / WASD to drive, <b>Space</b> to drift.
+                You auto-drive &mdash; steer with your <b>left thumb</b> and hold
+                <b>Drift</b> through a corner to charge a boost, then release for a
+                speed burst. Tap <b>Brake</b> to slow.<br>
+                Desktop: &larr;&rarr; / A&nbsp;D to steer, <b>Space</b> to drift,
+                <b>S</b> to brake.
             </div>
         </div>
 

--- a/apps/kart/input/input.js
+++ b/apps/kart/input/input.js
@@ -11,6 +11,11 @@ const STEER_TRAVEL = 70; // px of horizontal drag from touch-down for full lock
 
 export class Input {
     constructor(els) {
+        // Auto-accelerate: the kart always drives forward unless braking. This is
+        // the standard mobile-kart control because it frees the right thumb to
+        // drift — you can't hold a gas button AND a drift button with one thumb.
+        this.autoAccel = true;
+
         // touch state
         this._touchSteer = 0;
         this._steerId = null;
@@ -82,16 +87,18 @@ export class Input {
     // Device-agnostic snapshot handed to the simulation.
     sample() {
         let steer = this._touchSteer;
-        let accelerate = this._accel;
-        let brake = this._brake;
-        let drift = this._drift;
+        let brake = this._brake || this._keyBrake;
+        let drift = this._drift || this._keyDrift;
 
-        // keyboard overlays (so desktop testing works even with touch els present)
+        // keyboard steer overlays (so desktop testing works with touch els present)
         if (this._keyLeft) steer = -1;
         if (this._keyRight) steer = 1;
-        if (this._keyAccel) accelerate = true;
-        if (this._keyBrake) brake = true;
-        if (this._keyDrift) drift = true;
+
+        // auto-accelerate unless braking; a held gas button/key can still force it
+        let accelerate;
+        if (this.autoAccel) accelerate = !brake;
+        else accelerate = this._accel || this._keyAccel;
+        if (this._accel || this._keyAccel) accelerate = true;
 
         if (Math.abs(steer) < 0.04) steer = 0; // tiny deadzone
         return { steer, accelerate, brake, drift };

--- a/apps/kart/main.js
+++ b/apps/kart/main.js
@@ -14,8 +14,11 @@
 import { stepKart, createKartState } from './simulation/kart.js';
 import { createTrack } from './simulation/track.js';
 import { Stage } from './render/scene.js';
+import { Post } from './render/postprocessing.js';
 import { buildTrackView } from './render/trackView.js';
+import { buildProps } from './render/props.js';
 import { KartView } from './render/kartView.js';
+import { Effects } from './render/effects.js';
 import { ChaseCamera } from './render/chaseCamera.js';
 import { Input } from './input/input.js';
 import { Hud } from './hud.js';
@@ -38,25 +41,38 @@ function detectTier() {
     const dpr = window.devicePixelRatio || 1;
     const cores = navigator.hardwareConcurrency || 4;
     if (isMobile || cores < 4) {
-        return { pixelRatio: Math.min(dpr, 1.5), antialias: false };
+        return {
+            pixelRatio: Math.min(dpr, 1.5), antialias: false,
+            shadowMap: 1024, bloomStrength: 0.32, useHalfFloat: false,
+        };
     }
-    return { pixelRatio: Math.min(dpr, 2), antialias: true };
+    return {
+        pixelRatio: Math.min(dpr, 2), antialias: true,
+        shadowMap: 2048, bloomStrength: 0.38, useHalfFloat: true,
+    };
 }
 
 // ---------------------------------------------------------------- boot
 const canvas = document.getElementById('game');
-let stage, kartView, chase, hud, input, track;
+const tier = detectTier();
+let stage, post, kartView, effects, chase, hud, input, track;
 try {
     track = createTrack();
-    stage = new Stage(canvas, detectTier());
+    stage = new Stage(canvas, tier);
     stage.scene.add(buildTrackView(track));
+    stage.scene.add(buildProps(track));
     kartView = new KartView();
     stage.scene.add(kartView.group);
+    effects = new Effects(stage.scene);
     chase = new ChaseCamera(stage.camera);
+    post = new Post(stage.renderer, stage.scene, stage.camera, {
+        width: 1, height: 1,
+        bloomStrength: tier.bloomStrength,
+        useHalfFloat: tier.useHalfFloat,
+    });
     hud = new Hud();
     input = new Input({
         steerZone: document.getElementById('steer-zone'),
-        accel: document.getElementById('btn-accel'),
         brake: document.getElementById('btn-brake'),
         drift: document.getElementById('btn-drift'),
     });
@@ -70,6 +86,8 @@ function resize() {
     const w = window.innerWidth, h = window.innerHeight;
     if (w === 0 || h === 0) { requestAnimationFrame(resize); return; }
     stage.setSize(w, h);
+    const dpr = stage.renderer.getPixelRatio();
+    post.setSize(Math.round(w * dpr), Math.round(h * dpr));
 }
 window.addEventListener('resize', resize);
 resize();
@@ -87,6 +105,8 @@ const game = {
     lapTimes: [],
     prevProgress: 0,
     passedHalf: false,
+    shake: 0,          // decaying camera-shake kick (stage-ups)
+    lastStage: 0,      // for detecting drift-charge stage-ups
 };
 
 function freshSim() {
@@ -103,7 +123,10 @@ function resetRace() {
     game.lapTimes = [];
     game.prevProgress = track.progressAt(game.curr.x, game.curr.z);
     game.passedHalf = false;
+    game.shake = 0;
+    game.lastStage = 0;
     chase.reset();
+    effects.reset();
     hud.setLap(1, T.totalLaps);
     hud.setLapTime(0);
     hud.setSpeed(0);
@@ -197,6 +220,9 @@ function interpolated(alpha) {
         z: p.z + (c.z - p.z) * alpha,
         heading: angleLerp(p.heading, c.heading, alpha),
         slip: clamp(vLat / SLIP_REF, -1, 1),
+        steer: c.steer,
+        speed: c.forwardSpeed,
+        drifting: c.drifting,
         boost,
         driftStage: c.driftStage,
         boostStage: c.boostStage,
@@ -238,8 +264,21 @@ function frame(now) {
 
         // render with interpolation
         const r = interpolated(acc / STEP);
-        kartView.update(r);
+        kartView.update(r, dt);
+        effects.update(dt, r);
         chase.update(r, r.boost, dt);
+
+        // camera shake: continuous on boost + a kick on each charge stage-up
+        if (game.curr.driftStage > game.lastStage) game.shake = T.camShakeStageUp;
+        game.lastStage = game.curr.driftStage;
+        game.shake = Math.max(0, game.shake - dt * 2.2);
+        const shakeAmp = game.shake + r.boost * T.camShakeBoost;
+        if (shakeAmp > 0.001) {
+            stage.camera.position.x += (Math.random() - 0.5) * shakeAmp;
+            stage.camera.position.y += (Math.random() - 0.5) * shakeAmp;
+        }
+
+        post.setGrade(r.boost);
 
         // HUD (live values from latest sim state)
         if (game.state === STATE.RACING) {
@@ -250,7 +289,7 @@ function frame(now) {
             hud.setLapTime(game.raceTime - game.lapStart);
         }
 
-        stage.render();
+        post.render();
     } catch (e) {
         loopFatal = true;
         showFatal('frame: ' + ((e && e.message) ? e.message : String(e)));

--- a/apps/kart/render/effects.js
+++ b/apps/kart/render/effects.js
@@ -1,0 +1,214 @@
+// Particle + decal juice driven off the kart's render state:
+//   - drift smoke   : puffs off the rear wheels while drifting, tinted to the
+//                     current charge stage (so the slide colour-codes in-world)
+//   - skid marks    : dark strips laid on the asphalt while drifting (ring-buffer
+//                     InstancedMesh, one draw call)
+//   - sparks        : bright bursts on each stage-up and a trickle while boosting
+//
+// All cosmetic. Buffer-update patterns mirror the racing app's streak system.
+
+import * as THREE from 'three';
+import { COLORS, VISUALS } from '../config.js';
+
+export class Effects {
+    constructor(scene) {
+        this.group = new THREE.Group();
+        scene.add(this.group);
+        this.smoke = new Particles(VISUALS.smokeMax, THREE.NormalBlending, 1.0);
+        this.sparks = new Particles(VISUALS.sparkMax, THREE.AdditiveBlending, 0.55);
+        this.group.add(this.smoke.points);
+        this.group.add(this.sparks.points);
+        this._skid = makeSkid();
+        this.group.add(this._skid.mesh);
+        this._skidDist = 0;
+        this._prevStage = 0;
+    }
+
+    reset() {
+        this.smoke.clear();
+        this.sparks.clear();
+        this._skid.clear();
+        this._skidDist = 0;
+        this._prevStage = 0;
+    }
+
+    // fx: { x, z, heading, drifting, driftStage, boost, boostStage, speed, dx, dz }
+    update(dt, fx) {
+        const fwdX = Math.sin(fx.heading), fwdZ = Math.cos(fx.heading);
+        const rgtX = Math.cos(fx.heading), rgtZ = -Math.sin(fx.heading);
+        // rear-wheel world positions
+        const rear = (side) => ({
+            x: fx.x + rgtX * side * 0.98 + fwdX * -1.05,
+            z: fx.z + rgtZ * side * 0.98 + fwdZ * -1.05,
+        });
+
+        // ---- drift smoke + skid ----
+        if (fx.drifting) {
+            const tint = new THREE.Color(0xdfe6ee);
+            if (fx.driftStage > 0) tint.lerp(new THREE.Color(COLORS.driftStage[fx.driftStage - 1]), 0.55);
+            for (const side of [-1, 1]) {
+                const p = rear(side);
+                if (Math.random() < 0.9) this.smoke.spawn(p.x, 0.25, p.z, tint, 0.6 + Math.random() * 0.5, 1.1 + fx.driftStage * 0.3);
+            }
+            // lay skid marks every fixed distance travelled
+            this._skidDist += (fx.speed || 0) * dt;
+            if (this._skidDist > 0.6) {
+                this._skidDist = 0;
+                for (const side of [-1, 1]) {
+                    const p = rear(side);
+                    this._skid.drop(p.x, p.z, fx.heading);
+                }
+            }
+        }
+
+        // ---- stage-up spark burst ----
+        if (fx.driftStage > this._prevStage && fx.driftStage > 0) {
+            const c = new THREE.Color(COLORS.driftStage[fx.driftStage - 1]);
+            for (const side of [-1, 1]) {
+                const p = rear(side);
+                for (let i = 0; i < 10; i++) this.sparks.spawn(p.x, 0.4, p.z, c, 0.35, 0.5, 7);
+            }
+        }
+        this._prevStage = fx.driftStage;
+
+        // ---- boost trail sparks ----
+        if (fx.boost > 0.1 && Math.random() < fx.boost) {
+            const c = new THREE.Color(COLORS.driftStage[Math.max(0, fx.boostStage - 1)]);
+            const ex = { x: fx.x + fwdX * -1.7, z: fx.z + fwdZ * -1.7 };
+            this.sparks.spawn(ex.x, 0.6, ex.z, c, 0.3, 0.45, 5);
+        }
+
+        this.smoke.update(dt);
+        this.sparks.update(dt);
+    }
+}
+
+// Generic GPU point pool with soft round sprites and per-particle colour/alpha.
+class Particles {
+    constructor(max, blending, sizeScale) {
+        this.max = max;
+        this.pos = new Float32Array(max * 3);
+        this.col = new Float32Array(max * 3);
+        this.data = new Float32Array(max * 2); // [size, lifeFrac]
+        this.vel = new Float32Array(max * 3);
+        this.life = new Float32Array(max);
+        this.maxLife = new Float32Array(max);
+        this.cursor = 0;
+
+        const geo = new THREE.BufferGeometry();
+        this.aPos = new THREE.BufferAttribute(this.pos, 3).setUsage(THREE.DynamicDrawUsage);
+        this.aCol = new THREE.BufferAttribute(this.col, 3).setUsage(THREE.DynamicDrawUsage);
+        this.aData = new THREE.BufferAttribute(this.data, 2).setUsage(THREE.DynamicDrawUsage);
+        geo.setAttribute('position', this.aPos);
+        geo.setAttribute('color', this.aCol);
+        geo.setAttribute('aData', this.aData);
+
+        this.mat = new THREE.ShaderMaterial({
+            transparent: true,
+            depthWrite: false,
+            blending,
+            uniforms: { uScale: { value: sizeScale } },
+            vertexShader: /* glsl */`
+                attribute vec3 color;
+                attribute vec2 aData;
+                uniform float uScale;
+                varying vec3 vCol;
+                varying float vAlpha;
+                void main() {
+                    vCol = color;
+                    vAlpha = aData.y;
+                    vec4 mv = modelViewMatrix * vec4(position, 1.0);
+                    float d = max(-mv.z, 1.0);
+                    gl_PointSize = aData.x * uScale * (320.0 / d);
+                    gl_Position = projectionMatrix * mv;
+                }
+            `,
+            fragmentShader: /* glsl */`
+                varying vec3 vCol;
+                varying float vAlpha;
+                void main() {
+                    vec2 p = gl_PointCoord - 0.5;
+                    float a = smoothstep(0.5, 0.05, length(p));
+                    if (a <= 0.001) discard;
+                    gl_FragColor = vec4(vCol, a * vAlpha);
+                }
+            `,
+        });
+        this.points = new THREE.Points(geo, this.mat);
+        this.points.frustumCulled = false;
+    }
+
+    spawn(x, y, z, color, life, size, speed = 1.2) {
+        const i = this.cursor;
+        this.cursor = (this.cursor + 1) % this.max;
+        this.pos[i * 3] = x; this.pos[i * 3 + 1] = y; this.pos[i * 3 + 2] = z;
+        this.col[i * 3] = color.r; this.col[i * 3 + 1] = color.g; this.col[i * 3 + 2] = color.b;
+        const ang = Math.random() * Math.PI * 2;
+        this.vel[i * 3] = Math.cos(ang) * speed * 0.5;
+        this.vel[i * 3 + 1] = speed * (0.6 + Math.random() * 0.8);
+        this.vel[i * 3 + 2] = Math.sin(ang) * speed * 0.5;
+        this.life[i] = this.maxLife[i] = life;
+        this.data[i * 2] = size;
+        this.data[i * 2 + 1] = 1;
+    }
+
+    update(dt) {
+        for (let i = 0; i < this.max; i++) {
+            if (this.life[i] <= 0) { this.data[i * 2 + 1] = 0; continue; }
+            this.life[i] -= dt;
+            const f = Math.max(0, this.life[i] / this.maxLife[i]);
+            this.pos[i * 3] += this.vel[i * 3] * dt;
+            this.pos[i * 3 + 1] += this.vel[i * 3 + 1] * dt;
+            this.pos[i * 3 + 2] += this.vel[i * 3 + 2] * dt;
+            this.vel[i * 3] *= 0.92; this.vel[i * 3 + 1] *= 0.92; this.vel[i * 3 + 2] *= 0.92;
+            this.data[i * 2] += dt * 1.5;     // grow
+            this.data[i * 2 + 1] = f;          // fade
+        }
+        this.aPos.needsUpdate = true;
+        this.aCol.needsUpdate = true;
+        this.aData.needsUpdate = true;
+    }
+
+    clear() {
+        this.life.fill(0);
+        this.data.fill(0);
+        this.aData.needsUpdate = true;
+    }
+}
+
+function makeSkid() {
+    const max = VISUALS.skidMax;
+    const geo = new THREE.PlaneGeometry(0.34, 0.8);
+    geo.rotateX(-Math.PI / 2);
+    const mat = new THREE.MeshBasicMaterial({
+        color: 0x1a1a1f, transparent: true, opacity: 0.34, depthWrite: false,
+    });
+    const inst = new THREE.InstancedMesh(geo, mat, max);
+    inst.position.y = 0.03;
+    inst.frustumCulled = false;
+    const dummy = new THREE.Object3D();
+    // hide all initially
+    dummy.scale.setScalar(0);
+    for (let i = 0; i < max; i++) inst.setMatrixAt(i, dummy.matrix);
+    inst.instanceMatrix.needsUpdate = true;
+
+    let cursor = 0;
+    return {
+        mesh: inst,
+        drop(x, z, heading) {
+            dummy.position.set(x, 0, z);
+            dummy.rotation.set(0, heading, 0);
+            dummy.scale.setScalar(1);
+            dummy.updateMatrix();
+            inst.setMatrixAt(cursor, dummy.matrix);
+            inst.instanceMatrix.needsUpdate = true;
+            cursor = (cursor + 1) % max;
+        },
+        clear() {
+            dummy.scale.setScalar(0); dummy.updateMatrix();
+            for (let i = 0; i < max; i++) inst.setMatrixAt(i, dummy.matrix);
+            inst.instanceMatrix.needsUpdate = true;
+            cursor = 0;
+        },
+    };
+}

--- a/apps/kart/render/kartView.js
+++ b/apps/kart/render/kartView.js
@@ -1,94 +1,200 @@
-// Visual kart, built from primitives (art doesn't matter this milestone). It
-// reads an interpolated render state and adds feel: it leans into drifts,
-// squashes forward on boost, and shows a charge glow whose colour tracks the
-// drift stage. Purely cosmetic — no influence on the simulation.
+// Cartoon kart, built from primitives but with enough shapes (driver, helmet,
+// hubcaps, spoiler, exhausts, antenna) to read as a real little vehicle. It adds
+// feel on top of the sim: front wheels steer, all wheels spin with speed, the
+// body leans into drifts, hops when a drift kicks off, squashes on boost, and an
+// exhaust flame + ground glow flare up with the charge stage. Cosmetic only.
 
 import * as THREE from 'three';
+import { RoundedBoxGeometry } from 'three/addons/geometries/RoundedBoxGeometry.js';
 import { COLORS, TUNING as T } from '../config.js';
+import { toonMat } from './materials.js';
 
 export class KartView {
     constructor() {
         this.group = new THREE.Group();
 
-        // body shell — a wedge-ish box so "forward" reads at a glance
-        this.body = new THREE.Group();
-        this.group.add(this.body);
+        this.bob = new THREE.Group();          // hop + squash
+        this.group.add(this.bob);
 
-        const chassis = new THREE.Mesh(
-            new THREE.BoxGeometry(1.5, 0.5, 2.4),
-            new THREE.MeshLambertMaterial({ color: COLORS.kartBody })
-        );
-        chassis.position.y = 0.45;
-        this.body.add(chassis);
+        this.chassis = new THREE.Group();      // roll/lean
+        this.bob.add(this.chassis);
 
-        const nose = new THREE.Mesh(
-            new THREE.BoxGeometry(1.1, 0.35, 0.9),
-            new THREE.MeshLambertMaterial({ color: COLORS.kartBody })
-        );
-        nose.position.set(0, 0.32, 1.4);
-        this.body.add(nose);
+        const bodyMat = toonMat(COLORS.kartBody);
+        const accentMat = toonMat(COLORS.kartBody2);
+        const darkMat = toonMat(COLORS.kartAccent);
 
-        const seat = new THREE.Mesh(
-            new THREE.BoxGeometry(0.9, 0.5, 0.9),
-            new THREE.MeshLambertMaterial({ color: COLORS.kartAccent })
-        );
-        seat.position.set(0, 0.8, -0.4);
-        this.body.add(seat);
+        // main tub
+        const tub = mesh(roundedBox(1.7, 0.55, 2.6, 0.18), bodyMat);
+        tub.position.y = 0.5;
+        this.chassis.add(tub);
 
-        // wheels
-        const wheelGeo = new THREE.CylinderGeometry(0.42, 0.42, 0.35, 14);
-        wheelGeo.rotateZ(Math.PI / 2);
-        const wheelMat = new THREE.MeshLambertMaterial({ color: COLORS.wheel });
-        const wheelPos = [
-            [-0.85, 0.42, 1.0], [0.85, 0.42, 1.0],
-            [-0.9, 0.42, -1.0], [0.9, 0.42, -1.0],
-        ];
-        for (const p of wheelPos) {
-            const w = new THREE.Mesh(wheelGeo, wheelMat);
-            w.position.set(p[0], p[1], p[2]);
-            this.body.add(w);
+        // sloped nose
+        const nose = mesh(roundedBox(1.3, 0.4, 1.0, 0.14), bodyMat);
+        nose.position.set(0, 0.4, 1.45);
+        this.chassis.add(nose);
+
+        // side pods
+        for (const sx of [-1, 1]) {
+            const pod = mesh(roundedBox(0.4, 0.4, 1.6, 0.12), accentMat);
+            pod.position.set(sx * 0.95, 0.42, 0.1);
+            this.chassis.add(pod);
         }
 
-        // drift charge glow — a disc under the kart that brightens/colours by stage
-        const glowGeo = new THREE.CircleGeometry(1.4, 24);
+        // seat + driver
+        const seat = mesh(roundedBox(1.0, 0.5, 0.9, 0.12), darkMat);
+        seat.position.set(0, 0.78, -0.5);
+        this.chassis.add(seat);
+
+        const torso = mesh(roundedBox(0.7, 0.7, 0.6, 0.16), toonMat(COLORS.helmet));
+        torso.position.set(0, 1.15, -0.45);
+        this.chassis.add(torso);
+
+        const head = mesh(new THREE.SphereGeometry(0.32, 16, 12), toonMat(COLORS.driver));
+        head.position.set(0, 1.62, -0.35);
+        this.chassis.add(head);
+
+        const helmet = mesh(new THREE.SphereGeometry(0.36, 16, 12, 0, Math.PI * 2, 0, Math.PI * 0.62), toonMat(COLORS.helmet));
+        helmet.position.set(0, 1.66, -0.35);
+        this.chassis.add(helmet);
+
+        // steering wheel
+        const wheelHub = mesh(new THREE.TorusGeometry(0.22, 0.05, 8, 16), darkMat);
+        wheelHub.position.set(0, 1.05, 0.25);
+        wheelHub.rotation.x = Math.PI * 0.34;
+        this.chassis.add(wheelHub);
+
+        // rear spoiler
+        const wing = mesh(roundedBox(1.6, 0.12, 0.45, 0.05), accentMat);
+        wing.position.set(0, 1.05, -1.35);
+        this.chassis.add(wing);
+        for (const sx of [-0.6, 0.6]) {
+            const strut = mesh(new THREE.BoxGeometry(0.1, 0.5, 0.1), darkMat);
+            strut.position.set(sx, 0.82, -1.32);
+            this.chassis.add(strut);
+        }
+
+        // exhausts + boost flame
+        this.flames = [];
+        for (const sx of [-0.4, 0.4]) {
+            const pipe = mesh(new THREE.CylinderGeometry(0.09, 0.11, 0.5, 10), darkMat);
+            pipe.rotation.x = Math.PI / 2;
+            pipe.position.set(sx, 0.7, -1.55);
+            this.chassis.add(pipe);
+
+            const flame = mesh(new THREE.ConeGeometry(0.16, 0.7, 10), new THREE.MeshBasicMaterial({ color: 0xfff1a8 }));
+            flame.rotation.x = -Math.PI / 2;
+            flame.position.set(sx, 0.7, -1.95);
+            flame.visible = false;
+            this.chassis.add(flame);
+            this.flames.push(flame);
+        }
+
+        // antenna with ball
+        const ant = mesh(new THREE.CylinderGeometry(0.02, 0.02, 0.7, 6), darkMat);
+        ant.position.set(0.5, 1.2, -0.9);
+        this.chassis.add(ant);
+        const ball = mesh(new THREE.SphereGeometry(0.09, 10, 8), toonMat(COLORS.kartBody2));
+        ball.position.set(0.5, 1.55, -0.9);
+        this.chassis.add(ball);
+
+        // wheels (front pair steer; all spin)
+        this.frontL = makeWheel(); this.frontR = makeWheel();
+        this.rearL = makeWheel(0.52); this.rearR = makeWheel(0.52);
+        this.frontL.pivot.position.set(-0.92, 0.46, 1.05);
+        this.frontR.pivot.position.set(0.92, 0.46, 1.05);
+        this.rearL.pivot.position.set(-0.98, 0.52, -1.05);
+        this.rearR.pivot.position.set(0.98, 0.52, -1.05);
+        for (const w of [this.frontL, this.frontR, this.rearL, this.rearR]) this.bob.add(w.pivot);
+
+        // shadow casters
+        this.group.traverse((o) => { if (o.isMesh) o.castShadow = true; });
+
+        // ground charge glow
+        const glowGeo = new THREE.CircleGeometry(1.7, 28);
         glowGeo.rotateX(-Math.PI / 2);
         this.glowMat = new THREE.MeshBasicMaterial({
-            color: COLORS.driftStage[0],
-            transparent: true,
-            opacity: 0,
-            depthWrite: false,
+            color: COLORS.driftStage[0], transparent: true, opacity: 0, depthWrite: false,
         });
-        this.glow = new THREE.Mesh(glowGeo, this.glowMat);
-        this.glow.position.y = 0.05;
+        this.glow = mesh(glowGeo, this.glowMat);
+        this.glow.position.y = 0.04;
+        this.glow.castShadow = false;
         this.group.add(this.glow);
+
+        this._wasDrifting = false;
+        this._hopT = 0;
+        this._spin = 0;
     }
 
-    // r: interpolated render state from main (position, heading, feel scalars)
-    update(r) {
+    // r: interpolated render state. dt: real seconds since last frame.
+    update(r, dt) {
         this.group.position.set(r.x, 0, r.z);
         this.group.rotation.y = r.heading;
 
-        // lean into the slide: roll proportional to lateral slip, biased by drift
-        const roll = -clamp(r.slip, -1, 1) * T.kartBodyRoll;
-        this.body.rotation.z = roll;
+        // drift hop on the rising edge of a drift
+        if (r.drifting && !this._wasDrifting) this._hopT = 0.32;
+        this._wasDrifting = r.drifting;
+        let hop = 0;
+        if (this._hopT > 0) {
+            this._hopT = Math.max(0, this._hopT - dt);
+            hop = Math.sin((1 - this._hopT / 0.32) * Math.PI) * T.kartDriftHop;
+        }
+        this.bob.position.y = hop;
 
-        // boost squash: stretch forward, flatten slightly
+        // boost squash
         const sq = r.boost * T.kartBoostSquash;
-        this.body.scale.set(1 - sq * 0.5, 1 - sq * 0.5, 1 + sq);
+        this.bob.scale.set(1 - sq * 0.5, 1 - sq * 0.5, 1 + sq);
 
-        // drift charge glow
+        // body lean into the slide
+        this.chassis.rotation.z = -clamp(r.slip, -1, 1) * T.kartBodyRoll;
+
+        // wheels: front steer, all spin with forward speed
+        const steerAng = -r.steer * (T.wheelSteerMaxDeg * Math.PI / 180);
+        this.frontL.pivot.rotation.y = steerAng;
+        this.frontR.pivot.rotation.y = steerAng;
+        this._spin += (r.speed || 0) * dt * 1.6;
+        for (const w of [this.frontL, this.frontR, this.rearL, this.rearR]) w.tire.rotation.x = this._spin;
+
+        // exhaust flame on boost
+        const flameOn = r.boost > 0.05;
+        for (const f of this.flames) {
+            f.visible = flameOn;
+            const s = 0.6 + r.boost * 1.1;
+            f.scale.set(1, 1, s);
+        }
+
+        // ground charge glow / boost flare
         if (r.driftStage > 0) {
             this.glowMat.color.setHex(COLORS.driftStage[r.driftStage - 1]);
-            this.glowMat.opacity = 0.35 + 0.2 * Math.sin(performance.now() * 0.02);
+            this.glowMat.opacity = 0.4 + 0.22 * Math.sin(performance.now() * 0.02);
+            this.glow.scale.setScalar(0.8 + r.driftStage * 0.12);
         } else if (r.boost > 0.01) {
             this.glowMat.color.setHex(COLORS.driftStage[Math.max(0, r.boostStage - 1)]);
-            this.glowMat.opacity = 0.4 * r.boost;
+            this.glowMat.opacity = 0.45 * r.boost;
+            this.glow.scale.setScalar(1);
         } else {
             this.glowMat.opacity = 0;
         }
     }
 }
 
-function clamp(v, lo, hi) {
-    return v < lo ? lo : v > hi ? hi : v;
+function makeWheel(radius = 0.5) {
+    const pivot = new THREE.Group();
+    const tire = mesh(new THREE.CylinderGeometry(radius, radius, 0.42, 18), toonMat(COLORS.wheel));
+    tire.rotation.z = Math.PI / 2; // roll axis -> X
+    pivot.add(tire);
+    for (const sx of [-1, 1]) {
+        const cap = mesh(new THREE.CylinderGeometry(radius * 0.45, radius * 0.45, 0.44, 12), toonMat(COLORS.hubcap));
+        cap.rotation.z = Math.PI / 2;
+        cap.position.x = sx * 0.005;
+        tire.add(cap);
+    }
+    return { pivot, tire };
 }
+
+function mesh(geo, mat) { return new THREE.Mesh(geo, mat); }
+
+function roundedBox(w, h, d, r) {
+    return new RoundedBoxGeometry(w, h, d, 3, r);
+}
+
+function clamp(v, lo, hi) { return v < lo ? lo : v > hi ? hi : v; }

--- a/apps/kart/render/materials.js
+++ b/apps/kart/render/materials.js
@@ -1,0 +1,27 @@
+// Shared cel-shading helpers. A MeshToonMaterial with a small stepped gradient
+// map gives the flat banded look that reads as "cartoon" while still responding
+// to lights and shadows. One gradient ramp is shared across every mesh.
+
+import * as THREE from 'three';
+
+let _grad = null;
+
+export function toonGradient() {
+    if (_grad) return _grad;
+    // 4-step ramp: shadow -> mid -> light -> highlight
+    const steps = new Uint8Array([90, 160, 215, 255]);
+    _grad = new THREE.DataTexture(steps, steps.length, 1, THREE.RedFormat);
+    _grad.minFilter = THREE.NearestFilter;
+    _grad.magFilter = THREE.NearestFilter;
+    _grad.generateMipmaps = false;
+    _grad.needsUpdate = true;
+    return _grad;
+}
+
+export function toonMat(color, opts = {}) {
+    return new THREE.MeshToonMaterial({
+        color,
+        gradientMap: toonGradient(),
+        ...opts,
+    });
+}

--- a/apps/kart/render/postprocessing.js
+++ b/apps/kart/render/postprocessing.js
@@ -1,0 +1,88 @@
+// Postprocessing: RenderPass -> gentle UnrealBloom -> grade (soft vignette +
+// boost chromatic split) -> OutputPass. For the bright cartoon look the bloom is
+// kept low with a high threshold so only highlights (sky, white kerbs, sparks)
+// glow rather than the whole frame washing out. Chromatic aberration stays at
+// zero until you boost, where it punches to sell speed.
+//
+// useHalfFloat is forced off on mobile (iOS WebKit is flaky with HalfFloat
+// colour attachments); UnsignedByte renders reliably everywhere.
+
+import * as THREE from 'three';
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
+import { ShaderPass } from 'three/addons/postprocessing/ShaderPass.js';
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+
+const GRADE_SHADER = {
+    uniforms: {
+        tDiffuse: { value: null },
+        uAmount: { value: 0.0 },
+        uVignette: { value: 0.9 },
+    },
+    vertexShader: /* glsl */`
+        varying vec2 vUv;
+        void main() {
+            vUv = uv;
+            gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+        }
+    `,
+    fragmentShader: /* glsl */`
+        varying vec2 vUv;
+        uniform sampler2D tDiffuse;
+        uniform float uAmount;
+        uniform float uVignette;
+        void main() {
+            vec2 dir = vUv - 0.5;
+            float r2 = dot(dir, dir);
+            vec2 off = dir * (uAmount * (0.3 + r2 * 2.0));
+            vec3 col;
+            col.r = texture2D(tDiffuse, vUv + off).r;
+            col.g = texture2D(tDiffuse, vUv).g;
+            col.b = texture2D(tDiffuse, vUv - off).b;
+            float vig = smoothstep(0.95, uVignette * 0.45, r2);
+            col *= mix(0.78, 1.0, vig);
+            gl_FragColor = vec4(col, 1.0);
+        }
+    `,
+};
+
+export class Post {
+    constructor(renderer, scene, camera, opts = {}) {
+        const w = opts.width || 1;
+        const h = opts.height || 1;
+
+        const rtType = opts.useHalfFloat ? THREE.HalfFloatType : THREE.UnsignedByteType;
+        const target = new THREE.WebGLRenderTarget(w, h, { type: rtType, samples: 0 });
+
+        this.composer = new EffectComposer(renderer, target);
+        this.composer.addPass(new RenderPass(scene, camera));
+
+        this.bloom = new UnrealBloomPass(
+            new THREE.Vector2(w, h),
+            opts.bloomStrength ?? 0.35,
+            opts.bloomRadius ?? 0.6,
+            opts.bloomThreshold ?? 0.82,
+        );
+        this.composer.addPass(this.bloom);
+
+        this.grade = new ShaderPass(GRADE_SHADER);
+        this.composer.addPass(this.grade);
+
+        this.composer.addPass(new OutputPass());
+    }
+
+    setSize(w, h) {
+        this.composer.setSize(w, h);
+        this.bloom.setSize(w, h);
+    }
+
+    // amount: 0..1 chromatic intensity (driven by boost)
+    setGrade(amount) {
+        this.grade.uniforms.uAmount.value = amount * 0.016;
+    }
+
+    render() {
+        this.composer.render();
+    }
+}

--- a/apps/kart/render/props.js
+++ b/apps/kart/render/props.js
@@ -1,0 +1,86 @@
+// Static set dressing: chunky cartoon trees, distant rolling hills, and floating
+// clouds. Scattered once at build time and never touched again. Trees avoid the
+// drivable surface; hills sit far out in the fog for depth.
+
+import * as THREE from 'three';
+import { COLORS, VISUALS } from '../config.js';
+import { toonMat } from './materials.js';
+
+export function buildProps(track) {
+    const group = new THREE.Group();
+    group.add(trees(track));
+    group.add(hills());
+    group.add(clouds());
+    return group;
+}
+
+function trees(track) {
+    const g = new THREE.Group();
+    const trunkGeo = new THREE.CylinderGeometry(0.28, 0.38, 1.6, 8);
+    const trunkMat = toonMat(COLORS.treeTrunk);
+    const leafGeoA = new THREE.ConeGeometry(1.5, 2.6, 9);
+    const leafGeoB = new THREE.ConeGeometry(1.15, 2.0, 9);
+    const leafMatA = toonMat(COLORS.treeLeaf);
+    const leafMatB = toonMat(COLORS.treeLeaf2);
+
+    let placed = 0, attempts = 0;
+    while (placed < VISUALS.trees && attempts < VISUALS.trees * 12) {
+        attempts++;
+        const x = (Math.random() - 0.5) * 230;
+        const z = (Math.random() - 0.5) * 230;
+        if (track.isOnTrack(x, z)) continue;            // keep off the road
+        const scale = 0.8 + Math.random() * 1.1;
+        const t = new THREE.Group();
+        // trees don't cast shadows (they'd be the bulk of shadow casters); the
+        // kart, cones and banner shadows are enough to ground the scene.
+        const trunk = new THREE.Mesh(trunkGeo, trunkMat);
+        trunk.position.y = 0.8;
+        t.add(trunk);
+        const l1 = new THREE.Mesh(leafGeoA, leafMatA);
+        l1.position.y = 2.4; t.add(l1);
+        const l2 = new THREE.Mesh(leafGeoB, leafMatB);
+        l2.position.y = 3.6; t.add(l2);
+        t.position.set(x, 0, z);
+        t.scale.setScalar(scale);
+        t.rotation.y = Math.random() * Math.PI;
+        g.add(t);
+        placed++;
+    }
+    return g;
+}
+
+function hills() {
+    const g = new THREE.Group();
+    const mat = toonMat(COLORS.hill);
+    for (let i = 0; i < VISUALS.hills; i++) {
+        const a = (i / VISUALS.hills) * Math.PI * 2 + Math.random() * 0.3;
+        const r = 200 + Math.random() * 80;
+        const rad = 26 + Math.random() * 30;
+        const hill = new THREE.Mesh(new THREE.SphereGeometry(rad, 16, 10), mat);
+        hill.position.set(Math.cos(a) * r, -rad * 0.45, Math.sin(a) * r);
+        hill.scale.y = 0.5;
+        g.add(hill);
+    }
+    return g;
+}
+
+function clouds() {
+    const g = new THREE.Group();
+    const mat = new THREE.MeshBasicMaterial({ color: COLORS.cloud, fog: false });
+    for (let i = 0; i < VISUALS.clouds; i++) {
+        const cloud = new THREE.Group();
+        const puffs = 3 + Math.floor(Math.random() * 3);
+        for (let p = 0; p < puffs; p++) {
+            const r = 4 + Math.random() * 4;
+            const puff = new THREE.Mesh(new THREE.SphereGeometry(r, 12, 8), mat);
+            puff.position.set((Math.random() - 0.5) * 14, (Math.random() - 0.5) * 3, (Math.random() - 0.5) * 8);
+            puff.scale.y = 0.6;
+            cloud.add(puff);
+        }
+        const a = Math.random() * Math.PI * 2;
+        const r = 80 + Math.random() * 160;
+        cloud.position.set(Math.cos(a) * r, 45 + Math.random() * 35, Math.sin(a) * r);
+        g.add(cloud);
+    }
+    return g;
+}

--- a/apps/kart/render/scene.js
+++ b/apps/kart/render/scene.js
@@ -1,9 +1,10 @@
-// Renderer + scene + lights + ground plane. Pure presentation: it reads the
-// simulation's state but never changes it. Keeping all Three.js behind render/*
-// means the simulation stays portable.
+// Renderer + scene + sky + lights + ground. Bright cartoon look: a gradient sky
+// dome, a warm sun that casts soft shadows (the single biggest "this looks real"
+// win), and a striped mown-lawn ground. Pure presentation — never mutates sim.
 
 import * as THREE from 'three';
 import { COLORS } from '../config.js';
+import { toonMat } from './materials.js';
 
 export class Stage {
     constructor(canvas, tier) {
@@ -14,27 +15,81 @@ export class Stage {
         });
         this.renderer.setPixelRatio(tier.pixelRatio);
         this.renderer.outputColorSpace = THREE.SRGBColorSpace;
-        this.renderer.shadowMap.enabled = false;
+        this.renderer.shadowMap.enabled = true;
+        this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 
         this.scene = new THREE.Scene();
-        this.scene.background = new THREE.Color(COLORS.sky);
-        this.scene.fog = new THREE.Fog(COLORS.fog, 90, 320);
+        this.scene.fog = new THREE.Fog(COLORS.fog, 130, 380);
 
-        this.camera = new THREE.PerspectiveCamera(72, 1, 0.1, 600);
+        this.camera = new THREE.PerspectiveCamera(72, 1, 0.1, 1000);
         this.camera.position.set(0, 6, -10);
 
-        // lighting — flat and bright; art doesn't matter this milestone
-        this.scene.add(new THREE.HemisphereLight(0xffffff, 0x4a6a3a, 1.0));
-        const sun = new THREE.DirectionalLight(0xffffff, 1.1);
-        sun.position.set(40, 80, 30);
-        this.scene.add(sun);
+        this._addSky();
+        this._addLights(tier);
+        this._addGround();
+    }
 
-        // ground (grass) — large plane under everything
-        const groundGeo = new THREE.PlaneGeometry(1200, 1200);
-        groundGeo.rotateX(-Math.PI / 2);
-        const groundMat = new THREE.MeshLambertMaterial({ color: COLORS.grass });
-        this.ground = new THREE.Mesh(groundGeo, groundMat);
+    _addSky() {
+        const geo = new THREE.SphereGeometry(480, 32, 16);
+        const mat = new THREE.ShaderMaterial({
+            side: THREE.BackSide,
+            depthWrite: false,
+            fog: false,
+            uniforms: {
+                top: { value: new THREE.Color(COLORS.skyTop) },
+                bottom: { value: new THREE.Color(COLORS.skyBottom) },
+            },
+            vertexShader: /* glsl */`
+                varying vec3 vDir;
+                void main() {
+                    vDir = normalize(position);
+                    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+                }
+            `,
+            fragmentShader: /* glsl */`
+                varying vec3 vDir;
+                uniform vec3 top;
+                uniform vec3 bottom;
+                void main() {
+                    float t = clamp(vDir.y * 0.5 + 0.5, 0.0, 1.0);
+                    t = pow(t, 0.75);
+                    gl_FragColor = vec4(mix(bottom, top, t), 1.0);
+                }
+            `,
+        });
+        const sky = new THREE.Mesh(geo, mat);
+        sky.frustumCulled = false;
+        this.scene.add(sky);
+    }
+
+    _addLights(tier) {
+        this.scene.add(new THREE.HemisphereLight(COLORS.skyTop, COLORS.grass, 0.95));
+
+        const sun = new THREE.DirectionalLight(COLORS.sun, 1.35);
+        sun.position.set(60, 110, 40);
+        sun.castShadow = true;
+        const sz = tier.shadowMap;
+        sun.shadow.mapSize.set(sz, sz);
+        const d = 85;
+        sun.shadow.camera.left = -d;
+        sun.shadow.camera.right = d;
+        sun.shadow.camera.top = d;
+        sun.shadow.camera.bottom = -d;
+        sun.shadow.camera.near = 1;
+        sun.shadow.camera.far = 320;
+        sun.shadow.bias = -0.0006;
+        sun.shadow.normalBias = 0.5;
+        this.scene.add(sun);
+        this.scene.add(sun.target);
+    }
+
+    _addGround() {
+        const geo = new THREE.PlaneGeometry(1400, 1400);
+        geo.rotateX(-Math.PI / 2);
+        const mat = toonMat(0xffffff, { map: stripedLawn() });
+        this.ground = new THREE.Mesh(geo, mat);
         this.ground.position.y = -0.02;
+        this.ground.receiveShadow = true;
         this.scene.add(this.ground);
     }
 
@@ -50,8 +105,24 @@ export class Stage {
             this.camera.updateProjectionMatrix();
         }
     }
+}
 
-    render() {
-        this.renderer.render(this.scene, this.camera);
+// Canvas texture of alternating green stripes -> mown-lawn / golf-course look.
+function stripedLawn() {
+    const size = 256;
+    const c = document.createElement('canvas');
+    c.width = c.height = size;
+    const ctx = c.getContext('2d');
+    const a = '#' + COLORS.grass.toString(16).padStart(6, '0');
+    const b = '#' + COLORS.grassDark.toString(16).padStart(6, '0');
+    for (let i = 0; i < 8; i++) {
+        ctx.fillStyle = i % 2 ? a : b;
+        ctx.fillRect(0, (i / 8) * size, size, size / 8);
     }
+    const tex = new THREE.CanvasTexture(c);
+    tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+    tex.repeat.set(60, 60);
+    tex.colorSpace = THREE.SRGBColorSpace;
+    tex.anisotropy = 4;
+    return tex;
 }

--- a/apps/kart/render/trackView.js
+++ b/apps/kart/render/trackView.js
@@ -1,82 +1,105 @@
-// Builds the visible track from the simulation's sampled centerline: a flat
-// asphalt ribbon, bright edge lines, a dashed center line, and a checkered
-// start/finish stripe. Geometry only — no per-frame work.
+// Builds the visible track from the sim's sampled centerline: asphalt ribbon,
+// striped red/white kerbs, a dashed centre line, a checkered start stripe with
+// a START / FINISH banner arch, and traffic cones along the edges. Geometry
+// only — built once, no per-frame work.
 
 import * as THREE from 'three';
-import { COLORS } from '../config.js';
+import { COLORS, VISUALS } from '../config.js';
+import { toonMat } from './materials.js';
 
 export function buildTrackView(track) {
     const group = new THREE.Group();
     const n = track.samples.length;
 
-    // ---- asphalt ribbon (two triangles per segment, left/right edges) ----
+    // ---- asphalt ribbon ----
     const positions = [];
     const indices = [];
     for (let i = 0; i < n; i++) {
-        const l = track.leftEdge[i];
-        const r = track.rightEdge[i];
+        const l = track.leftEdge[i], r = track.rightEdge[i];
         positions.push(l.x, 0, l.z, r.x, 0, r.z);
     }
     for (let i = 0; i < n; i++) {
-        const a = i * 2;          // left i
-        const b = i * 2 + 1;      // right i
         const ni = (i + 1) % n;
-        const c = ni * 2;         // left i+1
-        const d = ni * 2 + 1;     // right i+1
-        indices.push(a, b, c, b, d, c);
+        indices.push(i * 2, i * 2 + 1, ni * 2, i * 2 + 1, ni * 2 + 1, ni * 2);
     }
     const geo = new THREE.BufferGeometry();
     geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
     geo.setIndex(indices);
     geo.computeVertexNormals();
-    const road = new THREE.Mesh(geo, new THREE.MeshLambertMaterial({ color: COLORS.track }));
-    road.position.y = 0;
+    const road = new THREE.Mesh(geo, toonMat(COLORS.track));
+    road.receiveShadow = true;
     group.add(road);
 
-    // ---- edge lines (closed loops slightly inset so they sit on the asphalt) ----
-    group.add(edgeLine(track.leftEdge, track.samples, 0.85, COLORS.trackEdge));
-    group.add(edgeLine(track.rightEdge, track.samples, 0.85, COLORS.trackEdge));
+    // ---- kerbs (striped red/white strips just outside each edge) ----
+    group.add(kerb(track.leftEdge, track.samples, 0.9));
+    group.add(kerb(track.rightEdge, track.samples, 0.9));
 
-    // ---- dashed center line ----
+    // ---- white edge lines + dashed centre line ----
+    group.add(edgeLine(track.leftEdge, track.samples));
+    group.add(edgeLine(track.rightEdge, track.samples));
     group.add(centerDashes(track));
 
-    // ---- start/finish checkered stripe across the track at sample 0 ----
+    // ---- start line + banner ----
     group.add(startStripe(track));
+    group.add(startBanner(track));
+
+    // ---- cones along the edges ----
+    group.add(cones(track));
 
     return group;
 }
 
-// A thin quad strip running along an edge, nudged toward the centerline so it
-// renders on the asphalt rather than the grass.
-function edgeLine(edge, center, blend, color) {
+// Striped kerb strip running from the edge outward, vertex-coloured red/white.
+function kerb(edge, center, width) {
     const n = edge.length;
-    const width = 0.45;
-    const positions = [];
-    const indices = [];
+    const pos = [], idx = [], col = [];
+    const red = new THREE.Color(COLORS.kerbRed);
+    const white = new THREE.Color(COLORS.kerbWhite);
     for (let i = 0; i < n; i++) {
-        // point on the asphalt near the edge
         const ex = edge[i].x, ez = edge[i].z;
-        const cx = center[i].x, cz = center[i].z;
-        const px = ex + (cx - ex) * (1 - blend);
-        const pz = ez + (cz - ez) * (1 - blend);
-        // inward direction (toward center)
-        let dx = cx - ex, dz = cz - ez;
-        const dl = Math.hypot(dx, dz) || 1e-6; dx /= dl; dz /= dl;
-        positions.push(px, 0, pz, px + dx * width, 0, pz + dz * width);
+        let ox = ex - center[i].x, oz = ez - center[i].z; // outward
+        const ol = Math.hypot(ox, oz) || 1e-6; ox /= ol; oz /= ol;
+        pos.push(ex, 0, ez, ex + ox * width, 0, ez + oz * width);
+        const c = (i % 2) ? red : white;
+        col.push(c.r, c.g, c.b, c.r, c.g, c.b);
     }
     for (let i = 0; i < n; i++) {
-        const a = i * 2, b = i * 2 + 1;
         const ni = (i + 1) % n;
-        const c = ni * 2, d = ni * 2 + 1;
-        indices.push(a, b, c, b, d, c);
+        idx.push(i * 2, i * 2 + 1, ni * 2, i * 2 + 1, ni * 2 + 1, ni * 2);
     }
-    const geo = new THREE.BufferGeometry();
-    geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
-    geo.setIndex(indices);
-    geo.computeVertexNormals();
-    const mesh = new THREE.Mesh(geo, new THREE.MeshBasicMaterial({ color }));
-    mesh.position.y = 0.02;
-    return mesh;
+    const g = new THREE.BufferGeometry();
+    g.setAttribute('position', new THREE.Float32BufferAttribute(pos, 3));
+    g.setAttribute('color', new THREE.Float32BufferAttribute(col, 3));
+    g.setIndex(idx);
+    g.computeVertexNormals();
+    const m = new THREE.Mesh(g, toonMat(0xffffff, { vertexColors: true }));
+    m.position.y = 0.015;
+    m.receiveShadow = true;
+    return m;
+}
+
+function edgeLine(edge, center) {
+    const n = edge.length;
+    const width = 0.4, inset = 0.12;
+    const pos = [], idx = [];
+    for (let i = 0; i < n; i++) {
+        const ex = edge[i].x, ez = edge[i].z;
+        let dx = center[i].x - ex, dz = center[i].z - ez;
+        const dl = Math.hypot(dx, dz) || 1e-6; dx /= dl; dz /= dl;
+        const px = ex + dx * inset, pz = ez + dz * inset;
+        pos.push(px, 0, pz, px + dx * width, 0, pz + dz * width);
+    }
+    for (let i = 0; i < n; i++) {
+        const ni = (i + 1) % n;
+        idx.push(i * 2, i * 2 + 1, ni * 2, i * 2 + 1, ni * 2 + 1, ni * 2);
+    }
+    const g = new THREE.BufferGeometry();
+    g.setAttribute('position', new THREE.Float32BufferAttribute(pos, 3));
+    g.setIndex(idx);
+    g.computeVertexNormals();
+    const m = new THREE.Mesh(g, new THREE.MeshBasicMaterial({ color: COLORS.trackEdge }));
+    m.position.y = 0.025;
+    return m;
 }
 
 function centerDashes(track) {
@@ -85,29 +108,69 @@ function centerDashes(track) {
     const mat = new THREE.MeshBasicMaterial({ color: COLORS.centerLine });
     const dashGeo = new THREE.PlaneGeometry(0.35, 2.2);
     dashGeo.rotateX(-Math.PI / 2);
-    for (let i = 0; i < n; i += 3) {
-        const s = track.samples[i];
-        const t = track.tangents[i];
-        const dash = new THREE.Mesh(dashGeo, mat);
-        dash.position.set(s.x, 0.03, s.z);
-        dash.rotation.y = Math.atan2(t.x, t.z);
-        g.add(dash);
+    for (let i = 4; i < n; i += 4) {
+        const s = track.samples[i], t = track.tangents[i];
+        const d = new THREE.Mesh(dashGeo, mat);
+        d.position.set(s.x, 0.03, s.z);
+        d.rotation.y = Math.atan2(t.x, t.z);
+        g.add(d);
     }
     return g;
 }
 
 function startStripe(track) {
-    const s = track.samples[0];
-    const t = track.tangents[0];
-    const w = track.halfWidth * 2;
-    const geo = new THREE.PlaneGeometry(w, 2.2);
+    const s = track.samples[0], t = track.tangents[0];
+    const geo = new THREE.PlaneGeometry(track.halfWidth * 2, 2.4);
     geo.rotateX(-Math.PI / 2);
-    const tex = checkerTexture();
-    const mat = new THREE.MeshBasicMaterial({ map: tex });
-    const stripe = new THREE.Mesh(geo, mat);
-    stripe.position.set(s.x, 0.04, s.z);
+    const stripe = new THREE.Mesh(geo, new THREE.MeshBasicMaterial({ map: checkerTexture() }));
+    stripe.position.set(s.x, 0.035, s.z);
     stripe.rotation.y = Math.atan2(t.x, t.z);
     return stripe;
+}
+
+function startBanner(track) {
+    const g = new THREE.Group();
+    const s = track.samples[0], t = track.tangents[0];
+    const yaw = Math.atan2(t.x, t.z);
+    const span = track.halfWidth * 2 + 1.6;
+    const postMat = toonMat(COLORS.bannerPost);
+
+    for (const side of [-1, 1]) {
+        const post = new THREE.Mesh(new THREE.CylinderGeometry(0.25, 0.25, 5.2, 12), postMat);
+        // offset sideways along the track's lateral (right) vector
+        const rx = Math.cos(yaw), rz = -Math.sin(yaw);
+        post.position.set(s.x + rx * side * span / 2, 2.6, s.z + rz * side * span / 2);
+        post.castShadow = true;
+        g.add(post);
+    }
+
+    const banner = new THREE.Mesh(
+        new THREE.BoxGeometry(span, 1.3, 0.2),
+        new THREE.MeshBasicMaterial({ map: bannerTexture() })
+    );
+    banner.position.set(s.x, 5.0, s.z);
+    banner.rotation.y = yaw;
+    g.add(banner);
+    return g;
+}
+
+function cones(track) {
+    const g = new THREE.Group();
+    const n = track.samples.length;
+    const step = Math.max(1, Math.floor(n / VISUALS.conesPerSide));
+    const coneGeo = new THREE.ConeGeometry(0.28, 0.8, 12);
+    const mat = toonMat(COLORS.cone);
+    for (let i = 0; i < n; i += step) {
+        for (const [edge, sign] of [[track.leftEdge, 1], [track.rightEdge, 1]]) {
+            let ox = edge[i].x - track.samples[i].x, oz = edge[i].z - track.samples[i].z;
+            const ol = Math.hypot(ox, oz) || 1e-6; ox /= ol; oz /= ol;
+            const c = new THREE.Mesh(coneGeo, mat);
+            c.position.set(edge[i].x + ox * 1.4 * sign, 0.4, edge[i].z + oz * 1.4 * sign);
+            c.castShadow = true;
+            g.add(c);
+        }
+    }
+    return g;
 }
 
 function checkerTexture() {
@@ -116,15 +179,38 @@ function checkerTexture() {
     c.width = c.height = size;
     const ctx = c.getContext('2d');
     const cs = size / cells;
-    for (let y = 0; y < cells; y++) {
+    for (let y = 0; y < cells; y++)
         for (let x = 0; x < cells; x++) {
             ctx.fillStyle = (x + y) % 2 ? '#111' : '#fff';
             ctx.fillRect(x * cs, y * cs, cs, cs);
         }
-    }
     const tex = new THREE.CanvasTexture(c);
     tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
     tex.repeat.set(6, 1);
+    tex.colorSpace = THREE.SRGBColorSpace;
+    return tex;
+}
+
+function bannerTexture() {
+    const w = 512, h = 96;
+    const c = document.createElement('canvas');
+    c.width = w; c.height = h;
+    const ctx = c.getContext('2d');
+    ctx.fillStyle = '#2a2f3a'; ctx.fillRect(0, 0, w, h);
+    // checker trim top/bottom
+    const cs = 16;
+    for (let x = 0; x < w / cs; x++) {
+        ctx.fillStyle = x % 2 ? '#fff' : '#111';
+        ctx.fillRect(x * cs, 0, cs, cs);
+        ctx.fillStyle = x % 2 ? '#111' : '#fff';
+        ctx.fillRect(x * cs, h - cs, cs, cs);
+    }
+    ctx.fillStyle = '#ffd23f';
+    ctx.font = 'bold 44px Helvetica, Arial, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('START / FINISH', w / 2, h / 2 + 2);
+    const tex = new THREE.CanvasTexture(c);
     tex.colorSpace = THREE.SRGBColorSpace;
     return tex;
 }


### PR DESCRIPTION
## Summary

A new single-player kart racing prototype at `/apps/kart/`, focused on milestone 1: **driving feel** (drift-to-boost), with a bright cartoon look. Architected so characters, kart types, maps, and host-authoritative multiplayer can be added later without a rewrite.

> Note on diff scope: the initial scaffold (pure simulation, fixed-timestep loop, lap/HUD, launcher entry) already landed on `master`, so this PR's diff is the **cartoon visual pass + controls fix** on top of it. Feature context for the whole milestone is below.

## What's in this PR
- **Controls fix:** the kart now **auto-drives** so the right thumb is free to drift (previously Gas and Drift were both right-thumb buttons — impossible to hold together). Drift is the big primary button; Brake is secondary; the Gas button was removed.
- **Bright cartoon look:** gentle bloom post-processing, gradient sky dome, warm sun with soft shadows, striped mown-lawn ground, and cel-shaded (toon) saturated materials throughout.
- **Rebuilt kart:** rounded body, driver + helmet, hubcapped wheels that steer and spin, spoiler, exhaust flame, a drift hop, and a ground charge-glow that tracks the drift stage.
- **Track dressing:** asphalt with red/white kerbs, a START/FINISH banner arch, traffic cones, plus trees, hills, and clouds.
- **Juice:** drift smoke (tinted to charge stage), skid marks, stage-up spark bursts, a boost trail, and camera shake on boost/stage-up.
- **New track:** a validated loop (no ribbon self-overlap; one tight ~12u corner plus medium corners and sweepers) so drift pays off differently around the lap.

## Architecture (multiplayer-ready)
- **Fixed-timestep 60Hz simulation** decoupled from rendering, with render interpolation between the last two sim states.
- The kart sim is a **pure `(state, input) -> state`** function (`simulation/`), free of any Three.js / DOM / input-device code, so it can run unchanged on a future authoritative host.
- Clean separation: `simulation/` (deterministic), `render/` (Three.js), `input/` (keyboard + touch), with all tunable feel numbers in one `config.js` object.

## Controls
- **Mobile (landscape):** left thumb = analog steer; **Drift** (big) and **Brake** (small) on the right; auto-drive.
- **Desktop:** ←→ / A·D steer, **Space** drift, **S** brake.
- Portrait shows a rotate prompt; a Screen Wake Lock is requested while racing.

## How to test
- [ ] `python3 -m http.server 8000`, open `/apps/kart/` (best on a phone, landscape).
- [ ] Drift-to-boost: hold Drift through a corner, watch the charge meter go blue→orange→purple, release for a boost.
- [ ] Confirm you can steer + drift simultaneously (the original bug).
- [ ] 3-lap race: countdown, lap counter/times, results panel, restart.
- [ ] Off-track grass slows you; cones/kerbs/banner render; shadows and bloom look right.

## Known caveat
The build environment has no display/GPU, so the visuals were authored **without being rendered** — the simulation and track math are verified in Node and every module is syntax-checked, but lighting brightness, shadow/bloom strength, and banner placement may need a tweak once viewed. An on-screen error overlay surfaces any runtime failure.

https://claude.ai/code/session_011FJ8jDY7WMXJFZSbi9cPeh

---
_Generated by [Claude Code](https://claude.ai/code/session_011FJ8jDY7WMXJFZSbi9cPeh)_