### PR TITLE
Kart: fix floating wheels, enlarge/widen track, add barrier walls

### DIFF
--- a/apps/kart/config.js
+++ b/apps/kart/config.js
@@ -15,7 +15,7 @@ export const TUNING = {
     // Exponential eases: `vForward += (target - vForward) * rate * dt`. A higher
     // rate snaps harder. This doubles as the acceleration curve (fast off the
     // line, tapering as you approach top speed) and the boost bleed-off.
-    topSpeed: 34,            // normal forward top speed (units/s)
+    topSpeed: 42,            // normal forward top speed (units/s)
     accel: 2.4,              // ramp-up rate toward target while accelerating
     engineBrake: 1.7,        // ramp-down rate when above target (how boost bleeds off)
     brakeStrength: 3.6,      // ramp rate toward 0 / reverse while braking
@@ -52,19 +52,23 @@ export const TUNING = {
     // ---------------------------------------------------------------- boost
     // Indexed by the highest stage reached when drift is released (0 = released
     // before stage 1 -> nothing). Boost adds a decaying bonus on top of topSpeed.
-    boostStageBonus: [0, 8, 13, 19],     // extra units/s above top speed
+    boostStageBonus: [0, 10, 16, 24],    // extra units/s above top speed
     boostStageDuration: [0, 0.75, 1.15, 1.6], // seconds the bonus takes to decay to 0
 
     // ---------------------------------------------------------------- off-track
-    offTrackMaxSpeed: 14,    // hard speed ceiling on the grass
+    offTrackMaxSpeed: 16,    // hard speed ceiling on the grass runoff
     offTrackDrag: 4.5,       // strong decel toward the ceiling when off-track
     offTrackGrip: 5.5,       // grass is a little loose underfoot
 
+    // ---------------------------------------------------------------- walls
+    wallBounce: 0.15,        // 0 = slide along wall, higher = bounce off it
+    wallScrub: 0.92,         // speed retained on wall contact (lower = more punishing)
+
     // ---------------------------------------------------------------- camera
-    camDistance: 7.4,        // how far behind the kart the camera sits
-    camHeight: 3.3,          // camera height above the ground
-    camLookAhead: 7.0,       // look target distance ahead of the kart
-    camLookHeight: 0.9,      // look slightly down toward the kart
+    camDistance: 8.6,        // how far behind the kart the camera sits
+    camHeight: 4.0,          // camera height above the ground
+    camLookAhead: 9.0,       // look target distance ahead of the kart
+    camLookHeight: 1.0,      // look slightly down toward the kart
     camFollowLag: 6.5,       // position follow rate (higher = tighter, less lag)
     camFovBase: 72,
     camFovBoost: 82,         // FOV widens on boost to sell speed
@@ -89,17 +93,18 @@ export const TUNING = {
 // sweepers so drift pays off. Kept here (not in render) because the simulation
 // needs the same geometry for the on-track test and lap progress.
 export const TRACK = {
-    halfWidth: 6.5,
+    halfWidth: 12,           // drivable road half-width (24u wide -> ~4 karts abreast)
+    wallHalfWidth: 14.5,     // hard wall: ~2.5u of grass runoff outside the road, then a barrier
     // [x, z] control points, traversed in order. Closed loop. This curve was
-    // validated offline to be free of self-overlap (min self-distance ~52u) while
-    // featuring one tight corner (turn radius ~12u), several medium corners, and
-    // long sweepers — so drift pays off differently around the lap. Start/finish
-    // sits on the straightest section.
+    // validated offline to be free of self-overlap (min self-distance ~91u) while
+    // featuring one tight corner (turn radius ~21u, comfortably clear of the wall
+    // radius), several medium corners, and long sweepers — so drift pays off
+    // differently around the lap. ~657u long. Start/finish on the straightest part.
     controlPoints: [
-        [-29.1, 36.5], [-47.5, 22.9], [-63.1, 0], [-60, -28.9],
-        [-35.7, -44.8], [-8.8, -38.4], [5.5, -24.3], [15.4, -19.4],
-        [36.6, -17.6], [63.1, 0], [71, 34.2], [49.4, 61.9],
-        [14.8, 65], [-11.6, 50.9],
+        [-46.7, 58.6], [-78.8, 38], [-108.3, 0], [-105.2, -50.7],
+        [-63.5, -79.6], [-15.7, -69], [10, -43.7], [27.2, -34.1],
+        [63.2, -30.4], [108.3, 0], [120.9, 58.2], [83, 104.1],
+        [24.4, 107], [-18.7, 81.8],
     ],
     samplesPerSegment: 26,   // spline resolution for the on-track test + mesh
 };
@@ -137,11 +142,11 @@ export const COLORS = {
 
 // Counts / sizes for set dressing and effects. Bumped down on mobile by the tier.
 export const VISUALS = {
-    trees: 46,
-    clouds: 14,
-    hills: 9,
-    conesPerSide: 26,        // pylons spaced along each track edge
+    trees: 64,
+    clouds: 16,
+    hills: 11,
+    conesPerSide: 32,        // pylons spaced along each track edge
     smokeMax: 90,            // drift smoke particle pool
-    skidMax: 140,            // skid-mark quad pool
+    skidMax: 160,            // skid-mark quad pool
     sparkMax: 60,            // boost / stage-up spark pool
 };

--- a/apps/kart/main.js
+++ b/apps/kart/main.js
@@ -26,7 +26,7 @@ import { TUNING as T } from './config.js';
 
 const STEP = 1 / 60;
 const MAX_BOOST_BONUS = Math.max(...T.boostStageBonus);
-const SLIP_REF = 12;            // lateral speed that reads as "full slide" (visual only)
+const SLIP_REF = 15;            // lateral speed that reads as "full slide" (visual only)
 const SPEED_DISPLAY_SCALE = 3;  // raw units/s -> punchier HUD number (display only)
 
 function showFatal(msg) {
@@ -267,6 +267,7 @@ function frame(now) {
         kartView.update(r, dt);
         effects.update(dt, r);
         chase.update(r, r.boost, dt);
+        stage.setSunFocus(r.x, r.z);
 
         // camera shake: continuous on boost + a kick on each charge stage-up
         if (game.curr.driftStage > game.lastStage) game.shake = T.camShakeStageUp;

--- a/apps/kart/render/effects.js
+++ b/apps/kart/render/effects.js
@@ -38,8 +38,8 @@ export class Effects {
         const rgtX = Math.cos(fx.heading), rgtZ = -Math.sin(fx.heading);
         // rear-wheel world positions
         const rear = (side) => ({
-            x: fx.x + rgtX * side * 0.98 + fwdX * -1.05,
-            z: fx.z + rgtZ * side * 0.98 + fwdZ * -1.05,
+            x: fx.x + rgtX * side * 1.02 + fwdX * -1.15,
+            z: fx.z + rgtZ * side * 1.02 + fwdZ * -1.15,
         });
 
         // ---- drift smoke + skid ----

--- a/apps/kart/render/kartView.js
+++ b/apps/kart/render/kartView.js
@@ -23,53 +23,58 @@ export class KartView {
         const accentMat = toonMat(COLORS.kartBody2);
         const darkMat = toonMat(COLORS.kartAccent);
 
+        // low floor pan ties the body to the wheels (no floating gap)
+        const floor = mesh(roundedBox(1.55, 0.3, 2.7, 0.12), darkMat);
+        floor.position.y = 0.4;
+        this.chassis.add(floor);
+
         // main tub
-        const tub = mesh(roundedBox(1.7, 0.55, 2.6, 0.18), bodyMat);
-        tub.position.y = 0.5;
+        const tub = mesh(roundedBox(1.4, 0.5, 1.9, 0.16), bodyMat);
+        tub.position.y = 0.78;
         this.chassis.add(tub);
 
         // sloped nose
-        const nose = mesh(roundedBox(1.3, 0.4, 1.0, 0.14), bodyMat);
-        nose.position.set(0, 0.4, 1.45);
+        const nose = mesh(roundedBox(1.2, 0.38, 1.05, 0.14), bodyMat);
+        nose.position.set(0, 0.6, 1.55);
         this.chassis.add(nose);
 
         // side pods
         for (const sx of [-1, 1]) {
-            const pod = mesh(roundedBox(0.4, 0.4, 1.6, 0.12), accentMat);
-            pod.position.set(sx * 0.95, 0.42, 0.1);
+            const pod = mesh(roundedBox(0.42, 0.45, 1.7, 0.12), accentMat);
+            pod.position.set(sx * 0.98, 0.5, 0.1);
             this.chassis.add(pod);
         }
 
         // seat + driver
         const seat = mesh(roundedBox(1.0, 0.5, 0.9, 0.12), darkMat);
-        seat.position.set(0, 0.78, -0.5);
+        seat.position.set(0, 0.95, -0.5);
         this.chassis.add(seat);
 
-        const torso = mesh(roundedBox(0.7, 0.7, 0.6, 0.16), toonMat(COLORS.helmet));
-        torso.position.set(0, 1.15, -0.45);
+        const torso = mesh(roundedBox(0.72, 0.72, 0.62, 0.16), toonMat(COLORS.helmet));
+        torso.position.set(0, 1.32, -0.45);
         this.chassis.add(torso);
 
         const head = mesh(new THREE.SphereGeometry(0.32, 16, 12), toonMat(COLORS.driver));
-        head.position.set(0, 1.62, -0.35);
+        head.position.set(0, 1.78, -0.35);
         this.chassis.add(head);
 
         const helmet = mesh(new THREE.SphereGeometry(0.36, 16, 12, 0, Math.PI * 2, 0, Math.PI * 0.62), toonMat(COLORS.helmet));
-        helmet.position.set(0, 1.66, -0.35);
+        helmet.position.set(0, 1.82, -0.35);
         this.chassis.add(helmet);
 
         // steering wheel
         const wheelHub = mesh(new THREE.TorusGeometry(0.22, 0.05, 8, 16), darkMat);
-        wheelHub.position.set(0, 1.05, 0.25);
+        wheelHub.position.set(0, 1.2, 0.35);
         wheelHub.rotation.x = Math.PI * 0.34;
         this.chassis.add(wheelHub);
 
         // rear spoiler
-        const wing = mesh(roundedBox(1.6, 0.12, 0.45, 0.05), accentMat);
-        wing.position.set(0, 1.05, -1.35);
+        const wing = mesh(roundedBox(1.65, 0.14, 0.5, 0.05), accentMat);
+        wing.position.set(0, 1.25, -1.5);
         this.chassis.add(wing);
-        for (const sx of [-0.6, 0.6]) {
-            const strut = mesh(new THREE.BoxGeometry(0.1, 0.5, 0.1), darkMat);
-            strut.position.set(sx, 0.82, -1.32);
+        for (const sx of [-0.62, 0.62]) {
+            const strut = mesh(new THREE.BoxGeometry(0.1, 0.55, 0.1), darkMat);
+            strut.position.set(sx, 0.98, -1.47);
             this.chassis.add(strut);
         }
 
@@ -78,12 +83,12 @@ export class KartView {
         for (const sx of [-0.4, 0.4]) {
             const pipe = mesh(new THREE.CylinderGeometry(0.09, 0.11, 0.5, 10), darkMat);
             pipe.rotation.x = Math.PI / 2;
-            pipe.position.set(sx, 0.7, -1.55);
+            pipe.position.set(sx, 0.72, -1.62);
             this.chassis.add(pipe);
 
             const flame = mesh(new THREE.ConeGeometry(0.16, 0.7, 10), new THREE.MeshBasicMaterial({ color: 0xfff1a8 }));
             flame.rotation.x = -Math.PI / 2;
-            flame.position.set(sx, 0.7, -1.95);
+            flame.position.set(sx, 0.72, -2.02);
             flame.visible = false;
             this.chassis.add(flame);
             this.flames.push(flame);
@@ -91,19 +96,20 @@ export class KartView {
 
         // antenna with ball
         const ant = mesh(new THREE.CylinderGeometry(0.02, 0.02, 0.7, 6), darkMat);
-        ant.position.set(0.5, 1.2, -0.9);
+        ant.position.set(0.52, 1.4, -0.9);
         this.chassis.add(ant);
         const ball = mesh(new THREE.SphereGeometry(0.09, 10, 8), toonMat(COLORS.kartBody2));
-        ball.position.set(0.5, 1.55, -0.9);
+        ball.position.set(0.52, 1.78, -0.9);
         this.chassis.add(ball);
 
-        // wheels (front pair steer; all spin)
-        this.frontL = makeWheel(); this.frontR = makeWheel();
-        this.rearL = makeWheel(0.52); this.rearR = makeWheel(0.52);
-        this.frontL.pivot.position.set(-0.92, 0.46, 1.05);
-        this.frontR.pivot.position.set(0.92, 0.46, 1.05);
-        this.rearL.pivot.position.set(-0.98, 0.52, -1.05);
-        this.rearR.pivot.position.set(0.98, 0.52, -1.05);
+        // wheels (front pair steer; all spin). Pivot y == radius so they sit
+        // exactly on the ground.
+        this.frontL = makeWheel(0.55); this.frontR = makeWheel(0.55);
+        this.rearL = makeWheel(0.62); this.rearR = makeWheel(0.62);
+        this.frontL.pivot.position.set(-0.98, 0.55, 1.15);
+        this.frontR.pivot.position.set(0.98, 0.55, 1.15);
+        this.rearL.pivot.position.set(-1.02, 0.62, -1.15);
+        this.rearR.pivot.position.set(1.02, 0.62, -1.15);
         for (const w of [this.frontL, this.frontR, this.rearL, this.rearR]) this.bob.add(w.pivot);
 
         // shadow casters

--- a/apps/kart/render/props.js
+++ b/apps/kart/render/props.js
@@ -23,12 +23,13 @@ function trees(track) {
     const leafMatA = toonMat(COLORS.treeLeaf);
     const leafMatB = toonMat(COLORS.treeLeaf2);
 
+    const clear = track.wallHalfWidth + 3;              // keep trees off the road + barriers
     let placed = 0, attempts = 0;
-    while (placed < VISUALS.trees && attempts < VISUALS.trees * 12) {
+    while (placed < VISUALS.trees && attempts < VISUALS.trees * 14) {
         attempts++;
-        const x = (Math.random() - 0.5) * 230;
-        const z = (Math.random() - 0.5) * 230;
-        if (track.isOnTrack(x, z)) continue;            // keep off the road
+        const x = (Math.random() - 0.5) * 320;
+        const z = (Math.random() - 0.5) * 320;
+        if (!track.confine(x, z, clear).hit) continue;  // inside clear radius -> skip
         const scale = 0.8 + Math.random() * 1.1;
         const t = new THREE.Group();
         // trees don't cast shadows (they'd be the bulk of shadow casters); the

--- a/apps/kart/render/scene.js
+++ b/apps/kart/render/scene.js
@@ -19,7 +19,7 @@ export class Stage {
         this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 
         this.scene = new THREE.Scene();
-        this.scene.fog = new THREE.Fog(COLORS.fog, 130, 380);
+        this.scene.fog = new THREE.Fog(COLORS.fog, 170, 480);
 
         this.camera = new THREE.PerspectiveCamera(72, 1, 0.1, 1000);
         this.camera.position.set(0, 6, -10);
@@ -66,21 +66,31 @@ export class Stage {
         this.scene.add(new THREE.HemisphereLight(COLORS.skyTop, COLORS.grass, 0.95));
 
         const sun = new THREE.DirectionalLight(COLORS.sun, 1.35);
-        sun.position.set(60, 110, 40);
+        sun.position.set(40, 90, 26);
         sun.castShadow = true;
         const sz = tier.shadowMap;
         sun.shadow.mapSize.set(sz, sz);
-        const d = 85;
+        // Tight frustum that follows the kart (see setSunFocus) so shadows stay
+        // crisp anywhere on the large track instead of covering it all at once.
+        const d = 40;
         sun.shadow.camera.left = -d;
         sun.shadow.camera.right = d;
         sun.shadow.camera.top = d;
         sun.shadow.camera.bottom = -d;
         sun.shadow.camera.near = 1;
-        sun.shadow.camera.far = 320;
+        sun.shadow.camera.far = 220;
         sun.shadow.bias = -0.0006;
         sun.shadow.normalBias = 0.5;
         this.scene.add(sun);
         this.scene.add(sun.target);
+        this.sun = sun;
+        this._sunOffset = sun.position.clone();
+    }
+
+    // Keep the shadow frustum centred on the kart.
+    setSunFocus(x, z) {
+        this.sun.target.position.set(x, 0, z);
+        this.sun.position.set(x + this._sunOffset.x, this._sunOffset.y, z + this._sunOffset.z);
     }
 
     _addGround() {

--- a/apps/kart/render/trackView.js
+++ b/apps/kart/render/trackView.js
@@ -46,7 +46,46 @@ export function buildTrackView(track) {
     // ---- cones along the edges ----
     group.add(cones(track));
 
+    // ---- barrier walls just outside the runoff (these constrain the kart) ----
+    group.add(walls(track));
+
     return group;
+}
+
+// Vertical barrier ribbons standing at the wall radius on both sides of the
+// track. The simulation enforces the same radius, so these read as the thing
+// keeping you on course. Striped red/white like crash barriers.
+function walls(track) {
+    const g = new THREE.Group();
+    const n = track.samples.length;
+    const wallR = track.wallHalfWidth;
+    const height = 1.6;
+    for (const sign of [-1, 1]) {
+        const pos = [], idx = [], col = [];
+        const red = new THREE.Color(COLORS.kerbRed);
+        const white = new THREE.Color(COLORS.kerbWhite);
+        for (let i = 0; i < n; i++) {
+            const s = track.samples[i], t = track.tangents[i];
+            const nx = t.z * sign, nz = -t.x * sign;      // outward normal for this side
+            const bx = s.x + nx * wallR, bz = s.z + nz * wallR;
+            pos.push(bx, 0, bz, bx, height, bz);
+            const c = (i % 2) ? red : white;
+            col.push(c.r, c.g, c.b, c.r, c.g, c.b);
+        }
+        for (let i = 0; i < n; i++) {
+            const ni = (i + 1) % n;
+            idx.push(i * 2, i * 2 + 1, ni * 2, i * 2 + 1, ni * 2 + 1, ni * 2);
+        }
+        const geo = new THREE.BufferGeometry();
+        geo.setAttribute('position', new THREE.Float32BufferAttribute(pos, 3));
+        geo.setAttribute('color', new THREE.Float32BufferAttribute(col, 3));
+        geo.setIndex(idx);
+        geo.computeVertexNormals();
+        const m = new THREE.Mesh(geo, toonMat(0xffffff, { vertexColors: true, side: THREE.DoubleSide }));
+        m.castShadow = true;
+        g.add(m);
+    }
+    return g;
 }
 
 // Striped kerb strip running from the edge outward, vertex-coloured red/white.

--- a/apps/kart/simulation/kart.js
+++ b/apps/kart/simulation/kart.js
@@ -152,6 +152,22 @@ export function stepKart(prev, input, dt, track) {
     s.x += s.vx * dt;
     s.z += s.vz * dt;
 
+    // ---- wall constraint: keep the kart inside the barrier and slide along it ----
+    const conf = track.confine(s.x, s.z, track.wallHalfWidth);
+    if (conf.hit) {
+        s.x = conf.x;
+        s.z = conf.z;
+        const vOut = s.vx * conf.nx + s.vz * conf.nz; // velocity into the wall
+        if (vOut > 0) {
+            s.vx -= conf.nx * vOut * (1 + T.wallBounce);
+            s.vz -= conf.nz * vOut * (1 + T.wallBounce);
+            s.vx *= T.wallScrub;  // scrub a little speed on contact
+            s.vz *= T.wallScrub;
+        }
+        // refresh cached forward speed after the correction
+        s.forwardSpeed = s.vx * fx + s.vz * fz;
+    }
+
     return s;
 }
 

--- a/apps/kart/simulation/track.js
+++ b/apps/kart/simulation/track.js
@@ -69,7 +69,7 @@ export function createTrack() {
     // Nearest point on the polyline to (x,z). Returns squared distance, the
     // segment index, and the param t along that segment.
     function nearest(x, z) {
-        let best = Infinity, bestSeg = 0, bestT = 0;
+        let best = Infinity, bestSeg = 0, bestT = 0, bestCx = x, bestCz = z;
         for (let i = 0; i < count; i++) {
             const a = samples[i];
             const b = samples[(i + 1) % count];
@@ -81,13 +81,25 @@ export function createTrack() {
             const cx = a.x + abx * t, cz = a.z + abz * t;
             const dx = x - cx, dz = z - cz;
             const d2 = dx * dx + dz * dz;
-            if (d2 < best) { best = d2; bestSeg = i; bestT = t; }
+            if (d2 < best) { best = d2; bestSeg = i; bestT = t; bestCx = cx; bestCz = cz; }
         }
-        return { dist2: best, seg: bestSeg, t: bestT };
+        return { dist2: best, seg: bestSeg, t: bestT, cx: bestCx, cz: bestCz };
     }
 
     function isOnTrack(x, z) {
         return nearest(x, z).dist2 <= hw * hw;
+    }
+
+    // Wall constraint: if (x,z) is farther than `radius` from the centerline,
+    // return the clamped position on the wall plus the outward unit normal so the
+    // caller can cancel the outward velocity and slide along the barrier.
+    function confine(x, z, radius) {
+        const nr = nearest(x, z);
+        const d = Math.sqrt(nr.dist2);
+        if (d <= radius) return { hit: false, x, z, nx: 0, nz: 0 };
+        const ox = (x - nr.cx) / (d || 1e-6);
+        const oz = (z - nr.cz) / (d || 1e-6);
+        return { hit: true, x: nr.cx + ox * radius, z: nr.cz + oz * radius, nx: ox, nz: oz };
     }
 
     // Normalized lap progress 0..1 along the loop at the nearest centerline point.
@@ -106,12 +118,14 @@ export function createTrack() {
 
     return {
         halfWidth: hw,
+        wallHalfWidth: TRACK.wallHalfWidth,
         samples,
         leftEdge,
         rightEdge,
         tangents,
         totalLen,
         isOnTrack,
+        confine,
         progressAt,
         startPose,
     };


### PR DESCRIPTION
## Summary

Follow-up fixes to the Kart app after play feedback that the wheels looked detached and the track was too small/narrow with nothing keeping you on it.

- **Floating wheels fixed.** Each wheel's center now sits exactly at its radius so the tires rest on the ground; wheels are bigger on a wider wheelbase, and a low floor pan ties the body to the wheels so the kart reads as planted instead of hovering. (Drift smoke / skid emitters moved to match the new rear-wheel positions.)
- **Bigger, wider track.** Rebuilt ~1.7× larger (≈657u lap) and widened the road from ~13u to **24u** (≈4 karts abreast, room for future multiplayer). Re-validated offline: no ribbon self-overlap (min self-distance ~91u), tightest corner radius ~21u (clear of the wall), with a tight corner + medium corners + sweepers retained.
- **Barrier walls that constrain you.** Walls sit just outside a short grass runoff and are enforced **in the simulation** — the kart slides along them with a slight bounce and speed scrub instead of sailing off into the void. Drawn as red/white crash barriers.
- **Supporting tweaks:** shadow now follows the kart with a tight frustum (crisp anywhere on the large track), fog pushed back, and top speed (34→42) + boost + camera distance nudged up for the larger circuit. All knobs remain in `config.js`.

## How to test
- [ ] `python3 -m http.server 8000`, open `/apps/kart/` (best on a phone, landscape).
- [ ] Wheels visibly rest on the track from the chase camera.
- [ ] The track feels roomy to navigate; the walls catch you instead of letting you drift off into grass forever.
- [ ] Drift-to-boost still works; smoke/skids come off the rear wheels; 3-lap race + results still function.

## Caveat
Built without a display/GPU in this environment, so visuals are unrendered here — the simulation, wall-confine, and track math are verified in Node and every module is syntax-checked. Wall feel (`wallBounce`, `wallScrub`) and the speed bump (`topSpeed`) are the most likely tuning targets.

https://claude.ai/code/session_011FJ8jDY7WMXJFZSbi9cPeh

---
_Generated by [Claude Code](https://claude.ai/code/session_011FJ8jDY7WMXJFZSbi9cPeh)_