### PR TITLE
Kart: smoother walls, brake/reverse, subtler drift

### DIFF
--- a/apps/kart/config.js
+++ b/apps/kart/config.js
@@ -18,9 +18,9 @@ export const TUNING = {
     topSpeed: 42,            // normal forward top speed (units/s)
     accel: 2.4,              // ramp-up rate toward target while accelerating
     engineBrake: 1.7,        // ramp-down rate when above target (how boost bleeds off)
-    brakeStrength: 3.6,      // ramp rate toward 0 / reverse while braking
+    brakeStrength: 5.0,      // ramp rate toward 0 / reverse while braking (firm)
     coastDrag: 0.7,          // ramp toward 0 when neither accelerating nor braking
-    reverseSpeed: 9,         // top reverse speed when holding brake from a stop
+    reverseSpeed: 12,        // top reverse speed when holding brake from a stop
 
     // ---------------------------------------------------------------- steering
     // Turn authority scales with speed so the kart is sluggish when slow and
@@ -33,18 +33,22 @@ export const TUNING = {
     // ---------------------------------------------------------------- grip / slide
     // Lateral (sideways) velocity is bled off each step: `vLat += (0-vLat)*grip*dt`.
     // High grip = planted; low grip = the kart slides, which is what makes a drift
-    // carve a wide arc.
+    // carve a wide arc. The effective grip eases toward its target (gripEase) so
+    // engaging/releasing a drift doesn't snap the kart sideways.
     normalGrip: 9.0,
-    driftGrip: 2.4,
+    driftGrip: 4.2,          // higher than before = a gentler, more controllable slide
+    gripEase: 7.0,           // how fast grip transitions (lower = smoother onset)
 
     // ---------------------------------------------------------------- drift
     driftMinSpeed: 11,        // must be going at least this fast to start a drift
     driftSteerThreshold: 0.16,// must be turning at least this hard to start a drift
     // While drifting, yaw rate = baseTurnRate * (a multiplier between min and max,
     // chosen by how hard the player steers INTO the drift). Countersteering widens
-    // the arc (min); steering hard inward tightens it (max).
-    driftYawMin: 0.55,
-    driftYawMax: 1.20,
+    // the arc (min); steering hard inward tightens it (max). Kept at/below 1 so a
+    // drift never snaps the kart around faster than a normal hard turn — it's a
+    // controlled slide, not a spin.
+    driftYawMin: 0.7,
+    driftYawMax: 0.98,
     // Seconds of continuous drift needed to reach each charge stage.
     // [stage1 (blue), stage2 (orange), stage3 (purple)]
     driftStageTimes: [0.55, 1.30, 2.20],
@@ -61,8 +65,9 @@ export const TUNING = {
     offTrackGrip: 5.5,       // grass is a little loose underfoot
 
     // ---------------------------------------------------------------- walls
-    wallBounce: 0.15,        // 0 = slide along wall, higher = bounce off it
-    wallScrub: 0.92,         // speed retained on wall contact (lower = more punishing)
+    kartRadius: 1.1,         // collision radius so the body edge stops AT the wall, not in it
+    wallBounce: 0.0,         // 0 = pure slide along wall (smooth), higher = bounce off it
+    wallScrub: 0.96,         // speed retained on wall contact (lower = more punishing)
 
     // ---------------------------------------------------------------- camera
     camDistance: 8.6,        // how far behind the kart the camera sits
@@ -76,12 +81,12 @@ export const TUNING = {
     camBoostPullback: 1.6,   // extra distance the camera drops back at full boost
 
     // ---------------------------------------------------------------- visual feel
-    kartBodyRoll: 0.42,      // radians the body leans into a drift at full slide
+    kartBodyRoll: 0.28,      // radians the body leans into a drift at full slide
     kartBoostSquash: 0.12,   // body stretch on boost (0 = none)
-    kartDriftHop: 0.35,      // little hop height when a drift kicks off
+    kartDriftHop: 0.12,      // small hop when a drift kicks off (subtle)
     wheelSteerMaxDeg: 26,    // visual front-wheel turn at full steer
-    camShakeBoost: 0.22,     // camera shake amplitude at full boost
-    camShakeStageUp: 0.5,    // shake kick when a drift charge stage levels up
+    camShakeBoost: 0.14,     // camera shake amplitude at full boost
+    camShakeStageUp: 0.26,   // shake kick when a drift charge stage levels up
 
     // ---------------------------------------------------------------- race
     totalLaps: 3,

--- a/apps/kart/simulation/kart.js
+++ b/apps/kart/simulation/kart.js
@@ -30,6 +30,7 @@ export function createKartState(pose) {
         vx: 0,
         vz: 0,
         forwardSpeed: 0,
+        grip: T.normalGrip,   // eased toward target grip for smooth drift onset
         steer: 0,
         drifting: false,
         driftDir: 0,
@@ -122,9 +123,12 @@ export function stepKart(prev, input, dt, track) {
     vForward += (target - vForward) * Math.min(1, accelRate * dt);
 
     // ---- lateral grip (low while drifting / on grass = slide) ----
-    let grip = s.drifting ? T.driftGrip : T.normalGrip;
-    if (!onTrack) grip = Math.min(grip, T.offTrackGrip);
-    vLateral += (0 - vLateral) * Math.min(1, grip * dt);
+    // Ease the effective grip toward its target so starting/ending a drift slides
+    // in gradually instead of snapping the kart sideways.
+    let gripTarget = s.drifting ? T.driftGrip : T.normalGrip;
+    if (!onTrack) gripTarget = Math.min(gripTarget, T.offTrackGrip);
+    s.grip += (gripTarget - s.grip) * Math.min(1, T.gripEase * dt);
+    vLateral += (0 - vLateral) * Math.min(1, s.grip * dt);
 
     // ---- recompose world velocity (still using current heading) ----
     s.vx = vForward * fx + vLateral * rx;
@@ -152,8 +156,11 @@ export function stepKart(prev, input, dt, track) {
     s.x += s.vx * dt;
     s.z += s.vz * dt;
 
-    // ---- wall constraint: keep the kart inside the barrier and slide along it ----
-    const conf = track.confine(s.x, s.z, track.wallHalfWidth);
+    // ---- wall constraint: keep the kart's BODY (not just its centre) inside the
+    // barrier and slide along it. Constraining the centre to wall - kartRadius
+    // stops the body edge from clipping through, and projecting out only the
+    // into-wall velocity component gives a smooth slide instead of a bounce. ----
+    const conf = track.confine(s.x, s.z, track.wallHalfWidth - T.kartRadius);
     if (conf.hit) {
         s.x = conf.x;
         s.z = conf.z;


### PR DESCRIPTION
## Summary

Feel fixes after play feedback on the Kart app: wall collision was janky/clippy, braking didn't let you stop and reverse, and drifting threw the kart around too much. All changes are in `config.js` + the pure simulation (`simulation/kart.js`).

- **Smoother wall collision.** The barrier now constrains the kart's *body* (wall radius minus a kart collision radius) instead of just its center point, so it no longer clips through the wall, and the response is a pure slide (bounce removed) so it stops jittering against walls.
- **Brake to stop and reverse.** Firmer deceleration (`brakeStrength` 3.6→5.0) and a clearer reverse (`reverseSpeed` 9→12) — holding brake brings you to a stop and then backs you up.
- **Subtler drift.** The grip used to drop instantly (9→2.4), lurching the kart sideways. Now it's a gentler slide (`driftGrip` 4.2) that **eases in** rather than snapping, the drift yaw is capped at a normal hard turn so it never spins you around, and the hop / body lean / camera shake are all reduced so engaging a drift is subtle.

## Verification (Node, headless)
- Brake from speed passes through a stop; brake from rest backs up to −12.
- Drift still slides more than a normal turn but moderately (lateral ~17 vs ~27 before).
- A kart shoved past the wall snaps back to exactly `wall − kartRadius` with its outward velocity removed (slide, no bounce).
- All modules syntax-checked.

## Caveat
No display/GPU in this environment, so the visuals are unrendered — verified via the simulation/physics math, not by playing it. New tuning knobs (`kartRadius`, `wallScrub`, `wallBounce`, `driftGrip`, `gripEase`, `driftYawMax`, `reverseSpeed`, `brakeStrength`) are all in `config.js` if the feel needs nudging.

https://claude.ai/code/session_011FJ8jDY7WMXJFZSbi9cPeh

---
_Generated by [Claude Code](https://claude.ai/code/session_011FJ8jDY7WMXJFZSbi9cPeh)_