### PR TITLE
Kart: make drift fully steerable and more subtle

### DIFF
--- a/apps/kart/config.js
+++ b/apps/kart/config.js
@@ -36,19 +36,19 @@ export const TUNING = {
     // carve a wide arc. The effective grip eases toward its target (gripEase) so
     // engaging/releasing a drift doesn't snap the kart sideways.
     normalGrip: 9.0,
-    driftGrip: 4.2,          // higher than before = a gentler, more controllable slide
+    driftGrip: 5.2,          // higher = a gentle, controllable slide (less throw-off)
     gripEase: 7.0,           // how fast grip transitions (lower = smoother onset)
 
     // ---------------------------------------------------------------- drift
     driftMinSpeed: 11,        // must be going at least this fast to start a drift
     driftSteerThreshold: 0.16,// must be turning at least this hard to start a drift
-    // While drifting, yaw rate = baseTurnRate * (a multiplier between min and max,
-    // chosen by how hard the player steers INTO the drift). Countersteering widens
-    // the arc (min); steering hard inward tightens it (max). Kept at/below 1 so a
-    // drift never snaps the kart around faster than a normal hard turn — it's a
-    // controlled slide, not a spin.
-    driftYawMin: 0.7,
-    driftYawMax: 0.98,
+    // Drift yaw is ADDITIVE so you stay in control: a gentle base pull in the
+    // drift direction, plus your raw steering on top. Steering into the drift
+    // tightens it; countersteering subtracts and can hold a line or straighten you
+    // right out of the drift. The total is kept at/below a normal hard turn, so a
+    // drift never snaps the kart around — it's a controllable slide, not a spin.
+    driftBaseYaw: 0.30,        // base turn in the drift direction (gentle)
+    driftSteerAuthority: 0.60, // how much raw steer (-1..1) adds/subtracts on top
     // Seconds of continuous drift needed to reach each charge stage.
     // [stage1 (blue), stage2 (orange), stage3 (purple)]
     driftStageTimes: [0.55, 1.30, 2.20],

--- a/apps/kart/simulation/kart.js
+++ b/apps/kart/simulation/kart.js
@@ -141,10 +141,11 @@ export function stepKart(prev, input, dt, track) {
     authority *= 1 - T.turnTopSpeedFalloff * speedFrac; // shave twitch at the very top
     let yawRate;
     if (s.drifting) {
-        // committed arc: steering INTO the drift tightens it, countersteer widens it
-        const inward = clamp(s.steer * s.driftDir, -1, 1); // 1 = hard into drift
-        const mult = T.driftYawMin + (T.driftYawMax - T.driftYawMin) * (inward + 1) * 0.5;
-        yawRate = s.driftDir * T.maxTurnRate * authority * mult;
+        // additive control: gentle base pull in the drift direction + your steer.
+        // countersteering subtracts, so you can tighten, hold a line, or straighten
+        // out — clamped to a normal hard turn so it never spins you.
+        const mult = clamp(s.driftDir * T.driftBaseYaw + s.steer * T.driftSteerAuthority, -1, 1);
+        yawRate = mult * T.maxTurnRate * authority;
     } else {
         yawRate = s.steer * T.maxTurnRate * authority;
     }


### PR DESCRIPTION
## Summary

Improve drifting after feedback that it was still too hard to steer mid-drift and "always throws me off." All changes are in `config.js` + the pure simulation (`simulation/kart.js`).

**The root cause:** the old drift forced the kart to keep turning in the drift direction — the yaw multiplier never dropped below ~0.7, so even full countersteer couldn't hold a line or straighten out. The drift drove *you*, not the other way around.

**The fix — additive, fully steerable drift:** drift yaw is now a gentle base pull in the drift direction *plus* your raw steering on top, clamped to a normal hard turn:
- **Neutral** (no steer): a gentle carve.
- **Steer into the drift:** tightens it.
- **Countersteer:** subtracts — hold a line or straighten right out of the drift.

Also raised `driftGrip` (4.2 → 5.2) so the slide is subtler and less likely to throw you off, while still sliding more than a normal turn and still charging the boost.

## Verification (Node, headless)
- Yaw while drifting right: into-drift 2.06 rad/s · neutral 1.05 · countersteer settles to −0.65 (turns *out* of the drift).
- Drift slide reduced (lateral ~13 vs ~17 last round, ~27 originally) but still > a normal turn.
- Drift still charges to stage 3 and grants a boost on release.
- Into-drift yaw never exceeds a normal hard turn; modules syntax-checked.

## Caveat
No display/GPU here, so this is verified via the simulation/physics math, not by playing it. Knobs in `config.js`: `driftBaseYaw`, `driftSteerAuthority`, `driftGrip`, `gripEase`.

https://claude.ai/code/session_011FJ8jDY7WMXJFZSbi9cPeh

---
_Generated by [Claude Code](https://claude.ai/code/session_011FJ8jDY7WMXJFZSbi9cPeh)_