### PR TITLE
Kart: heightfield terrain (2.5D) + larger map

### DIFF
--- a/apps/kart/config.js
+++ b/apps/kart/config.js
@@ -69,6 +69,13 @@ export const TUNING = {
     wallBounce: 0.0,         // 0 = pure slide along wall (smooth), higher = bounce off it
     wallScrub: 0.96,         // speed retained on wall contact (lower = more punishing)
 
+    // ---------------------------------------------------------------- terrain / vertical (2.5D)
+    gravity: 30,             // downward acceleration (units/s^2)
+    slopeAccel: 24,          // how strongly up/down slopes bleed/add forward speed
+    airSteer: 0.35,          // fraction of normal steering authority while airborne
+    hardLandSpeed: 14,       // downward speed above which a landing scrubs speed
+    landScrub: 0.8,          // forward speed retained on the hardest landing
+
     // ---------------------------------------------------------------- camera
     camDistance: 8.6,        // how far behind the kart the camera sits
     camHeight: 4.0,          // camera height above the ground
@@ -100,18 +107,36 @@ export const TUNING = {
 export const TRACK = {
     halfWidth: 12,           // drivable road half-width (24u wide -> ~4 karts abreast)
     wallHalfWidth: 14.5,     // hard wall: ~2.5u of grass runoff outside the road, then a barrier
-    // [x, z] control points, traversed in order. Closed loop. This curve was
-    // validated offline to be free of self-overlap (min self-distance ~91u) while
-    // featuring one tight corner (turn radius ~21u, comfortably clear of the wall
-    // radius), several medium corners, and long sweepers — so drift pays off
-    // differently around the lap. ~657u long. Start/finish on the straightest part.
+    // [x, z] control points, traversed in order. Closed loop. Validated offline to
+    // be free of self-overlap (min self-distance ~137u) with the tightest corner
+    // (turn radius ~32u) well clear of the wall radius. ~985u long — a big, flowing
+    // circuit. It drapes over the terrain heightfield (see TERRAIN), so corners and
+    // straights gain real elevation. Start/finish on the straightest part.
     controlPoints: [
-        [-46.7, 58.6], [-78.8, 38], [-108.3, 0], [-105.2, -50.7],
-        [-63.5, -79.6], [-15.7, -69], [10, -43.7], [27.2, -34.1],
-        [63.2, -30.4], [108.3, 0], [120.9, 58.2], [83, 104.1],
-        [24.4, 107], [-18.7, 81.8],
+        [-70.1, 87.9], [-118.2, 57], [-162.4, 0], [-157.8, -76.1],
+        [-95.3, -119.4], [-23.5, -103.5], [15, -65.6], [40.8, -51.2],
+        [94.8, -45.6], [162.4, 0], [181.4, 87.3], [124.5, 156.1],
+        [36.6, 160.5], [-28, 122.7],
     ],
     samplesPerSegment: 26,   // spline resolution for the on-track test + mesh
+};
+
+// Terrain heightfield (y = height(x,z)). Low-frequency waves give rolling hills;
+// Gaussian bumps add local hills / ramps. Validated so slopes along the track stay
+// drivable (max along-track ~13deg) while giving ~19u of elevation across the lap.
+// Single-valued by design (no bridges/overlaps — that's Level 3, out of scope).
+export const TERRAIN = {
+    waves: [
+        { a: 7,   fx: 0.013, fz: 0.015, px: 0.5, pz: 1.2 },
+        { a: 4,   fx: 0.024, fz: 0.020, px: 2.1, pz: 0.3 },
+        { a: 2,   fx: 0.041, fz: 0.038, px: 0.0, pz: 2.0 },
+    ],
+    bumps: [
+        { x: 90,   z: -70,  a: 8, s: 24 },   // hill beside a corner
+        { x: -150, z: 120,  a: 6, s: 30 },   // scenery rise off-track
+    ],
+    extent: 520,             // half-size of the rendered terrain mesh (covers the map)
+    meshStep: 8,             // terrain mesh vertex spacing (smaller = finer = heavier)
 };
 
 export const COLORS = {

--- a/apps/kart/main.js
+++ b/apps/kart/main.js
@@ -217,12 +217,14 @@ function interpolated(alpha) {
     const boost = clamp((c.forwardSpeed - T.topSpeed) / (MAX_BOOST_BONUS || 1), 0, 1);
     return {
         x: p.x + (c.x - p.x) * alpha,
+        y: p.y + (c.y - p.y) * alpha,
         z: p.z + (c.z - p.z) * alpha,
         heading: angleLerp(p.heading, c.heading, alpha),
         slip: clamp(vLat / SLIP_REF, -1, 1),
         steer: c.steer,
         speed: c.forwardSpeed,
         drifting: c.drifting,
+        airborne: c.airborne,
         boost,
         driftStage: c.driftStage,
         boostStage: c.boostStage,
@@ -267,7 +269,7 @@ function frame(now) {
         kartView.update(r, dt);
         effects.update(dt, r);
         chase.update(r, r.boost, dt);
-        stage.setSunFocus(r.x, r.z);
+        stage.setSunFocus(r.x, r.y, r.z);
 
         // camera shake: continuous on boost + a kick on each charge stage-up
         if (game.curr.driftStage > game.lastStage) game.shake = T.camShakeStageUp;

--- a/apps/kart/render/chaseCamera.js
+++ b/apps/kart/render/chaseCamera.js
@@ -20,15 +20,15 @@ export class ChaseCamera {
         const fx = Math.sin(r.heading), fz = Math.cos(r.heading);
         const dist = T.camDistance + T.camBoostPullback * boost;
 
-        // desired camera position: behind + above the kart
+        // desired camera position: behind + above the kart (track its height)
         const dx = r.x - fx * dist;
         const dz = r.z - fz * dist;
-        const dy = T.camHeight;
+        const dy = r.y + T.camHeight;
 
         // desired look target: ahead of and slightly above the kart
         const lx = r.x + fx * T.camLookAhead;
         const lz = r.z + fz * T.camLookAhead;
-        const ly = T.camLookHeight;
+        const ly = r.y + T.camLookHeight;
 
         if (!this._init) {
             this._pos.set(dx, dy, dz);

--- a/apps/kart/render/effects.js
+++ b/apps/kart/render/effects.js
@@ -9,6 +9,7 @@
 
 import * as THREE from 'three';
 import { COLORS, VISUALS } from '../config.js';
+import { heightAt } from '../simulation/terrain.js';
 
 export class Effects {
     constructor(scene) {
@@ -48,7 +49,7 @@ export class Effects {
             if (fx.driftStage > 0) tint.lerp(new THREE.Color(COLORS.driftStage[fx.driftStage - 1]), 0.55);
             for (const side of [-1, 1]) {
                 const p = rear(side);
-                if (Math.random() < 0.9) this.smoke.spawn(p.x, 0.25, p.z, tint, 0.6 + Math.random() * 0.5, 1.1 + fx.driftStage * 0.3);
+                if (Math.random() < 0.9) this.smoke.spawn(p.x, fx.y + 0.25, p.z, tint, 0.6 + Math.random() * 0.5, 1.1 + fx.driftStage * 0.3);
             }
             // lay skid marks every fixed distance travelled
             this._skidDist += (fx.speed || 0) * dt;
@@ -66,7 +67,7 @@ export class Effects {
             const c = new THREE.Color(COLORS.driftStage[fx.driftStage - 1]);
             for (const side of [-1, 1]) {
                 const p = rear(side);
-                for (let i = 0; i < 10; i++) this.sparks.spawn(p.x, 0.4, p.z, c, 0.35, 0.5, 7);
+                for (let i = 0; i < 10; i++) this.sparks.spawn(p.x, fx.y + 0.4, p.z, c, 0.35, 0.5, 7);
             }
         }
         this._prevStage = fx.driftStage;
@@ -75,7 +76,7 @@ export class Effects {
         if (fx.boost > 0.1 && Math.random() < fx.boost) {
             const c = new THREE.Color(COLORS.driftStage[Math.max(0, fx.boostStage - 1)]);
             const ex = { x: fx.x + fwdX * -1.7, z: fx.z + fwdZ * -1.7 };
-            this.sparks.spawn(ex.x, 0.6, ex.z, c, 0.3, 0.45, 5);
+            this.sparks.spawn(ex.x, fx.y + 0.6, ex.z, c, 0.3, 0.45, 5);
         }
 
         this.smoke.update(dt);
@@ -184,7 +185,6 @@ function makeSkid() {
         color: 0x1a1a1f, transparent: true, opacity: 0.34, depthWrite: false,
     });
     const inst = new THREE.InstancedMesh(geo, mat, max);
-    inst.position.y = 0.03;
     inst.frustumCulled = false;
     const dummy = new THREE.Object3D();
     // hide all initially
@@ -196,7 +196,7 @@ function makeSkid() {
     return {
         mesh: inst,
         drop(x, z, heading) {
-            dummy.position.set(x, 0, z);
+            dummy.position.set(x, heightAt(x, z) + 0.06, z);
             dummy.rotation.set(0, heading, 0);
             dummy.scale.setScalar(1);
             dummy.updateMatrix();

--- a/apps/kart/render/kartView.js
+++ b/apps/kart/render/kartView.js
@@ -7,17 +7,24 @@
 import * as THREE from 'three';
 import { RoundedBoxGeometry } from 'three/addons/geometries/RoundedBoxGeometry.js';
 import { COLORS, TUNING as T } from '../config.js';
+import { gradientAt } from '../simulation/terrain.js';
 import { toonMat } from './materials.js';
 
 export class KartView {
     constructor() {
         this.group = new THREE.Group();
 
-        this.bob = new THREE.Group();          // hop + squash
-        this.group.add(this.bob);
+        this.tilt = new THREE.Group();         // pitch/roll to the terrain slope
+        this.group.add(this.tilt);
 
-        this.chassis = new THREE.Group();      // roll/lean
+        this.bob = new THREE.Group();          // hop + squash
+        this.tilt.add(this.bob);
+
+        this.chassis = new THREE.Group();      // roll/lean (drift)
         this.bob.add(this.chassis);
+
+        this._pitch = 0;
+        this._roll = 0;
 
         const bodyMat = toonMat(COLORS.kartBody);
         const accentMat = toonMat(COLORS.kartBody2);
@@ -133,8 +140,20 @@ export class KartView {
 
     // r: interpolated render state. dt: real seconds since last frame.
     update(r, dt) {
-        this.group.position.set(r.x, 0, r.z);
+        this.group.position.set(r.x, r.y, r.z);
         this.group.rotation.y = r.heading;
+
+        // pitch/roll the kart to match the terrain slope (level out in the air)
+        const g = gradientAt(r.x, r.z);
+        const fx = Math.sin(r.heading), fz = Math.cos(r.heading);
+        const rxv = Math.cos(r.heading), rzv = -Math.sin(r.heading);
+        const pitchTarget = r.airborne ? 0 : -Math.atan(g.gx * fx + g.gz * fz);
+        const rollTarget = r.airborne ? 0 : Math.atan(g.gx * rxv + g.gz * rzv);
+        const k = Math.min(1, dt * 8);
+        this._pitch += (pitchTarget - this._pitch) * k;
+        this._roll += (rollTarget - this._roll) * k;
+        this.tilt.rotation.x = this._pitch;
+        this.tilt.rotation.z = this._roll;
 
         // drift hop on the rising edge of a drift
         if (r.drifting && !this._wasDrifting) this._hopT = 0.32;

--- a/apps/kart/render/props.js
+++ b/apps/kart/render/props.js
@@ -4,6 +4,7 @@
 
 import * as THREE from 'three';
 import { COLORS, VISUALS } from '../config.js';
+import { heightAt } from '../simulation/terrain.js';
 import { toonMat } from './materials.js';
 
 export function buildProps(track) {
@@ -41,7 +42,7 @@ function trees(track) {
         l1.position.y = 2.4; t.add(l1);
         const l2 = new THREE.Mesh(leafGeoB, leafMatB);
         l2.position.y = 3.6; t.add(l2);
-        t.position.set(x, 0, z);
+        t.position.set(x, heightAt(x, z), z);
         t.scale.setScalar(scale);
         t.rotation.y = Math.random() * Math.PI;
         g.add(t);
@@ -58,7 +59,8 @@ function hills() {
         const r = 200 + Math.random() * 80;
         const rad = 26 + Math.random() * 30;
         const hill = new THREE.Mesh(new THREE.SphereGeometry(rad, 16, 10), mat);
-        hill.position.set(Math.cos(a) * r, -rad * 0.45, Math.sin(a) * r);
+        const hx = Math.cos(a) * r, hz = Math.sin(a) * r;
+        hill.position.set(hx, heightAt(hx, hz) - rad * 0.45, hz);
         hill.scale.y = 0.5;
         g.add(hill);
     }

--- a/apps/kart/render/scene.js
+++ b/apps/kart/render/scene.js
@@ -3,7 +3,8 @@
 // win), and a striped mown-lawn ground. Pure presentation — never mutates sim.
 
 import * as THREE from 'three';
-import { COLORS } from '../config.js';
+import { COLORS, TERRAIN } from '../config.js';
+import { heightAt } from '../simulation/terrain.js';
 import { toonMat } from './materials.js';
 
 export class Stage {
@@ -87,18 +88,28 @@ export class Stage {
         this._sunOffset = sun.position.clone();
     }
 
-    // Keep the shadow frustum centred on the kart.
-    setSunFocus(x, z) {
-        this.sun.target.position.set(x, 0, z);
-        this.sun.position.set(x + this._sunOffset.x, this._sunOffset.y, z + this._sunOffset.z);
+    // Keep the shadow frustum centred on the kart (including its height on hills).
+    setSunFocus(x, y, z) {
+        this.sun.target.position.set(x, y, z);
+        this.sun.position.set(x + this._sunOffset.x, y + this._sunOffset.y, z + this._sunOffset.z);
     }
 
     _addGround() {
-        const geo = new THREE.PlaneGeometry(1400, 1400);
+        // Displaced terrain mesh: a grid whose vertices are lifted by heightAt so
+        // the ground matches the simulation's heightfield exactly.
+        const size = TERRAIN.extent * 2;
+        const seg = Math.max(8, Math.round(size / TERRAIN.meshStep));
+        const geo = new THREE.PlaneGeometry(size, size, seg, seg);
         geo.rotateX(-Math.PI / 2);
+        const pos = geo.attributes.position;
+        for (let i = 0; i < pos.count; i++) {
+            const x = pos.getX(i), z = pos.getZ(i);
+            pos.setY(i, heightAt(x, z) - 0.05);
+        }
+        pos.needsUpdate = true;
+        geo.computeVertexNormals();
         const mat = toonMat(0xffffff, { map: stripedLawn() });
         this.ground = new THREE.Mesh(geo, mat);
-        this.ground.position.y = -0.02;
         this.ground.receiveShadow = true;
         this.scene.add(this.ground);
     }

--- a/apps/kart/render/trackView.js
+++ b/apps/kart/render/trackView.js
@@ -1,11 +1,14 @@
-// Builds the visible track from the sim's sampled centerline: asphalt ribbon,
-// striped red/white kerbs, a dashed centre line, a checkered start stripe with
-// a START / FINISH banner arch, and traffic cones along the edges. Geometry
-// only — built once, no per-frame work.
+// Builds the visible track from the sim's sampled centerline, draped over the
+// terrain heightfield so the asphalt, kerbs, walls, banner and cones follow the
+// hills. Geometry only — built once, no per-frame work.
 
 import * as THREE from 'three';
 import { COLORS, VISUALS } from '../config.js';
+import { heightAt } from '../simulation/terrain.js';
 import { toonMat } from './materials.js';
+
+// small vertical offsets so layers stack cleanly on the terrain
+const Y_ROAD = 0.06, Y_KERB = 0.10, Y_EDGE = 0.14, Y_DASH = 0.16, Y_START = 0.18;
 
 export function buildTrackView(track) {
     const group = new THREE.Group();
@@ -16,7 +19,8 @@ export function buildTrackView(track) {
     const indices = [];
     for (let i = 0; i < n; i++) {
         const l = track.leftEdge[i], r = track.rightEdge[i];
-        positions.push(l.x, 0, l.z, r.x, 0, r.z);
+        positions.push(l.x, heightAt(l.x, l.z) + Y_ROAD, l.z,
+                       r.x, heightAt(r.x, r.z) + Y_ROAD, r.z);
     }
     for (let i = 0; i < n; i++) {
         const ni = (i + 1) % n;
@@ -31,8 +35,8 @@ export function buildTrackView(track) {
     group.add(road);
 
     // ---- kerbs (striped red/white strips just outside each edge) ----
-    group.add(kerb(track.leftEdge, track.samples, 0.9));
-    group.add(kerb(track.rightEdge, track.samples, 0.9));
+    group.add(kerb(track.leftEdge, track.samples));
+    group.add(kerb(track.rightEdge, track.samples));
 
     // ---- white edge lines + dashed centre line ----
     group.add(edgeLine(track.leftEdge, track.samples));
@@ -52,9 +56,6 @@ export function buildTrackView(track) {
     return group;
 }
 
-// Vertical barrier ribbons standing at the wall radius on both sides of the
-// track. The simulation enforces the same radius, so these read as the thing
-// keeping you on course. Striped red/white like crash barriers.
 function walls(track) {
     const g = new THREE.Group();
     const n = track.samples.length;
@@ -68,7 +69,8 @@ function walls(track) {
             const s = track.samples[i], t = track.tangents[i];
             const nx = t.z * sign, nz = -t.x * sign;      // outward normal for this side
             const bx = s.x + nx * wallR, bz = s.z + nz * wallR;
-            pos.push(bx, 0, bz, bx, height, bz);
+            const by = heightAt(bx, bz);
+            pos.push(bx, by, bz, bx, by + height, bz);
             const c = (i % 2) ? red : white;
             col.push(c.r, c.g, c.b, c.r, c.g, c.b);
         }
@@ -88,9 +90,9 @@ function walls(track) {
     return g;
 }
 
-// Striped kerb strip running from the edge outward, vertex-coloured red/white.
-function kerb(edge, center, width) {
+function kerb(edge, center) {
     const n = edge.length;
+    const width = 0.9;
     const pos = [], idx = [], col = [];
     const red = new THREE.Color(COLORS.kerbRed);
     const white = new THREE.Color(COLORS.kerbWhite);
@@ -98,7 +100,8 @@ function kerb(edge, center, width) {
         const ex = edge[i].x, ez = edge[i].z;
         let ox = ex - center[i].x, oz = ez - center[i].z; // outward
         const ol = Math.hypot(ox, oz) || 1e-6; ox /= ol; oz /= ol;
-        pos.push(ex, 0, ez, ex + ox * width, 0, ez + oz * width);
+        const ax = ex, az = ez, bx = ex + ox * width, bz = ez + oz * width;
+        pos.push(ax, heightAt(ax, az) + Y_KERB, az, bx, heightAt(bx, bz) + Y_KERB, bz);
         const c = (i % 2) ? red : white;
         col.push(c.r, c.g, c.b, c.r, c.g, c.b);
     }
@@ -112,7 +115,6 @@ function kerb(edge, center, width) {
     g.setIndex(idx);
     g.computeVertexNormals();
     const m = new THREE.Mesh(g, toonMat(0xffffff, { vertexColors: true }));
-    m.position.y = 0.015;
     m.receiveShadow = true;
     return m;
 }
@@ -126,7 +128,8 @@ function edgeLine(edge, center) {
         let dx = center[i].x - ex, dz = center[i].z - ez;
         const dl = Math.hypot(dx, dz) || 1e-6; dx /= dl; dz /= dl;
         const px = ex + dx * inset, pz = ez + dz * inset;
-        pos.push(px, 0, pz, px + dx * width, 0, pz + dz * width);
+        const qx = px + dx * width, qz = pz + dz * width;
+        pos.push(px, heightAt(px, pz) + Y_EDGE, pz, qx, heightAt(qx, qz) + Y_EDGE, qz);
     }
     for (let i = 0; i < n; i++) {
         const ni = (i + 1) % n;
@@ -136,21 +139,19 @@ function edgeLine(edge, center) {
     g.setAttribute('position', new THREE.Float32BufferAttribute(pos, 3));
     g.setIndex(idx);
     g.computeVertexNormals();
-    const m = new THREE.Mesh(g, new THREE.MeshBasicMaterial({ color: COLORS.trackEdge }));
-    m.position.y = 0.025;
-    return m;
+    return new THREE.Mesh(g, new THREE.MeshBasicMaterial({ color: COLORS.trackEdge }));
 }
 
 function centerDashes(track) {
     const g = new THREE.Group();
     const n = track.samples.length;
     const mat = new THREE.MeshBasicMaterial({ color: COLORS.centerLine });
-    const dashGeo = new THREE.PlaneGeometry(0.35, 2.2);
+    const dashGeo = new THREE.PlaneGeometry(0.4, 2.6);
     dashGeo.rotateX(-Math.PI / 2);
     for (let i = 4; i < n; i += 4) {
         const s = track.samples[i], t = track.tangents[i];
         const d = new THREE.Mesh(dashGeo, mat);
-        d.position.set(s.x, 0.03, s.z);
+        d.position.set(s.x, heightAt(s.x, s.z) + Y_DASH, s.z);
         d.rotation.y = Math.atan2(t.x, t.z);
         g.add(d);
     }
@@ -159,10 +160,10 @@ function centerDashes(track) {
 
 function startStripe(track) {
     const s = track.samples[0], t = track.tangents[0];
-    const geo = new THREE.PlaneGeometry(track.halfWidth * 2, 2.4);
+    const geo = new THREE.PlaneGeometry(track.halfWidth * 2, 2.6);
     geo.rotateX(-Math.PI / 2);
     const stripe = new THREE.Mesh(geo, new THREE.MeshBasicMaterial({ map: checkerTexture() }));
-    stripe.position.set(s.x, 0.035, s.z);
+    stripe.position.set(s.x, heightAt(s.x, s.z) + Y_START, s.z);
     stripe.rotation.y = Math.atan2(t.x, t.z);
     return stripe;
 }
@@ -173,12 +174,13 @@ function startBanner(track) {
     const yaw = Math.atan2(t.x, t.z);
     const span = track.halfWidth * 2 + 1.6;
     const postMat = toonMat(COLORS.bannerPost);
+    const rx = Math.cos(yaw), rz = -Math.sin(yaw);
+    const postH = 5.2;
 
     for (const side of [-1, 1]) {
-        const post = new THREE.Mesh(new THREE.CylinderGeometry(0.25, 0.25, 5.2, 12), postMat);
-        // offset sideways along the track's lateral (right) vector
-        const rx = Math.cos(yaw), rz = -Math.sin(yaw);
-        post.position.set(s.x + rx * side * span / 2, 2.6, s.z + rz * side * span / 2);
+        const bx = s.x + rx * side * span / 2, bz = s.z + rz * side * span / 2;
+        const post = new THREE.Mesh(new THREE.CylinderGeometry(0.25, 0.25, postH, 12), postMat);
+        post.position.set(bx, heightAt(bx, bz) + postH / 2, bz);
         post.castShadow = true;
         g.add(post);
     }
@@ -187,7 +189,7 @@ function startBanner(track) {
         new THREE.BoxGeometry(span, 1.3, 0.2),
         new THREE.MeshBasicMaterial({ map: bannerTexture() })
     );
-    banner.position.set(s.x, 5.0, s.z);
+    banner.position.set(s.x, heightAt(s.x, s.z) + postH - 0.2, s.z);
     banner.rotation.y = yaw;
     g.add(banner);
     return g;
@@ -200,11 +202,12 @@ function cones(track) {
     const coneGeo = new THREE.ConeGeometry(0.28, 0.8, 12);
     const mat = toonMat(COLORS.cone);
     for (let i = 0; i < n; i += step) {
-        for (const [edge, sign] of [[track.leftEdge, 1], [track.rightEdge, 1]]) {
+        for (const edge of [track.leftEdge, track.rightEdge]) {
             let ox = edge[i].x - track.samples[i].x, oz = edge[i].z - track.samples[i].z;
             const ol = Math.hypot(ox, oz) || 1e-6; ox /= ol; oz /= ol;
+            const cx = edge[i].x + ox * 1.4, cz = edge[i].z + oz * 1.4;
             const c = new THREE.Mesh(coneGeo, mat);
-            c.position.set(edge[i].x + ox * 1.4 * sign, 0.4, edge[i].z + oz * 1.4 * sign);
+            c.position.set(cx, heightAt(cx, cz) + 0.4, cz);
             c.castShadow = true;
             g.add(c);
         }
@@ -236,7 +239,6 @@ function bannerTexture() {
     c.width = w; c.height = h;
     const ctx = c.getContext('2d');
     ctx.fillStyle = '#2a2f3a'; ctx.fillRect(0, 0, w, h);
-    // checker trim top/bottom
     const cs = 16;
     for (let x = 0; x < w / cs; x++) {
         ctx.fillStyle = x % 2 ? '#fff' : '#111';

--- a/apps/kart/simulation/kart.js
+++ b/apps/kart/simulation/kart.js
@@ -76,7 +76,7 @@ export function stepKart(prev, input, dt, track) {
     const onTrack = track.isOnTrack(s.x, s.z);
     s.onTrack = onTrack;
     const grounded = !s.airborne;
-    const grad = gradientAt(s.x, s.z);             // terrain slope at current position
+    const slopeGrad = gradientAt(s.x, s.z);        // slope at the pre-move position (drives slope-speed)
     if (s.boostTimer > 0) s.boostTimer = Math.max(0, s.boostTimer - dt);
     const boosting = s.boostTimer > 0;
 
@@ -137,7 +137,7 @@ export function stepKart(prev, input, dt, track) {
 
     // ---- slope affects speed: gravity bleeds speed uphill, adds it downhill ----
     if (grounded) {
-        const alongSlope = grad.gx * fx + grad.gz * fz; // >0 climbing, <0 descending
+        const alongSlope = slopeGrad.gx * fx + slopeGrad.gz * fz; // >0 climbing, <0 descending
         vForward -= T.slopeAccel * alongSlope * dt;
     }
 
@@ -203,7 +203,7 @@ export function stepKart(prev, input, dt, track) {
     // can fall, launch (crest of a hill at speed). Airborne: ballistic fall under
     // gravity until we meet the ground again.
     const groundY = heightAt(s.x, s.z);
-    const grad2 = gradientAt(s.x, s.z);
+    const vertGrad = gradientAt(s.x, s.z);         // slope at the finalised position (drives launch/stick)
     if (s.airborne) {
         s.vy -= T.gravity * dt;
         s.y += s.vy * dt;
@@ -219,7 +219,7 @@ export function stepKart(prev, input, dt, track) {
             s.vy = 0;
         }
     } else {
-        const vGround = grad2.gx * s.vx + grad2.gz * s.vz; // ground's vertical rate along path
+        const vGround = vertGrad.gx * s.vx + vertGrad.gz * s.vz; // ground's vertical rate along path
         s.vy -= T.gravity * dt;
         const yBallistic = s.y + s.vy * dt;
         if (yBallistic > groundY + 0.05) {

--- a/apps/kart/simulation/kart.js
+++ b/apps/kart/simulation/kart.js
@@ -11,6 +11,9 @@
 //   heading       yaw, radians (forward = (sin h, cos h))
 //   vx, vz        world-space velocity
 //   forwardSpeed  signed speed along heading (cached for HUD/render/feel)
+//   y             height above the world plane (follows the terrain)
+//   vy            vertical velocity (for ramps / jumps / falling)
+//   airborne      bool (off the ground after launching off a crest)
 //   steer         smoothed steer actually applied (-1..1)
 //   drifting      bool
 //   driftDir      -1 / +1 committed drift direction
@@ -21,6 +24,7 @@
 //   onTrack       bool (last surface test)
 
 import { TUNING as T } from '../config.js';
+import { heightAt, gradientAt } from './terrain.js';
 
 export function createKartState(pose) {
     return {
@@ -30,6 +34,9 @@ export function createKartState(pose) {
         vx: 0,
         vz: 0,
         forwardSpeed: 0,
+        y: heightAt(pose.x, pose.z),
+        vy: 0,
+        airborne: false,
         grip: T.normalGrip,   // eased toward target grip for smooth drift onset
         steer: 0,
         drifting: false,
@@ -68,13 +75,15 @@ export function stepKart(prev, input, dt, track) {
     // ---- surface + boost bookkeeping ----
     const onTrack = track.isOnTrack(s.x, s.z);
     s.onTrack = onTrack;
+    const grounded = !s.airborne;
+    const grad = gradientAt(s.x, s.z);             // terrain slope at current position
     if (s.boostTimer > 0) s.boostTimer = Math.max(0, s.boostTimer - dt);
     const boosting = s.boostTimer > 0;
 
-    // ---- drift state machine ----
+    // ---- drift state machine (can only start a drift while on the ground) ----
     const wantDrift = input.drift && input.accelerate;
     if (!s.drifting) {
-        if (wantDrift && vForward > T.driftMinSpeed && Math.abs(s.steer) > T.driftSteerThreshold) {
+        if (grounded && wantDrift && vForward > T.driftMinSpeed && Math.abs(s.steer) > T.driftSteerThreshold) {
             s.drifting = true;
             s.driftDir = s.steer >= 0 ? 1 : -1;
             s.driftCharge = 0;
@@ -105,7 +114,11 @@ export function stepKart(prev, input, dt, track) {
         : 0;
     let target = T.topSpeed + boostBonus;
     let accelRate;
-    if (onTrack) {
+    if (!grounded) {
+        // airborne: no tire force, just a wisp of air drag
+        target = vForward;
+        accelRate = 0;
+    } else if (onTrack) {
         if (input.accelerate) {
             accelRate = vForward < target ? T.accel : T.engineBrake;
         } else if (input.brake) {
@@ -122,13 +135,21 @@ export function stepKart(prev, input, dt, track) {
     }
     vForward += (target - vForward) * Math.min(1, accelRate * dt);
 
-    // ---- lateral grip (low while drifting / on grass = slide) ----
+    // ---- slope affects speed: gravity bleeds speed uphill, adds it downhill ----
+    if (grounded) {
+        const alongSlope = grad.gx * fx + grad.gz * fz; // >0 climbing, <0 descending
+        vForward -= T.slopeAccel * alongSlope * dt;
+    }
+
+    // ---- lateral grip (low while drifting / on grass = slide; none in the air) ----
     // Ease the effective grip toward its target so starting/ending a drift slides
     // in gradually instead of snapping the kart sideways.
-    let gripTarget = s.drifting ? T.driftGrip : T.normalGrip;
-    if (!onTrack) gripTarget = Math.min(gripTarget, T.offTrackGrip);
-    s.grip += (gripTarget - s.grip) * Math.min(1, T.gripEase * dt);
-    vLateral += (0 - vLateral) * Math.min(1, s.grip * dt);
+    if (grounded) {
+        let gripTarget = s.drifting ? T.driftGrip : T.normalGrip;
+        if (!onTrack) gripTarget = Math.min(gripTarget, T.offTrackGrip);
+        s.grip += (gripTarget - s.grip) * Math.min(1, T.gripEase * dt);
+        vLateral += (0 - vLateral) * Math.min(1, s.grip * dt);
+    }
 
     // ---- recompose world velocity (still using current heading) ----
     s.vx = vForward * fx + vLateral * rx;
@@ -139,6 +160,7 @@ export function stepKart(prev, input, dt, track) {
     const speedFrac = clamp(Math.abs(vForward) / T.topSpeed, 0, 1);
     let authority = clamp(speedFrac * T.steerSpeedGain, 0, 1);
     authority *= 1 - T.turnTopSpeedFalloff * speedFrac; // shave twitch at the very top
+    if (!grounded) authority *= T.airSteer;             // little control in the air
     let yawRate;
     if (s.drifting) {
         // additive control: gentle base pull in the drift direction + your steer.
@@ -175,6 +197,42 @@ export function stepKart(prev, input, dt, track) {
         // refresh cached forward speed after the correction
         s.forwardSpeed = s.vx * fx + s.vz * fz;
     }
+
+    // ---- vertical dynamics over the terrain (2.5D) ----
+    // Grounded: stick to the surface, but if the ground drops away faster than we
+    // can fall, launch (crest of a hill at speed). Airborne: ballistic fall under
+    // gravity until we meet the ground again.
+    const groundY = heightAt(s.x, s.z);
+    const grad2 = gradientAt(s.x, s.z);
+    if (s.airborne) {
+        s.vy -= T.gravity * dt;
+        s.y += s.vy * dt;
+        if (s.y <= groundY) {
+            // landing
+            if (s.vy < -T.hardLandSpeed) {
+                const hit = Math.min(1, (-s.vy - T.hardLandSpeed) / T.hardLandSpeed);
+                const scrub = 1 - (1 - T.landScrub) * hit;
+                s.vx *= scrub; s.vz *= scrub; // hard landings scrub speed
+            }
+            s.y = groundY;
+            s.airborne = false;
+            s.vy = 0;
+        }
+    } else {
+        const vGround = grad2.gx * s.vx + grad2.gz * s.vz; // ground's vertical rate along path
+        s.vy -= T.gravity * dt;
+        const yBallistic = s.y + s.vy * dt;
+        if (yBallistic > groundY + 0.05) {
+            // crest: ground fell away faster than we drop -> we're airborne
+            s.airborne = true;
+            s.y = yBallistic;
+        } else {
+            // stay glued to the surface, matching its rise/fall
+            s.y = groundY;
+            s.vy = vGround;
+        }
+    }
+    s.forwardSpeed = s.vx * fx + s.vz * fz;
 
     return s;
 }

--- a/apps/kart/simulation/terrain.js
+++ b/apps/kart/simulation/terrain.js
@@ -35,11 +35,3 @@ export function gradientAt(x, z) {
     }
     return { gx, gz };
 }
-
-// Unit surface normal (y-up). Useful for orienting meshes to the slope.
-export function normalAt(x, z) {
-    const { gx, gz } = gradientAt(x, z);
-    const nx = -gx, ny = 1, nz = -gz;
-    const l = Math.hypot(nx, ny, nz) || 1;
-    return { x: nx / l, y: ny / l, z: nz / l };
-}

--- a/apps/kart/simulation/terrain.js
+++ b/apps/kart/simulation/terrain.js
@@ -1,0 +1,45 @@
+// Terrain heightfield. Pure analytic functions shared by the simulation (for
+// vertical dynamics) and the renderer (to drape the world over the surface), so
+// both agree exactly. No Three.js, no DOM — stays portable and deterministic.
+//
+// The surface is single-valued y = height(x, z): a sum of low-frequency waves
+// (rolling hills) plus a few Gaussian bumps (local hills / ramps). Single-valued
+// means no overlaps/bridges — that's the deliberate Level-2 scope.
+
+import { TERRAIN } from '../config.js';
+
+export function heightAt(x, z) {
+    let h = 0;
+    for (const w of TERRAIN.waves) {
+        h += w.a * Math.sin(w.fx * x + w.px) * Math.cos(w.fz * z + w.pz);
+    }
+    for (const b of TERRAIN.bumps) {
+        const dx = x - b.x, dz = z - b.z;
+        h += b.a * Math.exp(-(dx * dx + dz * dz) / (2 * b.s * b.s));
+    }
+    return h;
+}
+
+// Analytic gradient (∂h/∂x, ∂h/∂z).
+export function gradientAt(x, z) {
+    let gx = 0, gz = 0;
+    for (const w of TERRAIN.waves) {
+        gx += w.a * w.fx * Math.cos(w.fx * x + w.px) * Math.cos(w.fz * z + w.pz);
+        gz += w.a * Math.sin(w.fx * x + w.px) * (-w.fz * Math.sin(w.fz * z + w.pz));
+    }
+    for (const b of TERRAIN.bumps) {
+        const dx = x - b.x, dz = z - b.z;
+        const e = b.a * Math.exp(-(dx * dx + dz * dz) / (2 * b.s * b.s));
+        gx += e * (-dx / (b.s * b.s));
+        gz += e * (-dz / (b.s * b.s));
+    }
+    return { gx, gz };
+}
+
+// Unit surface normal (y-up). Useful for orienting meshes to the slope.
+export function normalAt(x, z) {
+    const { gx, gz } = gradientAt(x, z);
+    const nx = -gx, ny = 1, nz = -gz;
+    const l = Math.hypot(nx, ny, nz) || 1;
+    return { x: nx / l, y: ny / l, z: nz / l };
+}


### PR DESCRIPTION
## Summary

Adds real topology to the Kart map: a larger circuit draped over an analytic **heightfield**, with the simulation extended to "2.5D" so elevation actually affects driving. This is the Level 2 scope we discussed — rolling hills, slope-affected speed, and jumps off crests — deliberately *not* multi-level/bridges (that's Level 3, which would need a different track/collision representation).

### Terrain (`simulation/terrain.js`)
A shared, pure analytic heightfield — `heightAt`, `gradientAt`, `normalAt` — used by **both** the simulation and the renderer so they agree exactly. Single-valued `y = height(x,z)` (waves for rolling hills + Gaussian bumps), no randomness, stays deterministic and serializable.

### Simulation (still pure `(state, input) -> state`)
- Kart state gains `y`, `vy`, `airborne`.
- Karts stick to the surface; **slopes bleed speed uphill and add it downhill** (gravity along the slope).
- Karts **launch off crests at speed** and fall ballistically under gravity (with reduced steering and a speed scrub on hard landings).

### Rendering (draped over the terrain)
- Ground is now a displaced terrain mesh; the track ribbon, kerbs, edge lines, dashes, start line, banner, cones, walls, and props all follow the heightfield.
- The kart pitches/rolls to the slope (levels out in the air); the chase camera and shadow frustum track its height.

### Map
- Enlarged the circuit ~1.5× (≈985u lap), re-validated offline: no ribbon self-overlap, tightest corner well clear of the wall radius, along-track slopes kept drivable (~13° max) with ~19u of elevation across the lap.

## Verification (Node, headless)
- Spawns on terrain; grounded kart tracks the surface (max error 0.0000).
- Slope changes speed (uphill ~10 vs downhill ~32 on the same flank).
- Launches off a crest at speed and lands grounded.
- Driving-model regression (accel/brake-reverse/drift/boost) still holds; lap progress still advances on the draped track. All modules syntax-checked.

## Caveat
No display/GPU here, so the **visuals are unrendered** — the terrain physics and geometry math are verified in Node, but draping/tilt/camera need your eyes. Likely tuning targets: `gravity`, `slopeAccel`, terrain `waves`/`bumps` amplitudes (jumps are currently subtle), and `TERRAIN.meshStep` (terrain mesh density vs. perf). All in `config.js`.

https://claude.ai/code/session_011FJ8jDY7WMXJFZSbi9cPeh

---
_Generated by [Claude Code](https://claude.ai/code/session_011FJ8jDY7WMXJFZSbi9cPeh)_