### PR TITLE
Kart: fix start-line rollback, finish line, terrain poke-through

### DIFF
--- a/apps/kart/main.js
+++ b/apps/kart/main.js
@@ -191,6 +191,9 @@ function finishRace() {
 const NEUTRAL = { steer: 0, accelerate: false, brake: false, drift: false };
 
 function simStep() {
+    // Held at the start line until GO: don't advance physics during READY/COUNTDOWN
+    // so the kart can't roll down the slope before the race begins.
+    if (game.state !== STATE.RACING && game.state !== STATE.FINISHED) return;
     const cmd = game.state === STATE.RACING ? input.sample() : NEUTRAL;
     game.prev = game.curr;
     game.curr = stepKart(game.curr, cmd, STEP, track);

--- a/apps/kart/render/scene.js
+++ b/apps/kart/render/scene.js
@@ -104,7 +104,10 @@ export class Stage {
         const pos = geo.attributes.position;
         for (let i = 0; i < pos.count; i++) {
             const x = pos.getX(i), z = pos.getZ(i);
-            pos.setY(i, heightAt(x, z) - 0.05);
+            // sit the background terrain slightly below the true surface so the
+            // draped road/verge always cover it and the coarse mesh can't poke
+            // through near the walls
+            pos.setY(i, heightAt(x, z) - 0.18);
         }
         pos.needsUpdate = true;
         geo.computeVertexNormals();

--- a/apps/kart/render/trackView.js
+++ b/apps/kart/render/trackView.js
@@ -1,6 +1,8 @@
 // Builds the visible track from the sim's sampled centerline, draped over the
 // terrain heightfield so the asphalt, kerbs, walls, banner and cones follow the
-// hills. Geometry only — built once, no per-frame work.
+// hills. The road and verge are tessellated ACROSS their width too, so they
+// conform to terrain that curves sideways (otherwise the ground pokes through a
+// flat 2-vertex ribbon). Geometry only — built once, no per-frame work.
 
 import * as THREE from 'three';
 import { COLORS, VISUALS } from '../config.js';
@@ -8,31 +10,18 @@ import { heightAt } from '../simulation/terrain.js';
 import { toonMat } from './materials.js';
 
 // small vertical offsets so layers stack cleanly on the terrain
-const Y_ROAD = 0.06, Y_KERB = 0.10, Y_EDGE = 0.14, Y_DASH = 0.16, Y_START = 0.18;
+const Y_VERGE = 0.04, Y_ROAD = 0.07, Y_KERB = 0.11, Y_EDGE = 0.15, Y_DASH = 0.17, Y_START = 0.19;
+const ROAD_LAT = 6; // lateral segments across the road (drape sideways too)
 
 export function buildTrackView(track) {
     const group = new THREE.Group();
-    const n = track.samples.length;
 
-    // ---- asphalt ribbon ----
-    const positions = [];
-    const indices = [];
-    for (let i = 0; i < n; i++) {
-        const l = track.leftEdge[i], r = track.rightEdge[i];
-        positions.push(l.x, heightAt(l.x, l.z) + Y_ROAD, l.z,
-                       r.x, heightAt(r.x, r.z) + Y_ROAD, r.z);
-    }
-    for (let i = 0; i < n; i++) {
-        const ni = (i + 1) % n;
-        indices.push(i * 2, i * 2 + 1, ni * 2, i * 2 + 1, ni * 2 + 1, ni * 2);
-    }
-    const geo = new THREE.BufferGeometry();
-    geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
-    geo.setIndex(indices);
-    geo.computeVertexNormals();
-    const road = new THREE.Mesh(geo, toonMat(COLORS.track));
-    road.receiveShadow = true;
-    group.add(road);
+    // ---- smooth grass verge filling the runoff (road edge -> wall), draped ----
+    group.add(verge(track, -1));
+    group.add(verge(track, 1));
+
+    // ---- asphalt ribbon (tessellated across its width) ----
+    group.add(road(track));
 
     // ---- kerbs (striped red/white strips just outside each edge) ----
     group.add(kerb(track.leftEdge, track.samples));
@@ -56,6 +45,62 @@ export function buildTrackView(track) {
     return group;
 }
 
+function road(track) {
+    const n = track.samples.length;
+    const cols = ROAD_LAT + 1;
+    const pos = [], idx = [];
+    for (let i = 0; i < n; i++) {
+        const l = track.leftEdge[i], r = track.rightEdge[i];
+        for (let j = 0; j <= ROAD_LAT; j++) {
+            const f = j / ROAD_LAT;
+            const x = l.x + (r.x - l.x) * f;
+            const z = l.z + (r.z - l.z) * f;
+            pos.push(x, heightAt(x, z) + Y_ROAD, z);
+        }
+    }
+    for (let i = 0; i < n; i++) {
+        const ni = (i + 1) % n;
+        for (let j = 0; j < ROAD_LAT; j++) {
+            const a = i * cols + j, b = a + 1;
+            const c = ni * cols + j, d = c + 1;
+            idx.push(a, b, c, b, d, c);
+        }
+    }
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(pos, 3));
+    geo.setIndex(idx);
+    geo.computeVertexNormals();
+    const m = new THREE.Mesh(geo, toonMat(COLORS.track));
+    m.receiveShadow = true;
+    return m;
+}
+
+// Smooth grass strip from the road edge out to the wall, draped on the terrain so
+// the runoff doesn't show the coarse background terrain mesh.
+function verge(track, sign) {
+    const n = track.samples.length;
+    const ratio = track.wallHalfWidth / track.halfWidth;
+    const edge = sign < 0 ? track.leftEdge : track.rightEdge;
+    const pos = [], idx = [];
+    for (let i = 0; i < n; i++) {
+        const s = track.samples[i], e = edge[i];
+        const ox = (e.x - s.x) * ratio + s.x, oz = (e.z - s.z) * ratio + s.z; // wall point
+        pos.push(e.x, heightAt(e.x, e.z) + Y_VERGE, e.z,
+                 ox, heightAt(ox, oz) + Y_VERGE, oz);
+    }
+    for (let i = 0; i < n; i++) {
+        const ni = (i + 1) % n;
+        idx.push(i * 2, i * 2 + 1, ni * 2, i * 2 + 1, ni * 2 + 1, ni * 2);
+    }
+    const g = new THREE.BufferGeometry();
+    g.setAttribute('position', new THREE.Float32BufferAttribute(pos, 3));
+    g.setIndex(idx);
+    g.computeVertexNormals();
+    const m = new THREE.Mesh(g, toonMat(COLORS.grass));
+    m.receiveShadow = true;
+    return m;
+}
+
 function walls(track) {
     const g = new THREE.Group();
     const n = track.samples.length;
@@ -70,7 +115,7 @@ function walls(track) {
             const nx = t.z * sign, nz = -t.x * sign;      // outward normal for this side
             const bx = s.x + nx * wallR, bz = s.z + nz * wallR;
             const by = heightAt(bx, bz);
-            pos.push(bx, by, bz, bx, by + height, bz);
+            pos.push(bx, by - 0.25, bz, bx, by + height, bz); // sink the base into the grass
             const c = (i % 2) ? red : white;
             col.push(c.r, c.g, c.b, c.r, c.g, c.b);
         }
@@ -158,14 +203,35 @@ function centerDashes(track) {
     return g;
 }
 
+// Start/finish stripe as a terrain-draped grid (a flat quad floats/clips on a slope).
 function startStripe(track) {
     const s = track.samples[0], t = track.tangents[0];
-    const geo = new THREE.PlaneGeometry(track.halfWidth * 2, 2.6);
-    geo.rotateX(-Math.PI / 2);
-    const stripe = new THREE.Mesh(geo, new THREE.MeshBasicMaterial({ map: checkerTexture() }));
-    stripe.position.set(s.x, heightAt(s.x, s.z) + Y_START, s.z);
-    stripe.rotation.y = Math.atan2(t.x, t.z);
-    return stripe;
+    const rvx = t.z, rvz = -t.x;     // right vector
+    const halfW = track.halfWidth, depth = 2.8;
+    const LAT = 12, LON = 3;
+    const pos = [], uv = [], idx = [];
+    for (let a = 0; a <= LON; a++) {
+        const v = (a / LON - 0.5) * depth;
+        for (let b = 0; b <= LAT; b++) {
+            const u = (b / LAT * 2 - 1) * halfW;
+            const x = s.x + rvx * u + t.x * v;
+            const z = s.z + rvz * u + t.z * v;
+            pos.push(x, heightAt(x, z) + Y_START, z);
+            uv.push(b / LAT * 6, a / LON);
+        }
+    }
+    for (let a = 0; a < LON; a++) {
+        for (let b = 0; b < LAT; b++) {
+            const i0 = a * (LAT + 1) + b, i1 = i0 + 1, i2 = i0 + (LAT + 1), i3 = i2 + 1;
+            idx.push(i0, i2, i1, i1, i2, i3);
+        }
+    }
+    const g = new THREE.BufferGeometry();
+    g.setAttribute('position', new THREE.Float32BufferAttribute(pos, 3));
+    g.setAttribute('uv', new THREE.Float32BufferAttribute(uv, 2));
+    g.setIndex(idx);
+    g.computeVertexNormals();
+    return new THREE.Mesh(g, new THREE.MeshBasicMaterial({ map: checkerTexture() }));
 }
 
 function startBanner(track) {
@@ -228,7 +294,7 @@ function checkerTexture() {
         }
     const tex = new THREE.CanvasTexture(c);
     tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
-    tex.repeat.set(6, 1);
+    tex.repeat.set(1, 1);
     tex.colorSpace = THREE.SRGBColorSpace;
     return tex;
 }


### PR DESCRIPTION
## Summary

Fixes three bugs introduced by the heightfield terrain.

### 1. Kart rolled backwards at the start line
The start line sits on a slope (terrain `|dh/dx|` ≈ 0.16 there), and during the countdown the kart was fed neutral input, so the new slope-gravity term rolled it. The kart is now **held frozen at the line during READY/COUNTDOWN** and launches from a standstill on GO.

### 2. Finish line didn't lay on the surface
The start/finish stripe was a single flat quad, so it floated/clipped on the sloped ground. It's now a **terrain-draped grid** that conforms to the surface.

### 3. "Green bumps" in the track around the walls
That was the coarse background terrain mesh showing through:
- The road ribbon was only 2 vertices across — a flat cross-section that curved terrain poked through mid-track. It's now **tessellated across its width** so it drapes sideways too.
- The runoff strip (road edge → wall) showed the raw coarse mesh. Added a **smooth, terrain-draped grass verge** filling it.
- **Sank the wall bases** and dropped the **background terrain mesh** slightly (−0.18) so it stays hidden under the draped track near the walls.

## Verification (Node, headless)
- Grounded kart still sticks to the terrain (error 0.0000); confirmed the start line has a real slope (≈0.16) that explains the original rollback.
- All modules syntax-checked; files serve.

## Caveat
No display/GPU here, so the draping/finish-line/verge are verified by the geometry math, not rendered — these are visual fixes that need your eyes to confirm. If any green still shows near the walls on steeper spots, the knobs are `TERRAIN.meshStep` (finer mesh) and the verge/terrain offsets in `trackView.js` / `scene.js`.

https://claude.ai/code/session_011FJ8jDY7WMXJFZSbi9cPeh

---
_Generated by [Claude Code](https://claude.ai/code/session_011FJ8jDY7WMXJFZSbi9cPeh)_