### PR TITLE
Kart 2: fix finish-line geometry (root cause), de-jank drift, overhaul audio

### DIFF
--- a/apps/kart2/CLAUDE.md
+++ b/apps/kart2/CLAUDE.md
@@ -1,0 +1,164 @@
+# Kart 2 — CLAUDE.md
+
+Project-specific notes for the **Kart 2** app. Read this before changing
+`apps/kart2/index.html`. The repo-root `CLAUDE.md` covers site-wide rules
+(iOS PWA meta tags, `/apps/` structure, canonical origin `polkiewicz.com`).
+
+---
+
+## ⚠️ #1 LESSON: don't guess at 3D/visual bugs — RENDER IT
+
+This app is a WebGL game. For three rounds I tried to fix a "weird finish
+line / random walls" bug by **reading code and guessing**, and shipped three
+wrong/incomplete fixes. The bug was only found in ~20 minutes once I actually
+**rendered the scene headless and looked at it**, then **probed the geometry
+numerically**.
+
+**If a visual/3D bug is reported, set up the headless render harness FIRST.**
+It is fast, and there is no substitute for seeing the pixels + measuring the data.
+
+### Headless render harness (this works in this environment)
+
+```bash
+cd /tmp && mkdir kartshot && cd kartshot && npm init -y
+npm i puppeteer
+npx puppeteer browsers install chrome          # downloads Chromium
+npm i three@0.128.0 && cp node_modules/three/build/three.min.js .   # vendor three (CDN may be blocked in headless)
+```
+
+Make a debug copy of the page that (a) loads three from the local file and
+(b) exposes the internals from inside the IIFE:
+
+```js
+// prep.js
+let html = fs.readFileSync('.../apps/kart2/index.html','utf8');
+html = html.replace('https://cdnjs.cloudflare.com/.../three.min.js', './three.min.js');
+html = html.replace('animate();',
+  'window.__dbg={THREE,scene,camera,renderer,centerline,normals,tangents,setState:(s)=>{state=s;}}; animate();');
+fs.writeFileSync('/tmp/kartshot/kart.html', html);
+```
+
+Launch Chromium with **software WebGL** (no GPU in CI):
+
+```js
+puppeteer.launch({ headless:'new', args:[
+  '--no-sandbox','--enable-unsafe-swiftshader',
+  '--use-gl=angle','--use-angle=swiftshader' ]});
+await page.setCacheEnabled(false);                      // important
+await page.goto('file:///tmp/kartshot/kart.html?cb='+Date.now()); // cache-bust
+await page.waitForFunction('window.__dbg && window.__dbg.centerline.length>0');
+```
+
+Then to inspect:
+- **Free camera:** `window.__dbg.setState('paused')` freezes the render loop's
+  camera control; hide overlays with `document.querySelectorAll('.screen').forEach(s=>s.style.display='none')`;
+  set `camera.position/lookAt`, call `renderer.render(scene,camera)`, screenshot.
+  Useful angles: top-down on the start line, low "driver" angle, whole-track perspective.
+- **Read screenshots** with the image-reading tool.
+- **Probe geometry numerically** via `page.evaluate`: raycast (`THREE.Raycaster`)
+  through suspect pixels to ID the mesh; dump `geometry.attributes.position` /
+  `normal` / `index`; compare each vertex to where it *should* be; check for
+  tangent/normal flips (`dot(n[i], n[i+1]) < 0.5`), long edges, degenerate tris.
+- **Run the real game loop:** `page.click('#startBtn')`, wait through the
+  countdown, and capture `pageerror`/`console` — catches runtime exceptions in
+  the whole pipeline (audio, items, drift) with zero false confidence.
+
+### swiftshader caveat (don't get fooled like I did)
+swiftshader (software GL) has **its own shader bugs that are NOT on real
+hardware**. Notably its `MeshLambertMaterial` produced a fake "bowtie/fan"
+artifact on perfectly-good geometry. To check whether something is a real
+geometry bug vs a swiftshader artifact, **force materials to
+`MeshBasicMaterial`** (simple shader, renders geometry faithfully) and
+re-render. If it's clean under MeshBasic, the geometry is fine and the
+artifact won't appear on the iPhone.
+
+---
+
+## What this is
+
+A single, self-contained `index.html` (HTML + CSS + inline JS) — a 3D kart
+racer for **iPhone in portrait**, three.js **r128** from cdnjs. Tilt to steer,
+hold to drift for a boost, items, 3 laps. Everything (geometry, audio, UI) is
+generated at runtime; there are no external assets.
+
+## Architecture (all inside one IIFE)
+
+- **`worldGroup`** holds all rebuildable world geometry (sky, lights, road,
+  curbs, guardrails, start line, scenery, boost pads, item boxes). `loadTrack(idx)`
+  removes + `disposeObject()`s the old `worldGroup` and rebuilds it. **Karts,
+  particles, projectiles and hazards live directly in `scene`** so a track
+  reload doesn't dispose them.
+- **Track geometry** comes from `centerline[]`, `tangents[]`, `normals[]`
+  (length `N_SAMPLES = 900`), sampled from a **closed `CatmullRomCurve3`**.
+- **State machine:** `state ∈ menu | countdown | racing | finished | paused`
+  drives `animate()`.
+- **Karts:** `karts[]`, `player = karts[0]`; each has pos (XZ), `theta`, `speed`,
+  `groundY`, progress/lap tracking, drift/boost/item/bonk/shield timers, and
+  per-character stat multipliers.
+- **Sections in order:** helpers → DOM refs → config/data (CHARS, TRACKS,
+  ITEM_DEF) → storage → three init → world/track build → particles → karts →
+  progress/physics → items → camera → rankings/HUD/minimap → audio → input →
+  menu UI → flow (start/countdown/pause/finish) → main loop → boot.
+
+## Key features
+Tilt + touch-drag + keyboard steering; hold-to-drift with charged mini-turbo;
+boost pads; **items** (boost / homing rocket / banana / shield / lightning bolt)
+with item boxes, a roulette, an on-screen button, and AI usage (rank-weighted
+so trailing racers get stronger items); **3 themed tracks** (Sunshine Bay day /
+Neon Circuit night / Sunset Canyon) with a track-select; **character select**
+(speed/accel/handling trade-offs); minimap; position toasts; start light-tree;
+confetti finish; **per-track best lap/time in localStorage**; tilt-sensitivity
+slider + recenter; haptics; pause/resume (+ auto-pause on `visibilitychange`);
+WebAudio engine + chiptune music + SFX (all mutable); adaptive pixel-ratio.
+
+## Gotchas & conventions (learned the hard way)
+
+- **Track tangents/normals:** compute them from **finite differences of the
+  sampled centerline positions**, NOT from `curve.getTangentAt()`.
+  `getTangentAt()` on a *closed* Catmull-Rom returns a bad tangent near the seam
+  (a ~73° flip around sample ~889 here). A flipped normal swaps the road ribbon's
+  left/right edges and twists the road + guardrails into a crossing "wall" mess
+  at the finish line. (This was the real "random walls" bug.)
+- **Custom ribbon winding faces down.** The road `BufferGeometry`'s triangle
+  winding produces downward normals, so with default back-face culling the
+  road's *top* is culled and you **see through it to the ground**. The road
+  material is `side: THREE.DoubleSide` to fix this. If you build new ribbon
+  geometry, either fix the winding or use DoubleSide. (This — not "elevation" —
+  was the real "see through the ground" bug; flattening the tracks did not fix it.)
+- **Tracks are flat (`y = 0`).** Elevation was removed because a raised road
+  over a single flat ground plane shows void/gaps beside it. If you re-add
+  elevation you MUST also build a connected terrain skirt under/around the road,
+  and thread `centerline[i].y` through every piece of geometry + `kart.groundY`
+  + the camera.
+- **Ground-level decals** (start/finish line, boost pads): use `polygonOffset`
+  + a small Y lift (~0.1) and `renderOrder`. Do **not** use `depthWrite:false`
+  on opaque decals — it causes z-ordering artifacts.
+- **Start banner** must be offset to sit *in front of* the banner bar box, not
+  at its center (otherwise it z-fights / hides inside the bar).
+- **Lap logic:** karts start on a grid just *past* the start line; a lap counts
+  on a forward seam crossing (prev seg > 0.7·N, new seg < 0.25·N); finishing =
+  `TOTAL_LAPS` crossings.
+- **Tilt:** `gamma` is negated (tilt left → steer left) and recalibrated at "GO".
+  The sensitivity slider is **inverted** so dragging right = more sensitive:
+  the internal divisor `sensitivity = 58 - sliderValue` (smaller divisor = more
+  sensitive). Lower divisor = twitchier.
+- **Getting hit = a brief "bonk"** (speed cut + bounce + sparks) with **full
+  steering retained** — NOT a loss-of-control spinout. The user explicitly
+  dislikes spinouts; do not reintroduce uncontrollable spins.
+- **Drift** only engages when actually steering (`|steer| > 0.28`) so a hold
+  while pointing straight doesn't cause a random veer; direction is taken from
+  steering (never random), eases in via `driftRamp`, and tightness is modulated
+  by steering into/out of the committed direction.
+- **Audio** can't be heard in CI — code-review it; the engine is stacked
+  detuned saws + sub through a speed-driven lowpass; music is a square-lead +
+  triangle-bass + noise-drum chiptune loop over I-V-vi-IV.
+
+## Verification checklist before shipping a change here
+1. JS syntax: `node -e "new Function(<inline script body>)"`.
+2. Scan for stray non-ASCII (emoji/`—`/`…`/`·` are intentional).
+3. `python3 -m http.server` and confirm the page returns HTTP 200.
+4. **For anything visual or physics-related: render it headless** (see top),
+   from the relevant cameras, and run a full START→race session capturing
+   `pageerror`. Force `MeshBasicMaterial` to distinguish geometry bugs from
+   swiftshader shader artifacts.
+5. Be honest in the PR about what was and wasn't verified (no GPU, no audio in CI).

--- a/apps/kart2/index.html
+++ b/apps/kart2/index.html
@@ -413,8 +413,8 @@
         let fpsAccum = 0, fpsFrames = 0, dprAdjusted = false;
 
         // audio
-        let audioCtx = null, engineOsc = null, engineGain = null, muted = false;
-        let musicTimer = null, musicStep = 0, musicGain = null;
+        let audioCtx = null, masterGain = null, engineGain = null, engineFilter = null, engineOscs = [], muted = false;
+        let musicTimer = null, musicStep = 0, musicGain = null, noiseBuf = null;
 
         // ===================================================================
         //  STORAGE (best times per track)
@@ -500,12 +500,18 @@
             const pts = def.ctrl.map((p) => new THREE.Vector3(p[0], 0, p[1]));
             const curve = new THREE.CatmullRomCurve3(pts, true, 'catmullrom', 0.5);
             centerline = []; tangents = []; normals = [];
+            for (let i = 0; i < N_SAMPLES; i++) centerline.push(curve.getPointAt(i / N_SAMPLES));
+            // Derive tangents/normals from finite differences of the (smooth)
+            // sample positions rather than curve.getTangentAt(). getTangentAt
+            // glitches near the closed-curve seam (a single ~73° flip around
+            // sample 889) which swapped the ribbon's left/right edges and
+            // twisted the road + guardrails into a bowtie at the finish line.
             for (let i = 0; i < N_SAMPLES; i++) {
-                const u = i / N_SAMPLES;
-                const p = curve.getPointAt(u);
-                const t = curve.getTangentAt(u); t.y = 0; t.normalize();
-                const n = new THREE.Vector3(-t.z, 0, t.x);
-                centerline.push(p); tangents.push(t); normals.push(n);
+                const a = centerline[(i - 1 + N_SAMPLES) % N_SAMPLES];
+                const b = centerline[(i + 1) % N_SAMPLES];
+                const t = new THREE.Vector3(b.x - a.x, 0, b.z - a.z).normalize();
+                tangents.push(t);
+                normals.push(new THREE.Vector3(-t.z, 0, t.x));
             }
         }
 
@@ -599,7 +605,10 @@
             roadGeo.setAttribute('position', new THREE.Float32BufferAttribute(roadPos, 3));
             roadGeo.setAttribute('uv', new THREE.Float32BufferAttribute(roadUV, 2));
             roadGeo.setIndex(roadIdx); roadGeo.computeVertexNormals();
-            const roadMesh = new THREE.Mesh(roadGeo, new THREE.MeshLambertMaterial({ map: makeRoadTexture(th) }));
+            // DoubleSide: the ribbon's triangle winding faces downward, so with
+            // default back-face culling the road's top was culled — you saw
+            // straight through it to the ground. DoubleSide renders + lights both faces.
+            const roadMesh = new THREE.Mesh(roadGeo, new THREE.MeshLambertMaterial({ map: makeRoadTexture(th), side: THREE.DoubleSide }));
             roadMesh.renderOrder = 1; worldGroup.add(roadMesh);
 
             const curbGeo = new THREE.BufferGeometry();
@@ -970,7 +979,7 @@
                     statSpeed: ch.speed, statAccel: ch.accel, statHandling: ch.handling,
                     pos: new THREE.Vector3(), theta: 0, speed: 0, groundY: 0,
                     seg: 0, lastSeg: 0, u: 0, laps: 0, progress: 0, rank: i + 1,
-                    drifting: false, driftDir: 0, driftCharge: 0,
+                    drifting: false, driftDir: 0, driftCharge: 0, driftRamp: 0,
                     boostTimer: 0, hopT: 0, visualRoll: 0,
                     spinTimer: 0, shieldTimer: 0, invuln: 0,
                     item: null, itemRolling: 0, itemUseTimer: 0,
@@ -995,7 +1004,7 @@
                 k.groundY = c.y;
                 k.theta = Math.atan2(t.x, t.z);
                 k.speed = 0; k.seg = seg; k.lastSeg = k.seg; k.u = k.seg / N_SAMPLES; k.laps = 0; k.progress = k.seg / N_SAMPLES;
-                k.drifting = false; k.driftCharge = 0; k.boostTimer = 0; k.hopT = 0; k.visualRoll = 0;
+                k.drifting = false; k.driftCharge = 0; k.driftRamp = 0; k.boostTimer = 0; k.hopT = 0; k.visualRoll = 0;
                 k.spinTimer = 0; k.shieldTimer = 0; k.invuln = 0; k.item = null; k.itemRolling = 0; k.itemUseTimer = 0; k.stuckTimer = 0;
                 k.lane = grid[i].side * (HALF_W * 0.45);
                 k.finished = false; k.finishTime = 0; k.bestLap = Infinity; k.lastLapStart = 0;
@@ -1070,7 +1079,7 @@
             if (controlled) {
                 if (k.isPlayer) {
                     steer = steerInput;
-                    if (playerWantDrift && !k.drifting) startDrift(k);
+                    if (playerWantDrift && !k.drifting) startDrift(k, steer);
                     else if (!playerWantDrift && k.drifting) releaseDrift(k);
                 } else {
                     steer = aiSteer(k, dt);
@@ -1095,7 +1104,14 @@
             // steering (full control retained even when bonked)
             const speedFactor = clamp(k.speed / 26, 0, 1);
             let turn = steer * 2.5 * k.statHandling * speedFactor;
-            if (k.drifting) turn = (steer * 1.0 + k.driftDir * 1.5) * speedFactor * 1.25 * k.statHandling;
+            if (k.drifting) {
+                // ease the drift in, stay committed to driftDir, and let the player
+                // tighten (steer into) or loosen (steer out) it smoothly — no yank.
+                k.driftRamp = Math.min(1, (k.driftRamp || 0) + dt * 6);
+                const into = clamp(k.driftDir * steer, -1, 1);
+                const rate = 1.9 + into * 0.9;
+                turn = k.driftDir * rate * speedFactor * k.statHandling * k.driftRamp;
+            }
             k.theta += turn * dt;
 
             if (k.drifting && k.speed > 25) k.driftCharge += dt;
@@ -1163,12 +1179,14 @@
             if (stage > 0 && k.isPlayer) { sfxBoost(); vibrate(stage * 25); }
             k.drifting = false; k.driftCharge = 0; k.driftDir = 0;
         }
-        function startDrift(k) {
-            if (k.drifting || k.speed < 22) return;
+        function startDrift(k, steerVal) {
+            if (k.drifting || k.speed < 24) return;
+            // only drift when actually turning — prevents the old random veer when level
+            if (Math.abs(steerVal) < 0.28) return;
             k.drifting = true;
-            k.driftDir = (k.isPlayer ? (steerInput >= 0 ? 1 : -1) : 1);
-            if (Math.abs(k.isPlayer ? steerInput : 0) < 0.15) k.driftDir = (Math.random() < 0.5 ? 1 : -1);
-            k.hopT = 0.28;
+            k.driftDir = steerVal >= 0 ? 1 : -1;
+            k.driftRamp = 0;
+            k.hopT = 0.26;
         }
         function spawnRearSpark(k, color, spread) {
             const back = -2.6, side = 1.7;
@@ -1338,8 +1356,9 @@
             const gap = player.progress - k.progress;
             k._rubber = clamp(1 + gap * 0.10, 0.82, 1.18) * k.aiSkill;
             const aheadSeg = (k.seg + 30) % N_SAMPLES;
-            const turnTight = Math.abs(wrapAngle(Math.atan2(centerline[aheadSeg].x - k.pos.x, centerline[aheadSeg].z - k.pos.z) - k.theta));
-            if (!k.drifting && turnTight > 0.5 && k.speed > 40 && Math.random() < 0.02) startDrift(k);
+            const aheadAng = wrapAngle(Math.atan2(centerline[aheadSeg].x - k.pos.x, centerline[aheadSeg].z - k.pos.z) - k.theta);
+            const turnTight = Math.abs(aheadAng);
+            if (!k.drifting && turnTight > 0.5 && k.speed > 40 && Math.random() < 0.02) startDrift(k, aheadAng >= 0 ? 1 : -1);
             if (k.drifting && (turnTight < 0.2 || k.driftCharge > rand(1.0, 2.1))) releaseDrift(k);
             // avoid bananas
             for (const h of hazards) {
@@ -1380,7 +1399,7 @@
             const targetRoll = (k.drifting ? -k.driftDir * 0.16 : -(k.isPlayer ? steerInput : 0) * 0.06);
             k.visualRoll = lerp(k.visualRoll, targetRoll, instant ? 1 : 0.15);
             g.rotation.z = k.visualRoll;
-            g.rotation.y = k.theta + (k.drifting ? -k.driftDir * 0.32 : 0);
+            g.rotation.y = k.theta + (k.drifting ? -k.driftDir * 0.32 * (k.driftRamp || 1) : 0);
             const spin = k.speed * dt * 0.9;
             for (const w of k.mesh.wheels) w.rotation.x += spin;
             const fs = (k.isPlayer ? steerInput : 0) * 0.4 + (k.drifting ? k.driftDir * 0.3 : 0);
@@ -1493,59 +1512,90 @@
         function initAudio() {
             try {
                 audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-                engineGain = audioCtx.createGain(); engineGain.gain.value = 0; engineGain.connect(audioCtx.destination);
-                engineOsc = audioCtx.createOscillator(); engineOsc.type = 'sawtooth'; engineOsc.frequency.value = 70;
-                const lp = audioCtx.createBiquadFilter(); lp.type = 'lowpass'; lp.frequency.value = 900;
-                engineOsc.connect(lp); lp.connect(engineGain); engineOsc.start();
-                musicGain = audioCtx.createGain(); musicGain.gain.value = 0.06; musicGain.connect(audioCtx.destination);
+                const ctx = audioCtx;
+                masterGain = ctx.createGain(); masterGain.gain.value = 0.85; masterGain.connect(ctx.destination);
+                // engine: stacked detuned saws + a sub-osc through a resonant lowpass
+                engineGain = ctx.createGain(); engineGain.gain.value = 0;
+                engineFilter = ctx.createBiquadFilter(); engineFilter.type = 'lowpass'; engineFilter.frequency.value = 600; engineFilter.Q.value = 7;
+                engineFilter.connect(engineGain); engineGain.connect(masterGain);
+                engineOscs = [];
+                [[1, 'sawtooth', 0.32], [1.008, 'sawtooth', 0.28], [2.01, 'sawtooth', 0.12], [0.5, 'sine', 0.45]].forEach(([mult, type, g]) => {
+                    const o = ctx.createOscillator(); o.type = type; o.frequency.value = 55 * mult;
+                    const gn = ctx.createGain(); gn.gain.value = g; o.connect(gn); gn.connect(engineFilter); o.start();
+                    engineOscs.push({ o, mult });
+                });
+                musicGain = ctx.createGain(); musicGain.gain.value = 0.5; musicGain.connect(masterGain);
+                noiseBuf = ctx.createBuffer(1, Math.floor(ctx.sampleRate * 0.6), ctx.sampleRate);
+                const nd = noiseBuf.getChannelData(0); for (let i = 0; i < nd.length; i++) nd[i] = Math.random() * 2 - 1;
             } catch (e) { audioCtx = null; }
         }
         function updateEngineSound() {
             if (!audioCtx || muted) return;
-            const t = clamp(player.speed / MAX_SPEED, 0, 1.4);
-            engineOsc.frequency.setTargetAtTime(60 + t * 180, audioCtx.currentTime, 0.05);
-            engineGain.gain.setTargetAtTime(state === 'racing' ? 0.05 + t * 0.05 : 0, audioCtx.currentTime, 0.1);
+            const now = audioCtx.currentTime;
+            const t = clamp(player.speed / MAX_SPEED, 0, 1.5);
+            const base = 50 + t * 155 + (player.boostTimer > 0 ? 28 : 0);
+            engineOscs.forEach(e => e.o.frequency.setTargetAtTime(base * e.mult, now, 0.05));
+            engineFilter.frequency.setTargetAtTime(420 + t * 3200, now, 0.08);
+            engineGain.gain.setTargetAtTime(state === 'racing' ? 0.05 + t * 0.07 : 0, now, 0.12);
+        }
+        // ---- audio primitives ----
+        function aTone(freq, type, dur, gain, dest) {
+            if (!audioCtx) return;
+            const now = audioCtx.currentTime, o = audioCtx.createOscillator(), g = audioCtx.createGain();
+            o.type = type; o.frequency.value = freq;
+            g.gain.setValueAtTime(0.0001, now);
+            g.gain.exponentialRampToValueAtTime(gain, now + 0.012);
+            g.gain.exponentialRampToValueAtTime(0.0001, now + dur);
+            o.connect(g); g.connect(dest || masterGain); o.start(now); o.stop(now + dur + 0.03);
+        }
+        function aNoise(dur, gain, hp, dest) {
+            if (!audioCtx || !noiseBuf) return;
+            const now = audioCtx.currentTime, s = audioCtx.createBufferSource(); s.buffer = noiseBuf;
+            const f = audioCtx.createBiquadFilter(); f.type = hp ? 'highpass' : 'lowpass'; f.frequency.value = hp ? 5500 : 1800;
+            const g = audioCtx.createGain(); g.gain.setValueAtTime(gain, now); g.gain.exponentialRampToValueAtTime(0.0001, now + dur);
+            s.connect(f); f.connect(g); g.connect(dest || masterGain); s.start(now); s.stop(now + dur + 0.03);
+        }
+        function aKick(dest) {
+            if (!audioCtx) return;
+            const now = audioCtx.currentTime, o = audioCtx.createOscillator(), g = audioCtx.createGain();
+            o.frequency.setValueAtTime(135, now); o.frequency.exponentialRampToValueAtTime(46, now + 0.12);
+            g.gain.setValueAtTime(0.5, now); g.gain.exponentialRampToValueAtTime(0.001, now + 0.17);
+            o.connect(g); g.connect(dest || masterGain); o.start(now); o.stop(now + 0.19);
         }
         function sfxBoost() {
             if (!audioCtx || muted) return;
+            const now = audioCtx.currentTime;
+            aTone(220, 'square', 0.32, 0.12, masterGain);
             const o = audioCtx.createOscillator(), g = audioCtx.createGain();
-            o.type = 'square'; o.frequency.setValueAtTime(220, audioCtx.currentTime);
-            o.frequency.exponentialRampToValueAtTime(880, audioCtx.currentTime + 0.25);
-            g.gain.setValueAtTime(0.12, audioCtx.currentTime); g.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.3);
-            o.connect(g); g.connect(audioCtx.destination); o.start(); o.stop(audioCtx.currentTime + 0.32);
+            o.type = 'sawtooth'; o.frequency.setValueAtTime(180, now); o.frequency.exponentialRampToValueAtTime(900, now + 0.28);
+            g.gain.setValueAtTime(0.12, now); g.gain.exponentialRampToValueAtTime(0.001, now + 0.32);
+            o.connect(g); g.connect(masterGain); o.start(now); o.stop(now + 0.34);
+            aNoise(0.3, 0.12, true);
         }
         function sfxBeep(freq) {
             if (!audioCtx || muted) return;
-            const o = audioCtx.createOscillator(), g = audioCtx.createGain();
-            o.type = 'sine'; o.frequency.value = freq;
-            g.gain.setValueAtTime(0.16, audioCtx.currentTime); g.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.3);
-            o.connect(g); g.connect(audioCtx.destination); o.start(); o.stop(audioCtx.currentTime + 0.32);
+            aTone(freq, 'sine', 0.3, 0.16, masterGain);
+            aTone(freq * 2, 'sine', 0.18, 0.05, masterGain);
         }
-        // light, upbeat background loop
-        const MUSIC_NOTES = [0, 4, 7, 12, 7, 4, 0, -5, 2, 5, 9, 14, 9, 5, 2, -3];
+        // ---- chiptune-ish loop: lead + bass + drums over a I-V-vi-IV progression ----
+        const MUS_LEAD = [
+            523, 0, 659, 0, 784, 659, 523, 0,  587, 0, 494, 0, 392, 494, 587, 0,
+            523, 0, 440, 0, 330, 440, 523, 0,  349, 0, 523, 0, 440, 349, 523, 0
+        ];
+        const MUS_BASS = [65.41, 98.0, 110.0, 87.31]; // C2 G2 A2 F2
         function musicTick() {
             if (!audioCtx) return;
             if (!muted && (state === 'racing' || state === 'countdown')) {
-                const base = 196; // G3
-                const semi = MUSIC_NOTES[musicStep % MUSIC_NOTES.length];
-                const f = base * Math.pow(2, semi / 12);
-                const o = audioCtx.createOscillator(), g = audioCtx.createGain();
-                o.type = 'triangle'; o.frequency.value = f;
-                g.gain.setValueAtTime(0.0001, audioCtx.currentTime);
-                g.gain.linearRampToValueAtTime(0.05, audioCtx.currentTime + 0.02);
-                g.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime + 0.22);
-                o.connect(g); g.connect(musicGain); o.start(); o.stop(audioCtx.currentTime + 0.24);
-                // bass on the beat
-                if (musicStep % 4 === 0) {
-                    const bo = audioCtx.createOscillator(), bg = audioCtx.createGain();
-                    bo.type = 'sine'; bo.frequency.value = f / 2;
-                    bg.gain.setValueAtTime(0.08, audioCtx.currentTime); bg.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime + 0.3);
-                    bo.connect(bg); bg.connect(musicGain); bo.start(); bo.stop(audioCtx.currentTime + 0.32);
-                }
+                const s = musicStep % 32;
+                if (MUS_LEAD[s]) aTone(MUS_LEAD[s], 'square', 0.2, 0.085, musicGain);
+                if (s % 8 === 0 || s % 8 === 4) aTone(MUS_BASS[Math.floor(s / 8) % 4], 'triangle', 0.3, 0.22, musicGain);
+                if (s % 4 === 0) aKick(musicGain);
+                if (s % 8 === 4) aNoise(0.12, 0.16, false, musicGain);  // snare
+                if (s % 2 === 1) aNoise(0.025, 0.045, true, musicGain); // hat
             }
             musicStep++;
         }
-        function startMusic() { if (musicTimer) clearInterval(musicTimer); musicStep = 0; musicTimer = setInterval(musicTick, 200); }
+        function startMusic() { if (musicTimer) clearInterval(musicTimer); musicStep = 0; musicTimer = setInterval(musicTick, 125); }
         function stopMusic() { if (musicTimer) { clearInterval(musicTimer); musicTimer = null; } }
 
         // ===================================================================


### PR DESCRIPTION
This round I stopped guessing about the finish line and **installed a headless browser (puppeteer + swiftshader) to actually render and inspect the scene**. That found the real root cause — and a second hidden bug — plus let me verify the result.

## 1. The finish line ("random walls everywhere") — root-caused
Rendering the start area top-down showed the road and guardrails twisting into a crossing tangle right at the finish line. Probing the data:
- `curve.getTangentAt()` returns a **bad tangent (~73° flip) near the closed-curve seam (around sample 889)**. That flipped the track normal, which **swapped the road's left/right edges and twisted the road + rails** into the "walls." Fix: derive tangents/normals from **finite differences of the sampled centerline positions** (which are smooth) instead of `getTangentAt()`. Verified: 0 normal flips, 0 ribbon twists afterward.
- While in there I found the **"see through the ground" bug too**: the road ribbon's triangle winding faces *downward*, so with default back-face culling the road's top face was culled and you looked **straight through the road to the ground**. (Flattening last round didn't fix this.) Fix: render the road **double-sided**.

After both fixes the finish line renders clean from the driver's view and top-down (verified headless). Note: a "bowtie" artifact that showed up in my raw renders turned out to be a *swiftshader-only* `MeshLambertMaterial` shader glitch — `MeshBasicMaterial` renders the identical geometry perfectly — so it never existed on the iPhone; the winding + tangent bugs are the real ones.

## 2. Drift — de-janked
- Drift now **only engages when you're actually steering** (`|steer| > 0.28`), so holding while pointed straight no longer triggers the old **random left/right veer**.
- Direction comes from your steering (never random); the turn **eases in via a ramp** and you can **tighten/loosen** it by steering into/out of the drift while staying committed to the chosen side. Much smoother and more predictable.

## 3. Audio — rebuilt
- **Engine:** stacked detuned saw oscillators + a sub, through a resonant lowpass whose cutoff opens with speed → a fuller, revvier engine instead of a flat buzz.
- **Music:** a real chiptune loop — square lead + triangle bass over a I‑V‑vi‑IV progression with **kick/snare/hi-hat** percussion.
- **SFX:** layered boost (sweep + whoosh + harmonic) and richer beeps. Everything still respects mute.

## Verification
This time it's genuinely verified: I rendered the game in headless Chromium, confirmed the finish-line geometry is clean (driver view + top-down), and ran a full **START → countdown → race** session that produced **zero runtime errors** (exercising the new audio, drift, items, and game loop). I still can't *hear* the audio in CI, so that part is code-reviewed rather than listened to.

https://claude.ai/code/session_01KcttgDFQjC9ZLmniGbqeYf

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcttgDFQjC9ZLmniGbqeYf)_