### PR TITLE
Glide: cinematic dusk/dawn atmosphere + a masterful glider

### DIFF
--- a/apps/glide/index.html
+++ b/apps/glide/index.html
@@ -221,7 +221,7 @@
         const RING_RADIUS = 46;
         const RING_BONUS = 25;
         const TILT_RANGE = 24;        // degrees of tilt for full deflection
-        const CYCLE_DIST = 16000;     // world px for one full day/night cycle
+        const CYCLE_DIST = 22000;     // world px for one full day/night cycle (slow, majestic)
         // vertical flight model (gravity-based so the glider naturally sinks)
         const GRAVITY = 0.22;         // constant downward accel
         const LIFT = 0.70;            // upward accel at full back-tilt
@@ -295,18 +295,32 @@
         // ---------------------------------------------------------------
         //  Day / night cycle
         // ---------------------------------------------------------------
-        // Keyframes around the cycle: dawn -> day -> dusk -> night -> (dawn)
+        // Each keyframe is a full vertical gradient (zenith -> upper -> lower ->
+        // horizon) plus how dark the sky is (stars) and how warm the light is
+        // (dawn/dusk bloom). Interpolating these slowly fades dusk into night
+        // into dawn into day.
         const SKY = [
-            { at: 0.00, top: [58, 78, 140], bot: [255, 170, 120], dark: 0.45 }, // dawn
-            { at: 0.25, top: [74, 144, 217], bot: [180, 216, 246], dark: 0.00 }, // day
-            { at: 0.50, top: [54, 42, 96], bot: [255, 120, 95], dark: 0.55 },    // dusk
-            { at: 0.75, top: [8, 10, 38], bot: [26, 26, 58], dark: 1.00 },       // night
-            { at: 1.00, top: [58, 78, 140], bot: [255, 170, 120], dark: 0.45 },  // back to dawn
+            // dawn — indigo night yielding to a rose-gold horizon
+            { at: 0.00, stops: [[34, 38, 82], [86, 70, 130], [214, 124, 140], [255, 180, 142]], dark: 0.58, warm: 0.60 },
+            // sunrise — cool blue overhead, molten gold at the horizon
+            { at: 0.13, stops: [[56, 92, 158], [120, 140, 196], [255, 182, 120], [255, 230, 158]], dark: 0.14, warm: 0.90 },
+            // day — clean deep azure
+            { at: 0.28, stops: [[46, 120, 206], [92, 162, 226], [156, 204, 242], [208, 236, 251]], dark: 0.00, warm: 0.08 },
+            // golden hour — warm amber wash climbing the sky
+            { at: 0.44, stops: [[64, 106, 182], [150, 156, 206], [255, 198, 134], [255, 230, 176]], dark: 0.10, warm: 0.82 },
+            // dusk — violet zenith, fiery coral horizon
+            { at: 0.57, stops: [[46, 36, 94], [128, 60, 122], [240, 108, 96], [255, 150, 92]], dark: 0.44, warm: 1.00 },
+            // twilight — deep navy with a dim ember band
+            { at: 0.72, stops: [[20, 22, 60], [54, 44, 96], [118, 66, 108], [186, 98, 100]], dark: 0.84, warm: 0.55 },
+            // night — near-black, a faint cool glow at the horizon
+            { at: 0.86, stops: [[5, 7, 28], [11, 15, 44], [20, 26, 62], [40, 48, 92]], dark: 1.00, warm: 0.06 },
+            // back to dawn (seam)
+            { at: 1.00, stops: [[34, 38, 82], [86, 70, 130], [214, 124, 140], [255, 180, 142]], dark: 0.58, warm: 0.60 },
         ];
+        const STOP_POS = [0, 0.42, 0.72, 1];
         function cycleAt(dist) {
-            const p = ((dist / CYCLE_DIST) % 1 + 1) % 1; // start near dawn->day
-            // bias so a fresh game opens in daytime
-            return (p + 0.15) % 1;
+            const p = ((dist / CYCLE_DIST) % 1 + 1) % 1;
+            return (p + 0.20) % 1; // open on a bright morning
         }
         function skyState(dist) {
             const p = cycleAt(dist);
@@ -314,11 +328,27 @@
             while (i < SKY.length - 1 && p > SKY[i + 1].at) i++;
             const a = SKY[i], b = SKY[i + 1];
             const t = (p - a.at) / (b.at - a.at);
+            const stops = a.stops.map((c, k) => lerpColor(c, b.stops[k], t));
             return {
                 p: p,
-                top: lerpColor(a.top, b.top, t),
-                bot: lerpColor(a.bot, b.bot, t),
+                stops: stops,
+                top: stops[0],
+                bot: stops[3],
                 dark: lerp(a.dark, b.dark, t),
+                warm: lerp(a.warm, b.warm, t),
+            };
+        }
+        // Where the sun (day half) or moon (night half) sits, and its arc progress.
+        function celestialPos(sky) {
+            // sun owns most of the cycle so dusk shows a low setting sun;
+            // the moon takes the deep-night stretch.
+            const isDay = sky.p < 0.6;
+            const local = isDay ? (sky.p / 0.6) : ((sky.p - 0.6) / 0.4);
+            return {
+                isDay: isDay,
+                local: local,
+                x: local * W,
+                y: H * 0.66 - Math.sin(local * Math.PI) * H * 0.52,
             };
         }
 
@@ -326,16 +356,20 @@
         //  Stars
         // ---------------------------------------------------------------
         let stars = [];
+        let shootingStar = null;
         function buildStars() {
             stars = [];
-            const n = Math.round((W * H) / 9000);
+            const n = Math.round((W * H) / 6500);
             for (let i = 0; i < n; i++) {
+                const big = Math.random() < 0.10;
+                const tint = Math.random();
                 stars.push({
                     x: Math.random() * W,
-                    y: Math.random() * H * 0.85,
-                    r: Math.random() * 1.4 + 0.3,
+                    y: Math.random() * H * 0.82,
+                    r: big ? Math.random() * 1.5 + 1.2 : Math.random() * 1.0 + 0.25,
                     tw: Math.random() * Math.PI * 2,
-                    sp: 0.5 + Math.random() * 1.5,
+                    sp: 0.4 + Math.random() * 1.7,
+                    hue: tint < 0.28 ? [196, 212, 255] : (tint < 0.5 ? [255, 240, 214] : [255, 255, 255]),
                 });
             }
         }
@@ -344,82 +378,161 @@
         //  Drawing
         // ---------------------------------------------------------------
         function drawSky(sky) {
+            // multi-stop vertical gradient — the spectacular backdrop
             const g = ctx.createLinearGradient(0, 0, 0, H);
-            g.addColorStop(0, rgb(sky.top));
-            g.addColorStop(1, rgb(sky.bot));
+            for (let k = 0; k < sky.stops.length; k++) {
+                g.addColorStop(STOP_POS[k], rgb(sky.stops[k]));
+            }
             ctx.fillStyle = g;
             ctx.fillRect(0, 0, W, H);
 
-            // stars fade in with darkness
-            if (sky.dark > 0.05) {
+            // atmospheric horizon bloom — a warm wash centred on the sun that
+            // swells at dawn/dusk and melts away by midday/midnight
+            if (sky.warm > 0.02) {
+                const cx = celestialPos(sky).x;
+                const hy = H * 0.78;
+                const hc = sky.stops[3];
+                const a0 = 0.46 * sky.warm;
+                const bloom = ctx.createRadialGradient(cx, hy, 0, cx, hy, H * 0.95);
+                bloom.addColorStop(0, 'rgba(' + hc[0] + ',' + hc[1] + ',' + hc[2] + ',' + a0 + ')');
+                bloom.addColorStop(0.45, 'rgba(' + hc[0] + ',' + hc[1] + ',' + hc[2] + ',' + (a0 * 0.32) + ')');
+                bloom.addColorStop(1, 'rgba(' + hc[0] + ',' + hc[1] + ',' + hc[2] + ',0)');
                 ctx.save();
+                ctx.globalCompositeOperation = 'lighter';
+                ctx.fillStyle = bloom;
+                ctx.fillRect(0, 0, W, H);
+                ctx.restore();
+            }
+
+            // stars fade in with darkness
+            if (sky.dark > 0.04) {
                 const now = performance.now() / 1000;
                 for (const s of stars) {
-                    const tw = 0.55 + 0.45 * Math.sin(now * s.sp + s.tw);
-                    ctx.globalAlpha = sky.dark * tw;
-                    ctx.fillStyle = '#fff';
+                    const tw = 0.5 + 0.5 * Math.sin(now * s.sp + s.tw);
+                    ctx.globalAlpha = sky.dark * (0.3 + 0.7 * tw);
+                    ctx.fillStyle = 'rgb(' + s.hue[0] + ',' + s.hue[1] + ',' + s.hue[2] + ')';
                     ctx.beginPath();
                     ctx.arc(s.x, s.y, s.r, 0, Math.PI * 2);
                     ctx.fill();
                 }
+                ctx.globalAlpha = 1;
+                drawShootingStar(sky, now);
+            }
+        }
+
+        function drawShootingStar(sky, now) {
+            if (sky.dark < 0.6) { shootingStar = null; return; }
+            if (!shootingStar && Math.random() < 0.005) {
+                shootingStar = {
+                    x: Math.random() * W * 0.6 + W * 0.1,
+                    y: Math.random() * H * 0.28 + 16,
+                    vx: 7 + Math.random() * 4,
+                    vy: 2.5 + Math.random() * 2,
+                    life: 1,
+                };
+            }
+            if (shootingStar) {
+                const s = shootingStar;
+                s.x += s.vx; s.y += s.vy; s.life -= 0.022;
+                if (s.life <= 0 || s.x > W + 60) { shootingStar = null; return; }
+                const a = clamp(s.life, 0, 1) * sky.dark;
+                const tx = s.x - s.vx * 7, ty = s.y - s.vy * 7;
+                const grad = ctx.createLinearGradient(s.x, s.y, tx, ty);
+                grad.addColorStop(0, 'rgba(255,255,255,' + a + ')');
+                grad.addColorStop(1, 'rgba(180,200,255,0)');
+                ctx.save();
+                ctx.globalCompositeOperation = 'lighter';
+                ctx.strokeStyle = grad;
+                ctx.lineWidth = 2;
+                ctx.lineCap = 'round';
+                ctx.beginPath();
+                ctx.moveTo(s.x, s.y);
+                ctx.lineTo(tx, ty);
+                ctx.stroke();
                 ctx.restore();
             }
         }
 
         function drawCelestial(sky) {
-            // Sun travels the sky during the "day" half of the cycle (p 0..0.5),
-            // moon during the night half (p 0.5..1).
-            const p = sky.p;
-            const isDay = p < 0.5;
-            const local = isDay ? (p / 0.5) : ((p - 0.5) / 0.5); // 0..1 across its arc
-            const x = local * W;
-            const y = H * 0.62 - Math.sin(local * Math.PI) * H * 0.50;
-
+            const c = celestialPos(sky);
+            const x = c.x, y = c.y;
             ctx.save();
-            if (isDay) {
-                const r = 38;
-                const glow = ctx.createRadialGradient(x, y, 0, x, y, r * 4);
-                glow.addColorStop(0, 'rgba(255,240,190,0.55)');
-                glow.addColorStop(1, 'rgba(255,240,190,0)');
+            if (c.isDay) {
+                // sun — swells and reddens toward the golden hours
+                const warm = sky.warm;
+                const r = 30 + warm * 14;
+                const gr = r * (4 + warm * 3.5);
+                const glow = ctx.createRadialGradient(x, y, 0, x, y, gr);
+                glow.addColorStop(0, 'rgba(255,242,202,' + (0.42 + warm * 0.3) + ')');
+                glow.addColorStop(0.4, 'rgba(255,206,150,' + (0.18 + warm * 0.26) + ')');
+                glow.addColorStop(1, 'rgba(255,196,140,0)');
+                ctx.globalCompositeOperation = 'lighter';
                 ctx.fillStyle = glow;
-                ctx.beginPath(); ctx.arc(x, y, r * 4, 0, Math.PI * 2); ctx.fill();
-                ctx.fillStyle = '#fff4d6';
+                ctx.beginPath(); ctx.arc(x, y, gr, 0, Math.PI * 2); ctx.fill();
+                ctx.globalCompositeOperation = 'source-over';
+                const core = ctx.createRadialGradient(x - r * 0.3, y - r * 0.3, r * 0.1, x, y, r);
+                core.addColorStop(0, '#fffdf4');
+                core.addColorStop(0.55, '#fff0c8');
+                core.addColorStop(1, rgb(lerpColor([255, 228, 168], [255, 168, 110], warm)));
+                ctx.fillStyle = core;
                 ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI * 2); ctx.fill();
             } else {
-                const r = 30;
-                const glow = ctx.createRadialGradient(x, y, 0, x, y, r * 3.5);
-                glow.addColorStop(0, 'rgba(220,228,255,0.4)');
-                glow.addColorStop(1, 'rgba(220,228,255,0)');
+                const r = 26;
+                const gr = r * 4.5;
+                const glow = ctx.createRadialGradient(x, y, 0, x, y, gr);
+                glow.addColorStop(0, 'rgba(214,224,255,0.42)');
+                glow.addColorStop(0.5, 'rgba(182,198,255,0.13)');
+                glow.addColorStop(1, 'rgba(182,198,255,0)');
+                ctx.globalCompositeOperation = 'lighter';
                 ctx.fillStyle = glow;
-                ctx.beginPath(); ctx.arc(x, y, r * 3.5, 0, Math.PI * 2); ctx.fill();
-                ctx.fillStyle = '#eef0ff';
+                ctx.beginPath(); ctx.arc(x, y, gr, 0, Math.PI * 2); ctx.fill();
+                ctx.globalCompositeOperation = 'source-over';
+                // moon disc
+                const md = ctx.createRadialGradient(x - r * 0.3, y - r * 0.3, r * 0.2, x, y, r);
+                md.addColorStop(0, '#fdfdff');
+                md.addColorStop(1, '#c6cfec');
+                ctx.fillStyle = md;
                 ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI * 2); ctx.fill();
-                // crater shadow for a crescent
-                ctx.fillStyle = rgb(sky.top);
-                ctx.globalAlpha = 0.9;
-                ctx.beginPath(); ctx.arc(x + r * 0.4, y - r * 0.3, r * 0.95, 0, Math.PI * 2); ctx.fill();
+                // craters
+                ctx.fillStyle = 'rgba(150,160,196,0.4)';
+                ctx.beginPath(); ctx.arc(x - r * 0.28, y - r * 0.1, r * 0.18, 0, Math.PI * 2); ctx.fill();
+                ctx.beginPath(); ctx.arc(x + r * 0.22, y + r * 0.26, r * 0.12, 0, Math.PI * 2); ctx.fill();
+                ctx.beginPath(); ctx.arc(x + r * 0.05, y - r * 0.32, r * 0.08, 0, Math.PI * 2); ctx.fill();
+                // crescent shadow
+                ctx.globalAlpha = 0.5;
+                ctx.fillStyle = rgb(sky.stops[0]);
+                ctx.beginPath(); ctx.arc(x + r * 0.55, y - r * 0.32, r * 0.95, 0, Math.PI * 2); ctx.fill();
+                ctx.globalAlpha = 1;
             }
             ctx.restore();
         }
 
-        // Distant parallax hills
+        // Distant parallax mountain ridges with atmospheric haze for depth
         function drawHills(sky) {
+            const haze = sky.bot; // horizon colour the far ridges dissolve into
+            const earth = lerpColor([48, 50, 80], [20, 22, 42], sky.dark);
+            // farthest -> nearest; far ridges fade most into the haze
             const layers = [
-                { speed: 0.18, base: 0.74, amp: 0.06, freq: 0.0016, shade: 0.55 },
-                { speed: 0.34, base: 0.82, amp: 0.08, freq: 0.0026, shade: 0.35 },
+                { speed: 0.08, base: 0.68, amp: 0.05, freq: 0.0011, haze: 0.78, ph: 0.0 },
+                { speed: 0.17, base: 0.76, amp: 0.07, freq: 0.0018, haze: 0.52, ph: 2.1 },
+                { speed: 0.32, base: 0.85, amp: 0.10, freq: 0.0027, haze: 0.26, ph: 4.3 },
             ];
             for (const L of layers) {
                 const off = distance * L.speed;
-                // hill colour: blend sky bottom toward dark
-                const col = lerpColor(sky.bot, [20, 20, 38], 1 - L.shade + sky.dark * 0.4);
-                ctx.fillStyle = rgb(col);
+                const base = lerpColor(earth, haze, L.haze * (1 - sky.dark * 0.45));
+                const topY = H * (L.base - L.amp - 0.05);
+                const grd = ctx.createLinearGradient(0, topY, 0, H);
+                grd.addColorStop(0, rgb(lerpColor(base, haze, 0.3)));
+                grd.addColorStop(1, rgb(lerpColor(base, [10, 11, 26], 0.35 + sky.dark * 0.3)));
+                ctx.fillStyle = grd;
                 ctx.beginPath();
                 ctx.moveTo(0, H);
-                for (let x = 0; x <= W; x += 12) {
-                    const wx = (x + off) * 1;
+                for (let x = 0; x <= W; x += 10) {
+                    const wx = x + off;
                     const y = H * L.base
-                        - Math.sin(wx * L.freq) * H * L.amp
-                        - Math.sin(wx * L.freq * 2.3 + 1.1) * H * L.amp * 0.4;
+                        - Math.sin(wx * L.freq + L.ph) * H * L.amp
+                        - Math.sin(wx * L.freq * 2.3 + 1.1) * H * L.amp * 0.4
+                        - Math.sin(wx * L.freq * 5.1 + 0.5) * H * L.amp * 0.15;
                     ctx.lineTo(x, y);
                 }
                 ctx.lineTo(W, H);
@@ -431,55 +544,59 @@
         function drawCave(sky) {
             const step = 10;
             // terrain colours shift darker at night
-            const lightCol = lerpColor([120, 96, 74], [40, 44, 70], sky.dark);
-            const darkCol = lerpColor([58, 44, 34], [14, 16, 32], sky.dark);
-            const rimCol = lerpColor([170, 140, 110], [70, 78, 120], sky.dark);
+            const lightCol = lerpColor([118, 94, 72], [38, 42, 68], sky.dark);
+            const darkCol = lerpColor([56, 42, 32], [12, 14, 30], sky.dark);
+            // the rim catches sky light — warm at dawn/dusk, cool at night
+            let rimCol = lerpColor([176, 146, 114], [66, 74, 116], sky.dark);
+            rimCol = lerpColor(rimCol, sky.stops[3], sky.warm * 0.55);
+            const glowCol = lerpColor(sky.stops[3], [255, 240, 220], 0.2);
+
+            const edge = (yAt) => {
+                // wide soft glow first, then a crisp lit rim
+                ctx.lineJoin = 'round';
+                ctx.strokeStyle = 'rgba(' + glowCol[0] + ',' + glowCol[1] + ',' + glowCol[2] + ',' + (0.12 + sky.warm * 0.22) + ')';
+                ctx.lineWidth = 9;
+                ctx.beginPath();
+                for (let x = 0; x <= W; x += step) {
+                    const y = yAt(distance + x, distance);
+                    if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+                }
+                ctx.stroke();
+                ctx.strokeStyle = rgb(rimCol);
+                ctx.lineWidth = 2.5;
+                ctx.beginPath();
+                for (let x = 0; x <= W; x += step) {
+                    const y = yAt(distance + x, distance);
+                    if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+                }
+                ctx.stroke();
+            };
 
             // ----- top terrain -----
-            const gTop = ctx.createLinearGradient(0, 0, 0, H * 0.5);
+            const gTop = ctx.createLinearGradient(0, 0, 0, H * 0.55);
             gTop.addColorStop(0, rgb(darkCol));
             gTop.addColorStop(1, rgb(lightCol));
             ctx.fillStyle = gTop;
             ctx.beginPath();
             ctx.moveTo(0, 0);
-            for (let x = 0; x <= W; x += step) {
-                ctx.lineTo(x, topAt(distance + x, distance));
-            }
+            for (let x = 0; x <= W; x += step) ctx.lineTo(x, topAt(distance + x, distance));
             ctx.lineTo(W, 0);
             ctx.closePath();
             ctx.fill();
-            // rim
-            ctx.strokeStyle = rgb(rimCol);
-            ctx.lineWidth = 3;
-            ctx.beginPath();
-            for (let x = 0; x <= W; x += step) {
-                const y = topAt(distance + x, distance);
-                if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-            }
-            ctx.stroke();
+            edge(topAt);
 
             // ----- bottom terrain -----
-            const gBot = ctx.createLinearGradient(0, H * 0.5, 0, H);
+            const gBot = ctx.createLinearGradient(0, H * 0.45, 0, H);
             gBot.addColorStop(0, rgb(lightCol));
             gBot.addColorStop(1, rgb(darkCol));
             ctx.fillStyle = gBot;
             ctx.beginPath();
             ctx.moveTo(0, H);
-            for (let x = 0; x <= W; x += step) {
-                ctx.lineTo(x, botAt(distance + x, distance));
-            }
+            for (let x = 0; x <= W; x += step) ctx.lineTo(x, botAt(distance + x, distance));
             ctx.lineTo(W, H);
             ctx.closePath();
             ctx.fill();
-            // rim
-            ctx.strokeStyle = rgb(rimCol);
-            ctx.lineWidth = 3;
-            ctx.beginPath();
-            for (let x = 0; x <= W; x += step) {
-                const y = botAt(distance + x, distance);
-                if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
-            }
-            ctx.stroke();
+            edge(botAt);
         }
 
         function drawRings() {
@@ -510,49 +627,151 @@
         }
 
         function drawTrail() {
-            for (let i = 0; i < trail.length; i++) {
-                const t = trail[i];
-                const a = (i / trail.length) * 0.5;
-                ctx.fillStyle = 'rgba(255,255,255,' + a + ')';
+            if (trail.length < 2) return;
+            ctx.save();
+            ctx.globalCompositeOperation = 'lighter';
+            ctx.lineCap = 'round';
+            ctx.lineJoin = 'round';
+            for (let i = 1; i < trail.length; i++) {
+                const f = i / trail.length;            // 0 (oldest) -> 1 (newest, at tail)
+                const g = Math.round(214 + 40 * f);
+                const b = Math.round(170 + 70 * f);
+                ctx.strokeStyle = 'rgba(255,' + g + ',' + b + ',' + (f * f * 0.55) + ')';
+                ctx.lineWidth = f * 7 + 0.6;
                 ctx.beginPath();
-                ctx.arc(t.x, t.y, (i / trail.length) * 4 + 0.5, 0, Math.PI * 2);
-                ctx.fill();
+                ctx.moveTo(trail[i - 1].x, trail[i - 1].y);
+                ctx.lineTo(trail[i].x, trail[i].y);
+                ctx.stroke();
             }
+            ctx.restore();
         }
 
-        function drawGlider() {
-            const angle = clamp(gliderVY * 0.045, -0.7, 0.7);
+        function drawGlider(sky) {
+            const angle = clamp(gliderVY * 0.05, -0.62, 0.62);
+            // warm light tint for the lit upper surfaces (picks up dawn/dusk colour)
+            const lit = sky ? lerpColor([255, 255, 255], sky.stops[3], sky.warm * 0.4) : [255, 255, 255];
+            const litStr = rgb(lit);
+
             ctx.save();
             ctx.translate(gliderX, gliderY);
             ctx.rotate(angle);
-            // body — sleek glider pointing right
-            ctx.fillStyle = '#f4f6ff';
-            ctx.strokeStyle = '#2b3358';
-            ctx.lineWidth = 2;
+
+            // --- soft aura (heroic glow, strongest at dusk/dawn) ---
+            if (sky) {
+                const aura = ctx.createRadialGradient(0, 0, 4, 0, 0, 44);
+                aura.addColorStop(0, 'rgba(' + lit[0] + ',' + lit[1] + ',' + lit[2] + ',' + (0.10 + sky.warm * 0.16) + ')');
+                aura.addColorStop(1, 'rgba(' + lit[0] + ',' + lit[1] + ',' + lit[2] + ',0)');
+                ctx.save();
+                ctx.globalCompositeOperation = 'lighter';
+                ctx.fillStyle = aura;
+                ctx.beginPath(); ctx.arc(0, 0, 44, 0, Math.PI * 2); ctx.fill();
+                ctx.restore();
+            }
+
+            // === FAR WING (behind fuselage, in shade) sweeping down-back ===
+            ctx.fillStyle = '#8b96b8';
             ctx.beginPath();
-            ctx.moveTo(20, 0);
-            ctx.lineTo(-14, -8);
-            ctx.lineTo(-8, 0);
-            ctx.lineTo(-14, 8);
+            ctx.moveTo(7, 1);
+            ctx.lineTo(-24, 22);
+            ctx.lineTo(-30, 21);
+            ctx.lineTo(-3, 3);
+            ctx.closePath();
+            ctx.fill();
+
+            // === FUSELAGE: sleek pod-and-boom ===
+            const body = ctx.createLinearGradient(0, -9, 0, 9);
+            body.addColorStop(0, litStr);
+            body.addColorStop(0.45, '#eaf0fb');
+            body.addColorStop(1, '#9fb0d0');
+            ctx.fillStyle = body;
+            ctx.strokeStyle = 'rgba(40,48,78,0.55)';
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            ctx.moveTo(31, 0);                       // nose
+            ctx.quadraticCurveTo(25, -7, 13, -7.5);  // canopy hump (top)
+            ctx.quadraticCurveTo(-6, -5, -22, -2);   // taper into tail boom (top)
+            ctx.quadraticCurveTo(-27, -1.2, -30, 0); // tail tip
+            ctx.quadraticCurveTo(-27, 1.4, -22, 2.4);// boom (belly)
+            ctx.quadraticCurveTo(-4, 6, 12, 7);      // belly forward
+            ctx.quadraticCurveTo(25, 6.5, 31, 0);    // belly to nose
             ctx.closePath();
             ctx.fill();
             ctx.stroke();
-            // wing accent
+
+            // orange speed stripe along the flank
             ctx.fillStyle = '#ff9e4a';
             ctx.beginPath();
-            ctx.moveTo(20, 0);
-            ctx.lineTo(-14, -8);
-            ctx.lineTo(-2, -1);
+            ctx.moveTo(20, 1.6);
+            ctx.quadraticCurveTo(2, 3.4, -20, 1.6);
+            ctx.quadraticCurveTo(2, 4.6, 20, 3.2);
             ctx.closePath();
             ctx.fill();
-            // tail fin
+
+            // === T-TAIL: swept vertical fin + horizontal stabiliser ===
             ctx.fillStyle = '#cdd6f5';
             ctx.beginPath();
-            ctx.moveTo(-8, 0);
-            ctx.lineTo(-16, -7);
-            ctx.lineTo(-10, 0);
+            ctx.moveTo(-19, -1.5);
+            ctx.lineTo(-30, -13);
+            ctx.lineTo(-26.5, -13);
+            ctx.lineTo(-15, -0.5);
             ctx.closePath();
             ctx.fill();
+            ctx.fillStyle = litStr;
+            ctx.beginPath();          // tailplane on top of the fin
+            ctx.moveTo(-30.5, -12.5);
+            ctx.lineTo(-37, -14.5);
+            ctx.lineTo(-25, -13.5);
+            ctx.lineTo(-27, -11.5);
+            ctx.closePath();
+            ctx.fill();
+
+            // === NEAR WING (lit) — long, slender, swept up-back ===
+            const wing = ctx.createLinearGradient(0, 0, -28, -30);
+            wing.addColorStop(0, litStr);
+            wing.addColorStop(1, '#c4d0ee');
+            ctx.fillStyle = wing;
+            ctx.strokeStyle = 'rgba(40,48,78,0.35)';
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            ctx.moveTo(9, -1);        // root leading edge
+            ctx.lineTo(-25, -31);     // tip leading edge
+            ctx.lineTo(-31, -29.5);   // wingtip
+            ctx.lineTo(-2, 2);        // root trailing edge
+            ctx.closePath();
+            ctx.fill();
+            ctx.stroke();
+            // crisp lit leading edge
+            ctx.strokeStyle = 'rgba(255,255,255,0.85)';
+            ctx.lineWidth = 1.4;
+            ctx.beginPath();
+            ctx.moveTo(9, -1);
+            ctx.lineTo(-25, -31);
+            ctx.stroke();
+
+            // === CANOPY: tinted glass bubble with a highlight ===
+            ctx.save();
+            ctx.translate(13, -3.4);
+            ctx.rotate(-0.12);
+            const glass = ctx.createLinearGradient(0, -5, 0, 4);
+            glass.addColorStop(0, '#bfe0ff');
+            glass.addColorStop(0.5, '#5d8fc8');
+            glass.addColorStop(1, '#274a78');
+            ctx.fillStyle = glass;
+            ctx.beginPath();
+            ctx.ellipse(0, 0, 9.5, 5, 0, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.fillStyle = 'rgba(255,255,255,0.8)';
+            ctx.beginPath();
+            ctx.ellipse(-2.5, -1.8, 3.4, 1.3, -0.3, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.restore();
+
+            // nose glint
+            ctx.fillStyle = 'rgba(255,255,255,0.7)';
+            ctx.beginPath();
+            ctx.ellipse(27, -1.5, 2.4, 1.2, 0, 0, Math.PI * 2);
+            ctx.fill();
+
             ctx.restore();
         }
 
@@ -601,9 +820,10 @@
             gliderVY = clamp(gliderVY, -MAX_CLIMB, MAX_DIVE);
             gliderY += gliderVY;
 
-            // trail
-            trail.push({ x: gliderX - 12, y: gliderY + 4 });
-            if (trail.length > 16) trail.shift();
+            // trail (vapor from the tail) — older puffs drift back with the world
+            for (let k = 0; k < trail.length; k++) trail[k].x -= speed;
+            trail.push({ x: gliderX - 20, y: gliderY + 2 });
+            if (trail.length > 26) trail.shift();
 
             spawnRingsAhead();
 
@@ -677,7 +897,7 @@
 
             if (state !== 'dead') {
                 drawTrail();
-                drawGlider();
+                drawGlider(sky);
             }
             drawParticles();
 

--- a/apps/glide/index.html
+++ b/apps/glide/index.html
@@ -210,6 +210,11 @@
             canvas.style.height = H + 'px';
             ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
             buildStars();
+            buildClouds();
+            buildBirds();
+            buildAmbient();
+            buildVignette();
+            buildNoise();
         }
         window.addEventListener('resize', resize);
 
@@ -375,6 +380,108 @@
         }
 
         // ---------------------------------------------------------------
+        //  Atmosphere — clouds, birds, ambient motes, aurora, vignette, grain
+        // ---------------------------------------------------------------
+        let clouds = [];
+        function buildClouds() {
+            clouds = [];
+            // two depth layers: far (small, faint, slow) and near (big, bold)
+            const span = W + 460;
+            const make = (count, layer, yLo, yHi, scaleLo, scaleHi, speed) => {
+                for (let i = 0; i < count; i++) {
+                    const sc = scaleLo + Math.random() * (scaleHi - scaleLo);
+                    const puffs = [];
+                    const np = 4 + Math.floor(Math.random() * 3);
+                    for (let j = 0; j < np; j++) {
+                        puffs.push({
+                            dx: (Math.random() - 0.5) * 120 * sc,
+                            dy: (Math.random() - 0.4) * 26 * sc,
+                            r: (26 + Math.random() * 26) * sc,
+                        });
+                    }
+                    clouds.push({
+                        layer: layer,
+                        x0: Math.random() * span,
+                        y: (yLo + Math.random() * (yHi - yLo)) * H,
+                        sc: sc,
+                        speed: speed,
+                        puffs: puffs,
+                    });
+                }
+            };
+            make(3, 0, 0.10, 0.42, 0.5, 0.85, 0.045);   // far
+            make(3, 1, 0.16, 0.52, 0.9, 1.35, 0.11);     // near
+            clouds.sort((a, b) => a.layer - b.layer);
+        }
+
+        let birds = [];
+        function buildBirds() {
+            birds = [];
+            const flocks = 2 + Math.floor(Math.random() * 2);
+            for (let f = 0; f < flocks; f++) {
+                const n = 4 + Math.floor(Math.random() * 5);
+                const members = [];
+                for (let i = 0; i < n; i++) {
+                    members.push({
+                        ox: (Math.random() - 0.5) * 80 - i * 9,
+                        oy: (Math.random() - 0.5) * 36 + Math.abs(i - n / 2) * 5,
+                        ph: Math.random() * Math.PI * 2,
+                        sz: 4 + Math.random() * 3,
+                    });
+                }
+                birds.push({
+                    x0: Math.random() * (W + 300),
+                    y: (0.18 + Math.random() * 0.3) * H,
+                    speed: 0.16 + Math.random() * 0.1,
+                    flap: 4 + Math.random() * 3,
+                    members: members,
+                });
+            }
+        }
+
+        let ambient = [];
+        function buildAmbient() {
+            ambient = [];
+            const n = Math.round((W * H) / 26000);
+            for (let i = 0; i < n; i++) {
+                ambient.push({
+                    x: Math.random() * W,
+                    y: Math.random() * H,
+                    r: Math.random() * 1.8 + 0.6,
+                    drift: 0.2 + Math.random() * 0.5,
+                    sway: Math.random() * Math.PI * 2,
+                    swaySp: 0.4 + Math.random() * 0.9,
+                    tw: Math.random() * Math.PI * 2,
+                });
+            }
+        }
+
+        let vignetteGrad = null;
+        function buildVignette() {
+            const g = ctx.createRadialGradient(W / 2, H * 0.46, H * 0.34, W / 2, H * 0.5, H * 0.82);
+            g.addColorStop(0, 'rgba(0,0,0,0)');
+            g.addColorStop(0.7, 'rgba(0,0,0,0)');
+            g.addColorStop(1, 'rgba(6,6,16,0.42)');
+            vignetteGrad = g;
+        }
+
+        let noisePattern = null;
+        function buildNoise() {
+            const size = 96;
+            const nc = document.createElement('canvas');
+            nc.width = size; nc.height = size;
+            const nctx = nc.getContext('2d');
+            const img = nctx.createImageData(size, size);
+            for (let i = 0; i < img.data.length; i += 4) {
+                const v = (Math.random() * 255) | 0;
+                img.data[i] = v; img.data[i + 1] = v; img.data[i + 2] = v;
+                img.data[i + 3] = 255;
+            }
+            nctx.putImageData(img, 0, 0);
+            noisePattern = ctx.createPattern(nc, 'repeat');
+        }
+
+        // ---------------------------------------------------------------
         //  Drawing
         // ---------------------------------------------------------------
         function drawSky(sky) {
@@ -507,6 +614,165 @@
             ctx.restore();
         }
 
+        // Aurora — shimmering ribbons of light high in the night sky
+        function drawAurora(sky) {
+            if (sky.dark < 0.55) return;
+            const a = (sky.dark - 0.55) / 0.45;     // fades in through twilight->night
+            const now = performance.now() / 1000;
+            ctx.save();
+            ctx.globalCompositeOperation = 'lighter';
+            const bands = [
+                { col: [90, 245, 185], yb: 0.30, amp: 30, fr: 0.011, sp: 0.18, w: 78, al: 0.30 },
+                { col: [130, 150, 255], yb: 0.38, amp: 38, fr: 0.008, sp: -0.13, w: 96, al: 0.24 },
+                { col: [205, 120, 235], yb: 0.25, amp: 24, fr: 0.014, sp: 0.22, w: 60, al: 0.22 },
+            ];
+            for (const band of bands) {
+                ctx.beginPath();
+                for (let x = 0; x <= W; x += 12) {
+                    const y = band.yb * H
+                        + Math.sin(x * band.fr + now * band.sp) * band.amp
+                        + Math.sin(x * band.fr * 2.7 + now * band.sp * 1.6) * band.amp * 0.4;
+                    if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+                }
+                // vertical curtain via a tall gradient stroke
+                const c = band.col;
+                const grad = ctx.createLinearGradient(0, band.yb * H - band.w, 0, band.yb * H + band.w);
+                grad.addColorStop(0, 'rgba(' + c[0] + ',' + c[1] + ',' + c[2] + ',0)');
+                grad.addColorStop(0.5, 'rgba(' + c[0] + ',' + c[1] + ',' + c[2] + ',' + (band.al * a) + ')');
+                grad.addColorStop(1, 'rgba(' + c[0] + ',' + c[1] + ',' + c[2] + ',0)');
+                ctx.strokeStyle = grad;
+                ctx.lineWidth = band.w;
+                ctx.stroke();
+            }
+            ctx.restore();
+        }
+
+        // God rays — soft volumetric shafts from the sun at the golden hours
+        function drawGodRays(sky) {
+            const c = celestialPos(sky);
+            if (!c.isDay || sky.warm < 0.35) return;
+            const a = (sky.warm - 0.35) / 0.65;
+            const hc = sky.stops[3];
+            ctx.save();
+            ctx.globalCompositeOperation = 'lighter';
+            ctx.translate(c.x, c.y);
+            const rays = 9;
+            for (let i = 0; i < rays; i++) {
+                const ang = (i / rays) * Math.PI * 2 + performance.now() / 9000;
+                const len = H * (0.5 + 0.25 * Math.sin(i * 1.7));
+                const wide = 0.06 + 0.03 * Math.sin(i * 2.3);
+                ctx.save();
+                ctx.rotate(ang);
+                const grad = ctx.createLinearGradient(0, 0, len, 0);
+                grad.addColorStop(0, 'rgba(' + hc[0] + ',' + hc[1] + ',' + hc[2] + ',' + (0.10 * a) + ')');
+                grad.addColorStop(1, 'rgba(' + hc[0] + ',' + hc[1] + ',' + hc[2] + ',0)');
+                ctx.fillStyle = grad;
+                ctx.beginPath();
+                ctx.moveTo(0, 0);
+                ctx.lineTo(len, -len * wide);
+                ctx.lineTo(len, len * wide);
+                ctx.closePath();
+                ctx.fill();
+                ctx.restore();
+            }
+            ctx.restore();
+        }
+
+        // Volumetric parallax clouds, lit on top and shaded beneath, tinted by the sky
+        function drawClouds(sky) {
+            const span = W + 460;
+            // lit (top) and shaded (base) cloud colours derived from the current sky
+            let lit = lerpColor([255, 255, 255], sky.stops[3], sky.warm * 0.55);
+            lit = lerpColor(lit, [56, 62, 96], sky.dark * 0.78);
+            let shade = lerpColor([168, 170, 192], sky.stops[1], 0.45);
+            shade = lerpColor(shade, [24, 28, 52], sky.dark * 0.82);
+            const baseAlpha = lerp(0.92, 0.55, sky.dark);
+            for (const cl of clouds) {
+                let sx = ((cl.x0 - distance * cl.speed) % span + span) % span - 230;
+                const layerA = baseAlpha * (cl.layer === 0 ? 0.55 : 1);
+                for (const pf of cl.puffs) {
+                    const b = clamp(0.5 + pf.dy / (30 * cl.sc), 0, 1); // upper puffs lit, lower shaded
+                    const col = lerpColor(lit, shade, b);
+                    const px = sx + pf.dx, py = cl.y + pf.dy;
+                    const g = ctx.createRadialGradient(px, py - pf.r * 0.2, pf.r * 0.15, px, py, pf.r);
+                    g.addColorStop(0, 'rgba(' + col[0] + ',' + col[1] + ',' + col[2] + ',' + layerA + ')');
+                    g.addColorStop(0.7, 'rgba(' + col[0] + ',' + col[1] + ',' + col[2] + ',' + (layerA * 0.5) + ')');
+                    g.addColorStop(1, 'rgba(' + col[0] + ',' + col[1] + ',' + col[2] + ',0)');
+                    ctx.fillStyle = g;
+                    ctx.beginPath();
+                    ctx.arc(px, py, pf.r, 0, Math.PI * 2);
+                    ctx.fill();
+                }
+            }
+        }
+
+        // Distant drifting flocks of birds
+        function drawBirds(sky) {
+            const col = lerpColor([60, 64, 86], [10, 12, 28], sky.dark);
+            const now = performance.now() / 1000;
+            const span = W + 300;
+            ctx.save();
+            ctx.strokeStyle = rgb(col);
+            ctx.globalAlpha = lerp(0.5, 0.28, sky.dark);
+            ctx.lineWidth = 1.6;
+            ctx.lineCap = 'round';
+            for (const fl of birds) {
+                const fx = ((fl.x0 - distance * fl.speed) % span + span) % span - 150;
+                for (const m of fl.members) {
+                    const x = fx + m.ox;
+                    const y = fl.y + m.oy + Math.sin(now * 0.5 + m.ph) * 6;
+                    const w = m.sz, up = Math.sin(now * fl.flap + m.ph) * 0.5 + 0.5; // 0..1 wing beat
+                    const lift = up * w * 0.7;
+                    ctx.beginPath();
+                    ctx.moveTo(x - w, y + lift);
+                    ctx.quadraticCurveTo(x - w * 0.4, y - lift * 0.6, x, y);
+                    ctx.quadraticCurveTo(x + w * 0.4, y - lift * 0.6, x + w, y + lift);
+                    ctx.stroke();
+                }
+            }
+            ctx.restore();
+        }
+
+        // Floating ambient motes — dust in daylight, glowing embers/fireflies at night
+        function drawAmbient(sky) {
+            const now = performance.now() / 1000;
+            const warmC = lerpColor([255, 224, 150], [255, 150, 90], sky.warm);
+            const dayC = [255, 255, 255];
+            const col = lerpColor(dayC, warmC, clamp(sky.warm + sky.dark * 0.6, 0, 1));
+            const glow = sky.dark > 0.5;               // fireflies twinkle at night
+            ctx.save();
+            ctx.globalCompositeOperation = 'lighter';
+            for (const m of ambient) {
+                m.x -= m.drift * (0.6 + speed * 0.04);
+                m.x += Math.sin(now * m.swaySp + m.sway) * 0.3;
+                if (m.x < -6) { m.x = W + 6; m.y = Math.random() * H; }
+                let a = 0.25;
+                if (glow) a = 0.15 + 0.45 * (0.5 + 0.5 * Math.sin(now * 2.2 + m.tw));
+                ctx.globalAlpha = a * (glow ? 1 : 0.5);
+                ctx.fillStyle = 'rgb(' + col[0] + ',' + col[1] + ',' + col[2] + ')';
+                ctx.beginPath();
+                ctx.arc(m.x, m.y, m.r, 0, Math.PI * 2);
+                ctx.fill();
+            }
+            ctx.restore();
+        }
+
+        function drawVignette() {
+            if (vignetteGrad) {
+                ctx.fillStyle = vignetteGrad;
+                ctx.fillRect(0, 0, W, H);
+            }
+        }
+
+        function drawGrain() {
+            if (!noisePattern) return;
+            ctx.save();
+            ctx.globalAlpha = 0.028;
+            ctx.fillStyle = noisePattern;
+            ctx.fillRect(0, 0, W, H);
+            ctx.restore();
+        }
+
         // Distant parallax mountain ridges with atmospheric haze for depth
         function drawHills(sky) {
             const haze = sky.bot; // horizon colour the far ridges dissolve into
@@ -599,29 +865,57 @@
             edge(botAt);
         }
 
-        function drawRings() {
+        function drawRings(sky) {
+            const now = performance.now();
             for (const r of rings) {
                 const sx = r.wx - distance;
                 if (sx < -RING_RADIUS * 2 || sx > W + RING_RADIUS * 2) continue;
                 if (r.collected) continue;
-                const pulse = 1 + 0.06 * Math.sin(performance.now() / 200 + r.wx);
+                // gentle rotation about the vertical axis -> perspective ellipse
+                const spin = Math.sin(now / 900 + r.wx * 0.7);
+                const sxScale = 0.42 + 0.58 * Math.abs(spin); // 0.42 (edge-on) .. 1 (face-on)
+                const bob = Math.sin(now / 600 + r.wx) * 4;
                 ctx.save();
-                ctx.translate(sx, r.y);
-                ctx.scale(1, pulse);
-                // outer glow
-                const glow = ctx.createRadialGradient(0, 0, RING_RADIUS * 0.5, 0, 0, RING_RADIUS * 1.3);
-                glow.addColorStop(0, 'rgba(255,220,120,0)');
-                glow.addColorStop(0.75, 'rgba(255,210,100,0.35)');
-                glow.addColorStop(1, 'rgba(255,210,100,0)');
+                ctx.translate(sx, r.y + bob);
+
+                // outer glow (additive)
+                ctx.save();
+                ctx.globalCompositeOperation = 'lighter';
+                const glow = ctx.createRadialGradient(0, 0, RING_RADIUS * 0.45, 0, 0, RING_RADIUS * 1.5);
+                glow.addColorStop(0, 'rgba(255,224,130,0)');
+                glow.addColorStop(0.72, 'rgba(255,206,96,0.4)');
+                glow.addColorStop(1, 'rgba(255,200,90,0)');
                 ctx.fillStyle = glow;
-                ctx.beginPath(); ctx.arc(0, 0, RING_RADIUS * 1.3, 0, Math.PI * 2); ctx.fill();
-                // ring
-                ctx.lineWidth = 8;
-                ctx.strokeStyle = '#ffd86b';
+                ctx.beginPath(); ctx.arc(0, 0, RING_RADIUS * 1.5, 0, Math.PI * 2); ctx.fill();
+                ctx.restore();
+
+                ctx.scale(sxScale, 1);
+                // metallic torus band: gradient across the ring thickness
+                const band = ctx.createLinearGradient(0, -RING_RADIUS, 0, RING_RADIUS);
+                band.addColorStop(0, '#fff0b8');
+                band.addColorStop(0.5, '#ffc24a');
+                band.addColorStop(1, '#e8932a');
+                ctx.lineWidth = 9;
+                ctx.strokeStyle = band;
                 ctx.beginPath(); ctx.arc(0, 0, RING_RADIUS, 0, Math.PI * 2); ctx.stroke();
-                ctx.lineWidth = 3;
-                ctx.strokeStyle = 'rgba(255,255,255,0.8)';
-                ctx.beginPath(); ctx.arc(0, 0, RING_RADIUS - 5, 0, Math.PI * 2); ctx.stroke();
+                // bright inner highlight
+                ctx.lineWidth = 2.5;
+                ctx.strokeStyle = 'rgba(255,255,255,0.85)';
+                ctx.beginPath(); ctx.arc(0, 0, RING_RADIUS - 4.5, 0, Math.PI * 2); ctx.stroke();
+                ctx.restore();
+
+                // sparkle that races around the rim
+                const sa = now / 360 + r.wx;
+                const sxp = Math.cos(sa) * RING_RADIUS * sxScale;
+                const syp = Math.sin(sa) * RING_RADIUS;
+                ctx.save();
+                ctx.globalCompositeOperation = 'lighter';
+                ctx.translate(sx, r.y + bob);
+                const spark = ctx.createRadialGradient(sxp, syp, 0, sxp, syp, 9);
+                spark.addColorStop(0, 'rgba(255,255,255,0.95)');
+                spark.addColorStop(1, 'rgba(255,255,255,0)');
+                ctx.fillStyle = spark;
+                ctx.beginPath(); ctx.arc(sxp, syp, 9, 0, Math.PI * 2); ctx.fill();
                 ctx.restore();
             }
         }
@@ -889,11 +1183,16 @@
                 ctx.translate((Math.random() - 0.5) * shakeT * 18, (Math.random() - 0.5) * shakeT * 18);
             }
 
-            drawSky(sky);
-            drawCelestial(sky);
-            drawHills(sky);
-            drawCave(sky);
-            drawRings();
+            drawSky(sky);          // gradient + horizon bloom + stars + shooting star
+            drawAurora(sky);       // night ribbons of light
+            drawGodRays(sky);      // golden-hour shafts
+            drawCelestial(sky);    // sun / moon
+            drawClouds(sky);       // lit volumetric clouds
+            drawBirds(sky);        // distant flocks
+            drawHills(sky);        // hazy parallax ridges
+            drawCave(sky);         // the canyon
+            drawRings(sky);
+            drawAmbient(sky);      // foreground motes / fireflies
 
             if (state !== 'dead') {
                 drawTrail();
@@ -902,6 +1201,10 @@
             drawParticles();
 
             ctx.restore();
+
+            // screen-space finishing passes (do not shake)
+            drawVignette();
+            drawGrain();
 
             // ring pickup flash
             if (lastFlash > 0) {


### PR DESCRIPTION
A deep graphics pass on the Glide game (`/apps/glide/index.html`) to turn it into a living, cinematic sky. Everything is procedural canvas rendering — no assets.

## Spectacular skies that slowly fade in and out
- **Multi-stop gradient backdrops** across a slow 7-keyframe cycle — dawn → sunrise → day → golden hour → dusk → twilight → night — each fading gently into the next.
- An additive **horizon bloom** that swells at dawn/dusk and melts away by midday/midnight.
- The sun owns most of the arc so **dusk shows a low setting sun** sinking into a violet-to-coral sky; a warm glowing sun core that reddens at golden hour, and a soft crescent moon with a halo for deep night.

## Living atmosphere
- **Volumetric parallax clouds** in two depth layers, lit on top and shaded beneath, tinted by the current sky (white by day, gold at sunset, dark navy at night).
- **Aurora** ribbons that shimmer high in the night sky and fade in through twilight.
- **God rays** — soft volumetric light shafts from the sun at the golden hours.
- **Distant flocks of birds**, flapping and drifting on parallax.
- **Floating ambient motes** — dust in daylight, glowing fireflies at night.
- Colored, varied **twinkling stars** plus the occasional **shooting star**.
- Three **hazy parallax mountain ridges** for aerial depth; **cave rims that catch the warm sky light**.

## The glider & details
- A refined sailplane: shaded pod-and-boom fuselage, tinted glass canopy with a highlight, swept lit/shaded wings, T-tail, speed stripe, nose glint, and a subtle warm aura.
- A **glowing vapor trail** that streams back from the tail.
- **Ornate rings**: a spinning perspective ellipse with a metallic gold band, inner highlight, additive glow, and a sparkle racing the rim.

## Cinematic finishing
- A soft **vignette** and subtle **film grain** to frame the scene and kill gradient banding.

## Verification
Rendered headless across **all seven cycle phases** (dawn, sunrise, day, golden hour, dusk, twilight, night) and in real gameplay — clouds/birds/aurora/rays/trail all render correctly, collision → game-over still fires, no console/page errors, and JS passes `node --check`. Per-frame draw cost measured at **~1 ms** (median 0.7 ms, p95 1.9 ms) even under software rendering, so there's ample headroom for 60 fps on device.

> Note: this PR contains the full Glide game and supersedes the graphics already pushed to #147 — they overlap, so only one should be merged. Happy to close #147 if you'd like this to be the canonical one.
>
> Caveat: validated in software-rendered headless Chromium; additive glows/blooms can read slightly differently on a real display, and any intensity is a one-line tweak.

https://claude.ai/code/session_01D1J1Qr83B1ovAmH1MJXkJV

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1J1Qr83B1ovAmH1MJXkJV)_