### PR TITLE
Glide: left/right tilt controls + a redesigned sailplane

### DIFF
--- a/apps/glide/index.html
+++ b/apps/glide/index.html
@@ -157,8 +157,8 @@
         <div class="glider-emoji">🛩️</div>
         <div class="title">GLIDE</div>
         <div class="subtitle">
-            Soar through the canyon. <b>Tilt your phone back to climb,
-            forward to dive.</b> Thread the narrowing cave and fly through
+            Soar through the canyon. <b>Tilt your phone left to climb,
+            right to dive.</b> Thread the narrowing cave and fly through
             golden rings for bonus points.
         </div>
         <button class="btn" id="startBtn">Take Off</button>
@@ -255,7 +255,7 @@
         let lastFlash = 0;            // ring flash timer
 
         // input sources
-        let neutralBeta = null;
+        let neutralGamma = null;
         let tiltActive = false;
         let keyTilt = 0;
         let pointerTilt = 0;          // last-resort drag fallback
@@ -942,128 +942,148 @@
 
         function drawGlider(sky) {
             const angle = clamp(gliderVY * 0.05, -0.62, 0.62);
-            // warm light tint for the lit upper surfaces (picks up dawn/dusk colour)
+            // warm light tint for lit upper surfaces (picks up dawn/dusk colour)
             const lit = sky ? lerpColor([255, 255, 255], sky.stops[3], sky.warm * 0.4) : [255, 255, 255];
             const litStr = rgb(lit);
+            const outline = 'rgba(38,46,76,0.5)';
 
             ctx.save();
             ctx.translate(gliderX, gliderY);
             ctx.rotate(angle);
+            ctx.scale(1.04, 1.04);
 
-            // --- soft aura (heroic glow, strongest at dusk/dawn) ---
+            // --- warm aura (heroic glow, strongest at dawn/dusk) ---
             if (sky) {
-                const aura = ctx.createRadialGradient(0, 0, 4, 0, 0, 44);
+                const aura = ctx.createRadialGradient(0, 0, 6, 0, 0, 54);
                 aura.addColorStop(0, 'rgba(' + lit[0] + ',' + lit[1] + ',' + lit[2] + ',' + (0.10 + sky.warm * 0.16) + ')');
                 aura.addColorStop(1, 'rgba(' + lit[0] + ',' + lit[1] + ',' + lit[2] + ',0)');
                 ctx.save();
                 ctx.globalCompositeOperation = 'lighter';
                 ctx.fillStyle = aura;
-                ctx.beginPath(); ctx.arc(0, 0, 44, 0, Math.PI * 2); ctx.fill();
+                ctx.beginPath(); ctx.arc(0, 0, 54, 0, Math.PI * 2); ctx.fill();
                 ctx.restore();
             }
 
-            // === FAR WING (behind fuselage, in shade) sweeping down-back ===
-            ctx.fillStyle = '#8b96b8';
-            ctx.beginPath();
-            ctx.moveTo(7, 1);
-            ctx.lineTo(-24, 22);
-            ctx.lineTo(-30, 21);
-            ctx.lineTo(-3, 3);
-            ctx.closePath();
-            ctx.fill();
-
-            // === FUSELAGE: sleek pod-and-boom ===
-            const body = ctx.createLinearGradient(0, -9, 0, 9);
-            body.addColorStop(0, litStr);
-            body.addColorStop(0.45, '#eaf0fb');
-            body.addColorStop(1, '#9fb0d0');
-            ctx.fillStyle = body;
-            ctx.strokeStyle = 'rgba(40,48,78,0.55)';
+            // === FAR WING (behind the fuselage, swept up-and-back, in shade) ===
+            const farWing = ctx.createLinearGradient(0, 0, -30, -24);
+            farWing.addColorStop(0, '#9aa6c6');
+            farWing.addColorStop(1, '#6e7aa0');
+            ctx.fillStyle = farWing;
+            ctx.strokeStyle = outline;
             ctx.lineWidth = 1;
             ctx.beginPath();
-            ctx.moveTo(31, 0);                       // nose
-            ctx.quadraticCurveTo(25, -7, 13, -7.5);  // canopy hump (top)
-            ctx.quadraticCurveTo(-6, -5, -22, -2);   // taper into tail boom (top)
-            ctx.quadraticCurveTo(-27, -1.2, -30, 0); // tail tip
-            ctx.quadraticCurveTo(-27, 1.4, -22, 2.4);// boom (belly)
-            ctx.quadraticCurveTo(-4, 6, 12, 7);      // belly forward
-            ctx.quadraticCurveTo(25, 6.5, 31, 0);    // belly to nose
+            ctx.moveTo(8, -3);
+            ctx.quadraticCurveTo(-8, -13, -27, -25);     // leading edge to tip
+            ctx.quadraticCurveTo(-33, -27.5, -32, -22.5); // winglet
+            ctx.quadraticCurveTo(-18, -14, -3, -1);       // trailing edge to root
             ctx.closePath();
             ctx.fill();
             ctx.stroke();
 
-            // orange speed stripe along the flank
-            ctx.fillStyle = '#ff9e4a';
+            // === FUSELAGE: sleek pod-and-boom ===
+            const body = ctx.createLinearGradient(0, -8, 0, 9);
+            body.addColorStop(0, litStr);
+            body.addColorStop(0.4, '#eef2fb');
+            body.addColorStop(1, '#93a4c8');
+            ctx.fillStyle = body;
+            ctx.strokeStyle = outline;
+            ctx.lineWidth = 1.1;
             ctx.beginPath();
-            ctx.moveTo(20, 1.6);
-            ctx.quadraticCurveTo(2, 3.4, -20, 1.6);
-            ctx.quadraticCurveTo(2, 4.6, 20, 3.2);
+            ctx.moveTo(38, 1);
+            ctx.quadraticCurveTo(30, -4, 14, -7);      // nose to cockpit shoulder
+            ctx.quadraticCurveTo(-8, -7, -28, -3);     // slender upper boom
+            ctx.quadraticCurveTo(-36, -2.5, -41, -1);  // to the tail tip
+            ctx.quadraticCurveTo(-36, 0.8, -28, 2);    // lower boom
+            ctx.quadraticCurveTo(-6, 8, 10, 8);        // belly pod
+            ctx.quadraticCurveTo(28, 6.5, 38, 1);      // belly back to nose
+            ctx.closePath();
+            ctx.fill();
+            ctx.stroke();
+
+            // sporty accent stripe along the flank
+            const stripe = ctx.createLinearGradient(30, 0, -22, 0);
+            stripe.addColorStop(0, '#ff8a3c');
+            stripe.addColorStop(1, '#ff5566');
+            ctx.fillStyle = stripe;
+            ctx.beginPath();
+            ctx.moveTo(30, 2.4);
+            ctx.quadraticCurveTo(4, 4.2, -24, 0.8);
+            ctx.quadraticCurveTo(2, 5.6, 30, 4.2);
             ctx.closePath();
             ctx.fill();
 
-            // === T-TAIL: swept vertical fin + horizontal stabiliser ===
-            ctx.fillStyle = '#cdd6f5';
+            // === T-TAIL: swept vertical fin + horizontal stabiliser on top ===
+            ctx.fillStyle = '#cfd8f1';
+            ctx.strokeStyle = outline;
+            ctx.lineWidth = 0.9;
             ctx.beginPath();
-            ctx.moveTo(-19, -1.5);
-            ctx.lineTo(-30, -13);
-            ctx.lineTo(-26.5, -13);
-            ctx.lineTo(-15, -0.5);
+            ctx.moveTo(-29, -2);
+            ctx.lineTo(-40, -13);
+            ctx.lineTo(-35.5, -13);
+            ctx.lineTo(-24, -1);
             ctx.closePath();
             ctx.fill();
+            ctx.stroke();
             ctx.fillStyle = litStr;
-            ctx.beginPath();          // tailplane on top of the fin
-            ctx.moveTo(-30.5, -12.5);
-            ctx.lineTo(-37, -14.5);
-            ctx.lineTo(-25, -13.5);
-            ctx.lineTo(-27, -11.5);
+            ctx.beginPath();
+            ctx.moveTo(-45, -13);
+            ctx.quadraticCurveTo(-38, -15.2, -32, -12.6);
+            ctx.quadraticCurveTo(-38.5, -11.6, -45, -12.4);
             ctx.closePath();
             ctx.fill();
 
-            // === NEAR WING (lit) — long, slender, swept up-back ===
-            const wing = ctx.createLinearGradient(0, 0, -28, -30);
+            // === NEAR WING (hero: long, slender, swept down-and-back, lit) ===
+            const wing = ctx.createLinearGradient(6, 0, -30, 26);
             wing.addColorStop(0, litStr);
-            wing.addColorStop(1, '#c4d0ee');
+            wing.addColorStop(0.6, '#dde5f7');
+            wing.addColorStop(1, '#aebbe0');
             ctx.fillStyle = wing;
-            ctx.strokeStyle = 'rgba(40,48,78,0.35)';
+            ctx.strokeStyle = outline;
             ctx.lineWidth = 1;
             ctx.beginPath();
-            ctx.moveTo(9, -1);        // root leading edge
-            ctx.lineTo(-25, -31);     // tip leading edge
-            ctx.lineTo(-31, -29.5);   // wingtip
-            ctx.lineTo(-2, 2);        // root trailing edge
+            ctx.moveTo(10, -1);
+            ctx.quadraticCurveTo(-6, 12, -28, 26);       // leading edge to tip
+            ctx.quadraticCurveTo(-34, 28.5, -33, 23.5);  // rounded winglet
+            ctx.quadraticCurveTo(-16, 14, -2, 2);        // trailing edge to root
             ctx.closePath();
             ctx.fill();
             ctx.stroke();
             // crisp lit leading edge
-            ctx.strokeStyle = 'rgba(255,255,255,0.85)';
-            ctx.lineWidth = 1.4;
+            ctx.strokeStyle = 'rgba(255,255,255,0.9)';
+            ctx.lineWidth = 1.5;
             ctx.beginPath();
-            ctx.moveTo(9, -1);
-            ctx.lineTo(-25, -31);
+            ctx.moveTo(10, -1);
+            ctx.quadraticCurveTo(-6, 12, -28, 26);
             ctx.stroke();
 
-            // === CANOPY: tinted glass bubble with a highlight ===
-            ctx.save();
-            ctx.translate(13, -3.4);
-            ctx.rotate(-0.12);
-            const glass = ctx.createLinearGradient(0, -5, 0, 4);
-            glass.addColorStop(0, '#bfe0ff');
-            glass.addColorStop(0.5, '#5d8fc8');
-            glass.addColorStop(1, '#274a78');
+            // === CANOPY: glass bubble with a reflection streak ===
+            const glass = ctx.createLinearGradient(0, -9, 0, -1);
+            glass.addColorStop(0, '#d2ecff');
+            glass.addColorStop(0.5, '#5f93cc');
+            glass.addColorStop(1, '#264a78');
             ctx.fillStyle = glass;
+            ctx.strokeStyle = 'rgba(40,60,90,0.55)';
+            ctx.lineWidth = 0.8;
             ctx.beginPath();
-            ctx.ellipse(0, 0, 9.5, 5, 0, 0, Math.PI * 2);
+            ctx.moveTo(25, -2);
+            ctx.quadraticCurveTo(23, -8.5, 11, -9.2);
+            ctx.quadraticCurveTo(1, -9, -0.5, -3.5);
+            ctx.quadraticCurveTo(13, -2.6, 25, -2);
+            ctx.closePath();
             ctx.fill();
-            ctx.fillStyle = 'rgba(255,255,255,0.8)';
+            ctx.stroke();
+            ctx.fillStyle = 'rgba(255,255,255,0.72)';
             ctx.beginPath();
-            ctx.ellipse(-2.5, -1.8, 3.4, 1.3, -0.3, 0, Math.PI * 2);
+            ctx.moveTo(19, -4.5);
+            ctx.quadraticCurveTo(14, -7.6, 7, -7);
+            ctx.quadraticCurveTo(13, -5.6, 19, -4.5);
+            ctx.closePath();
             ctx.fill();
-            ctx.restore();
 
-            // nose glint
+            // nose tip highlight
             ctx.fillStyle = 'rgba(255,255,255,0.7)';
             ctx.beginPath();
-            ctx.ellipse(27, -1.5, 2.4, 1.2, 0, 0, Math.PI * 2);
+            ctx.ellipse(34, -0.5, 2.6, 1.4, 0, 0, Math.PI * 2);
             ctx.fill();
 
             ctx.restore();
@@ -1230,7 +1250,7 @@
             particles = [];
             shakeT = 0;
             lastFlash = 0;
-            neutralBeta = null; // recalibrate tilt to current hold
+            neutralGamma = null; // recalibrate tilt to current hold
             dom.score.textContent = '0';
             dom.ringHud.textContent = '◎ 0';
         }
@@ -1275,12 +1295,12 @@
         //  Input
         // ---------------------------------------------------------------
         function onOrientation(e) {
-            if (e.beta == null) return;
+            if (e.gamma == null) return;
             tiltActive = true;
-            if (neutralBeta == null) neutralBeta = e.beta;
-            // tilt phone back toward you (beta increases) -> climb (positive)
-            const rel = e.beta - neutralBeta;
-            tilt = clamp(rel / TILT_RANGE, -1, 1);
+            if (neutralGamma == null) neutralGamma = e.gamma;
+            // tilt the phone left (gamma decreases) -> climb; tilt right -> dive
+            const rel = e.gamma - neutralGamma;
+            tilt = clamp(-rel / TILT_RANGE, -1, 1);
         }
 
         let tiltListenerAdded = false;


### PR DESCRIPTION
Two gameplay/visual tweaks to Glide (`/apps/glide/index.html`), building on the merged cinematic graphics.

## 1. Tilt controls → left / right
The tilt input now reads the **left/right axis** (`gamma`) instead of front/back (`beta`), which felt unnatural:
- **Tilt the phone left to climb, right to dive.**
- Your hold position at takeoff becomes neutral, and it recalibrates each run.
- Start-screen instructions updated to match. Keyboard (↑/↓) and drag fallbacks for desktop are unchanged.

## 2. A proper sailplane
Rebuilt the glider sprite from scratch so it actually reads as a glider:
- **Pod-and-boom fuselage** with smooth bezier curves and a top-lit / belly-shaded gradient.
- **Long, slender swept wings** — a lit "hero" near wing and a shaded far wing, each with a **winglet** and a crisp white **leading-edge highlight** (the high-aspect-ratio look that signals "glider").
- **Glass bubble canopy** with a reflection streak.
- **T-tail** (swept vertical fin + horizontal stabiliser on top).
- Sporty **accent stripe** and a **nose glint**.
- Still picks up warm dawn/dusk light and trails vapor.

## Verification
JS passes `node --check`. Rendered the glider zoomed (level / climb / dive) and in-scene across day cycle phases; ran real gameplay; **collision → game-over confirmed** (final score recorded, overlay shown); no console/page errors.

> Note: real device tilt can't be exercised in headless Chromium, so the new flight path was validated via the keyboard, which feeds the same `tilt` value the sensor does. Worth a quick check on-device that left=up / right=down feels right — the sign is a one-character flip and `TILT_RANGE` tunes sensitivity if not.

https://claude.ai/code/session_01D1J1Qr83B1ovAmH1MJXkJV

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1J1Qr83B1ovAmH1MJXkJV)_