### PR TITLE
Glide: calmer tilt sensitivity + cleaner moon

### DIFF
--- a/apps/glide/index.html
+++ b/apps/glide/index.html
@@ -225,7 +225,7 @@
         const RING_SPACING = 900;     // world px between rings
         const RING_RADIUS = 46;
         const RING_BONUS = 25;
-        const TILT_RANGE = 24;        // degrees of tilt for full deflection
+        const TILT_RANGE = 38;        // degrees of tilt for full deflection
         const CYCLE_DIST = 22000;     // world px for one full day/night cycle (slow, majestic)
         // vertical flight model (gravity-based so the glider naturally sinks)
         const GRAVITY = 0.22;         // constant downward accel
@@ -605,11 +605,15 @@
                 ctx.beginPath(); ctx.arc(x - r * 0.28, y - r * 0.1, r * 0.18, 0, Math.PI * 2); ctx.fill();
                 ctx.beginPath(); ctx.arc(x + r * 0.22, y + r * 0.26, r * 0.12, 0, Math.PI * 2); ctx.fill();
                 ctx.beginPath(); ctx.arc(x + r * 0.05, y - r * 0.32, r * 0.08, 0, Math.PI * 2); ctx.fill();
-                // crescent shadow
-                ctx.globalAlpha = 0.5;
-                ctx.fillStyle = rgb(sky.stops[0]);
-                ctx.beginPath(); ctx.arc(x + r * 0.55, y - r * 0.32, r * 0.95, 0, Math.PI * 2); ctx.fill();
-                ctx.globalAlpha = 1;
+                // soft terminator shading, clipped to the disc so it never bleeds into the sky
+                ctx.save();
+                ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI * 2); ctx.clip();
+                const term = ctx.createRadialGradient(x - r * 0.5, y - r * 0.5, r * 0.3, x + r * 0.45, y + r * 0.45, r * 1.5);
+                term.addColorStop(0, 'rgba(120,132,170,0)');
+                term.addColorStop(1, 'rgba(120,132,170,0.45)');
+                ctx.fillStyle = term;
+                ctx.beginPath(); ctx.arc(x, y, r, 0, Math.PI * 2); ctx.fill();
+                ctx.restore();
             }
             ctx.restore();
         }


### PR DESCRIPTION
Two small follow-up fixes to Glide (`/apps/glide/index.html`) from playtest feedback.

## 1. Tilt was too sensitive
Widened `TILT_RANGE` from **24° → 38°** of phone tilt for full up/down deflection. Small movements now produce gentler response, so the glider is less twitchy and easier to hold steady. (Direction and neutral-calibration are unchanged — still tilt left to climb, right to dive.)

## 2. The moon's "weird dark circle"
The old crescent effect drew a **sky-coloured disc offset *outside* the moon's silhouette** at 50% alpha — the part hanging past the moon's edge tinted the sky next to it, which is the dark circle you saw.

Replaced it with **soft terminator shading clipped to the moon disc**: a subtle radial shadow on the side away from the light, masked to the moon's circle so it can never bleed into the sky. The moon now reads as a clean lit sphere and the surrounding stars stay crisp right up to its edge.

## Verification
JS passes `node --check`; rendered the night sky in-scene and the moon in isolation at large scale on the night gradient — shading sits cleanly on the disc with zero sky bleed (stars crisp to the rim), no console/page errors.

> Note: tilt feel itself can't be exercised in headless Chromium; 38° is a sensible calmer default and is a one-line tweak if you'd like it even gentler.

https://claude.ai/code/session_01D1J1Qr83B1ovAmH1MJXkJV

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1J1Qr83B1ovAmH1MJXkJV)_