### PR TITLE
Glide: tilt left to climb (fix inverted tilt direction)

### DIFF
--- a/apps/glide/index.html
+++ b/apps/glide/index.html
@@ -1302,9 +1302,9 @@
             if (e.gamma == null) return;
             tiltActive = true;
             if (neutralGamma == null) neutralGamma = e.gamma;
-            // tilt the phone left (gamma decreases) -> climb; tilt right -> dive
+            // tilt the phone left -> climb; tilt right -> dive
             const rel = e.gamma - neutralGamma;
-            tilt = clamp(-rel / TILT_RANGE, -1, 1);
+            tilt = clamp(rel / TILT_RANGE, -1, 1);
         }
 
         let tiltListenerAdded = false;


### PR DESCRIPTION
Fixes the tilt direction so **tilting the phone left climbs** (and tilting right dives), matching the on-screen instructions.

## What was wrong
The device-orientation handler mapped the `gamma` (left/right) axis with an inverted sign relative to a real device, so tilting left actually dove instead of climbing.

## The fix
One-line sign flip in `onOrientation`:
```diff
-            tilt = clamp(-rel / TILT_RANGE, -1, 1);
+            tilt = clamp(rel / TILT_RANGE, -1, 1);
```
Now tilt-left → positive `tilt` → climb; tilt-right → dive. The keyboard mapping (ArrowUp = positive `tilt` = climb) and the sensitivity (`TILT_RANGE = 38°`) are unchanged.

## Verification
- JS passes `node --check`.
- Smoke-tested the physics pipeline in a real run: holding the climb input keeps the glider airborne; holding the dive input flies it into the floor and triggers game-over. No console/page errors.

> Caveat: real-device tilt can't be exercised in headless Chromium, so I verified the shared `tilt`→physics path via the keyboard (positive `tilt` = climb, confirmed end-to-end). This flip aligns the device gamma sign with that mapping and with your report that left should go up. If on your phone it ends up reversed, it's the same one-character sign flip.

https://claude.ai/code/session_01D1J1Qr83B1ovAmH1MJXkJV

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1J1Qr83B1ovAmH1MJXkJV)_