### PR TITLE
Glide: spec-correct iOS tilt direction + visible build tag

### DIFF
--- a/apps/glide/index.html
+++ b/apps/glide/index.html
@@ -129,6 +129,13 @@
             max-width: 300px;
             line-height: 1.5;
         }
+        #buildTag {
+            margin-top: 16px;
+            font-size: 11px;
+            letter-spacing: 0.5px;
+            color: #4a5675;
+            font-variant-numeric: tabular-nums;
+        }
         .back {
             position: fixed;
             top: calc(env(safe-area-inset-top) + 10px);
@@ -163,6 +170,7 @@
         </div>
         <button class="btn" id="startBtn">Take Off</button>
         <div id="tiltNote"></div>
+        <div id="buildTag">build 5 · tilt-left-up</div>
     </div>
 
     <!-- Game over -->
@@ -1302,9 +1310,10 @@
             if (e.gamma == null) return;
             tiltActive = true;
             if (neutralGamma == null) neutralGamma = e.gamma;
-            // tilt the phone left -> climb; tilt right -> dive
+            // On iOS portrait, tilting the phone's left side down makes gamma
+            // go negative; we want that to climb, so negate. (tilt left = up)
             const rel = e.gamma - neutralGamma;
-            tilt = clamp(rel / TILT_RANGE, -1, 1);
+            tilt = clamp(-rel / TILT_RANGE, -1, 1);
         }
 
         let tiltListenerAdded = false;


### PR DESCRIPTION
Addresses the "tilt is still backwards on iPhone" report — but with an honest diagnosis rather than another blind sign-flip.

## The real problem is probably caching, not the sign
A sign flip **must** reverse the behavior. Across the last two PRs the mapping went `-rel` → `rel`, yet both reportedly felt "backwards." Both literally cannot be backwards on a device that reports `gamma` consistently. The likely explanation: the iPhone is running a **cached build** (home-screen PWA shell + GitHub Pages CDN, ~10 min), so the "fixes" never actually executed on the phone.

## What this PR does
1. **Sets the iOS-spec-correct sign.** Back to `-rel`: in portrait, tilting the phone's left side down drives `gamma` negative, and we want that to climb (positive `tilt`). This is the spec-correct mapping for "tilt left = up" on iPhone.
2. **Adds a visible build tag** (`build 5 · tilt-left-up`) on the start screen, so you can confirm at a glance that a fresh build is actually loaded — if you don't see it, you're on a cached copy and the controls won't have changed.

## How to force a fresh load on iPhone (important)
The code can't fix iOS's home-screen cache from inside the page, so once this is on `master`:
1. If Glide is on your home screen, **delete that icon** and re-add it from Safari (home-screen PWAs keep their own cached shell).
2. Or open it in **Safari** directly and pull-to-refresh, ideally after a minute (CDN TTL).
3. Confirm the start screen reads **`build 5 · tilt-left-up`** before testing.

Then: tilt the phone **left to climb, right to dive**. If with *this* build it's still reversed, then iOS is reporting `gamma` opposite to spec on your device and I'll flip the one character back — but this time we'll know it's the code and not the cache, because the build tag proves the new code ran.

## Verification
JS passes `node --check`; start screen renders the build tag (confirmed by screenshot + DOM read); no console/page errors.

https://claude.ai/code/session_01D1J1Qr83B1ovAmH1MJXkJV

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1J1Qr83B1ovAmH1MJXkJV)_