### PR TITLE
Remove LinkedIn from landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,6 @@ text-decoration: underline;
   <div class="line" id="line-1"></div>
   <div class="line" id="line-2"></div>
   <div class="line" id="line-3"></div>
-  <div class="line" id="line-4"></div>
 </div>
 
 <script>
@@ -70,7 +69,6 @@ text-decoration: underline;
     '  software engineer',
     '',
     { text: '  m.polkiewicz@gmail.com', href: 'mailto:m.polkiewicz@gmail.com', linkStart: 2 },
-    { text: '  linkedin.com/in/polkiewicz', href: 'https://www.linkedin.com/in/polkiewicz', linkStart: 2 },
   ];
 
   const CHAR_SPEED = 30;


### PR DESCRIPTION
Removes the LinkedIn link from the landing page (`index.html`).

## Changes
- Removed the `linkedin.com/in/polkiewicz` entry from the typed contact lines
- Removed the now-orphaned `line-4` div (the typing loop iterates over `lines.length`, so the extra div is no longer used)

The landing page now shows only the name, title, and email.

https://claude.ai/code/session_01N8k5YgE7tWD9YP5wfQs5Jg

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8k5YgE7tWD9YP5wfQs5Jg)_