### PR TITLE
Kart 3 multiplayer M2: WebRTC fast path, client pose authority, mid-race rejoin

### DIFF
--- a/apps/kart3/CLAUDE.md
+++ b/apps/kart3/CLAUDE.md
@@ -86,12 +86,37 @@ work, and don't regress these four seams.
   both players and drive the lobby via DOM clicks. The client autopilot
   works because input packets carry `player.ctrl` (controller output), not
   raw touch state.
-- Known M1 limitation for M2: client steering reaches the host ~50-150ms
-  late, so the host's copy of a client kart corners on stale inputs and
-  scrubs speed the local player never sees. Candidates: client-authoritative
-  own-kart pose in input packets (fine at this trust level), or host-side
-  input delay buffering. Also: no client rocket-start (host can't see
-  pre-GO inputs), no late-join.
+### M2 netcode (SHIPPED): WebRTC fast path + pose authority + rejoin
+
+- **WebRTC DataChannels** (`rtcInitiate`/`rtcHandleSignal`): host offers one
+  unordered/unreliable 'fast' channel per client from the LOBBY (pre-warmed
+  before GO); SDP/ICE relayed through the DO (`rtc` messages). Snapshots are
+  dual-sent (WS broadcast + every open channel) and clients dedupe by tick —
+  fastest transport wins; pairs that can't go P2P just stay on the relay.
+  Inputs go rtc-else-ws (`sendToHostFast`). `window.__noRtc` forces relay
+  (used in tests).
+- **Client-authoritative pose** (fixes M1's stale-steering): input packets
+  carry the own-kart pose; on the host, remote karts skip physics entirely
+  (`updateRemoteKart`) — pose is lerp-applied, effect timers tick, item
+  pickups/laps/ranks stay host-derived, `clampToTrack` sanity-bounds it.
+  They're immovable in `resolveCollisions` (owner moves them). The client no
+  longer eases toward the host echo (it's just its own delayed pose) — only
+  a >45u emergency snap remains. Client rocket-start is back.
+- **Mid-race rejoin**: DO stores `seats` (id+name) at race start; a hello
+  during `racing` whose name matches a vacant seat is re-admitted with
+  `welcome.rejoin`. Host converts that kart AI→remote and sends a targeted
+  `rejoin-state` event (seed + racePlayers + full `netSnapshot`). Clients
+  auto-retry 4× on mid-race socket loss (own kart keeps driving, remotes
+  freeze on the last snap); cold rejoin (page reload) rebuilds the race and
+  `netRestore`s.
+- **Connection indicator** (`#netInd`): client shows `P2P/RELAY · Nms`
+  (WS RTT via `pp` echo, doubles as keepalive); host shows open-channel
+  count. Green when fully P2P.
+- **CI caveat**: under SwiftShader CPU contention the host page's sim runs
+  slower than wall time (hitch guard drops time) while pose-authoritative
+  clients keep real-time speed — host AI and raceClock fall behind. That's
+  load distortion, not a netcode bug; quiet machines and real phones at
+  60fps don't exhibit it. Run perf-sensitive assertions on a quiet machine.
 
 ## Track / world model
 

--- a/apps/kart3/VISION.md
+++ b/apps/kart3/VISION.md
@@ -140,8 +140,11 @@ racing is rock solid.
    latency makes the host sim clients' karts on stale steering — consider
    client-authoritative own-kart pose (fine at this trust level) or input
    delay buffering alongside WebRTC.
-2. **M2 — WebRTC + full grid**: DataChannels with relay fallback, 4 humans +
-   AI fill, disconnect→AI conversion, rejoin.
+2. **M2 — WebRTC + full grid** ✅ *(shipped)*: DataChannels with relay
+   fallback (dual-send + tick dedupe, lobby-pre-warmed), client-authoritative
+   own-kart pose (host keeps items/laps/ranks; fixed M1's stale-steering),
+   disconnect→AI conversion, auto-rejoin by seat name with full-state
+   restore, client rocket starts, P2P/RELAY + RTT indicator.
 3. **M3 — Matchmaking**: quick-race queue, names/avatars, polish lobby.
 4. **M4 — Resilience polish**: host clock sync hardening, jitter buffers,
    reconnect UX, version gating.

--- a/apps/kart3/index.html
+++ b/apps/kart3/index.html
@@ -53,6 +53,12 @@
         #lapPill { top: calc(env(safe-area-inset-top) + 10px); left: calc(env(safe-area-inset-left) + 14px); }
         #timePill { top: calc(env(safe-area-inset-top) + 10px); right: calc(env(safe-area-inset-right) + 14px); text-align: right; }
         #lapTime { font-variant-numeric: tabular-nums; }
+        #netInd { position: absolute; top: calc(env(safe-area-inset-top) + 62px); right: calc(env(safe-area-inset-right) + 14px);
+            display: none; font-size: 10px; font-weight: 900; letter-spacing: 1px; padding: 3px 9px; border-radius: 999px;
+            background: rgba(6,14,30,0.55); border: 1px solid rgba(255,255,255,0.14); color: #8fd6ff;
+            font-variant-numeric: tabular-nums; }
+        #netInd.on { display: block; }
+        #netInd.p2p { color: #7dffb0; }
 
         /* Big position, MK64-style bottom-left */
         #posBig { position: absolute; left: calc(env(safe-area-inset-left) + 16px);
@@ -311,6 +317,7 @@
             <div class="value" id="lapTime">0:00.0</div>
         </div>
         <button id="pauseBtn">⏸</button>
+        <div id="netInd">RELAY</div>
         <div id="posBig" class="pos-8">8<small>th</small></div>
         <div id="miniWrap"><canvas id="minimap" width="208" height="208"></canvas></div>
         <div id="boostWrap">
@@ -471,7 +478,7 @@
             joinRoomBtn: $('joinRoomBtn'), netStatus: $('netStatus'),
             lobbyScreen: $('lobbyScreen'), roomCode: $('roomCode'), lobbyList: $('lobbyList'),
             lobbyChars: $('lobbyChars'), readyBtn: $('readyBtn'), lobbyStartBtn: $('lobbyStartBtn'),
-            leaveBtn: $('leaveBtn'), lobbyMsg: $('lobbyMsg'),
+            leaveBtn: $('leaveBtn'), lobbyMsg: $('lobbyMsg'), netInd: $('netInd'),
             muteBtn: $('muteBtn'), itemBtn: $('itemBtn'), driftBtn: $('driftBtn'), pauseBtn: $('pauseBtn'),
             pauseScreen: $('pauseScreen'), resumeBtn: $('resumeBtn'), restartBtn: $('restartBtn'), quitBtn: $('quitBtn'),
             minimap: $('minimap'), stick: $('stick'), stickDot: $('stickDot'),
@@ -613,18 +620,93 @@
         const net = {
             mode: 'solo',              // 'solo' | 'host' | 'client'
             ws: null, connected: false,
-            myId: -1, isHost: false, code: '',
-            players: [], phase: 'lobby',
+            myId: -1, isHost: false, code: '', hostId: 0,
+            players: [], racePlayers: [], phase: 'lobby',
             myCharIdx: 0, myReady: false,
             fireCount: 0,
             remoteCtrl: {},            // host: playerId → latest input packet
             snaps: [],                 // client: [{rt, d}] buffered snapshots
+            lastSnapTick: 0,           // dedupe (snaps arrive on both transports)
             lastInputSent: 0,
-            pingTimer: 0,
-            racing: false,
-            _lastRoll: 0, _lastItem: null,
+            pingTimer: 0, pingMs: 0,
+            racing: false, rejoinTries: 0,
+            rtc: {},                   // pid → {pc, ch, open} WebRTC fast path
+            _lastRoll: 0, _lastItem: null, _itemKey: '',
         };
         function netActive() { return net.mode !== 'solo'; }
+        function wsSend(obj) {
+            if (net.ws && net.connected) { try { net.ws.send(JSON.stringify(obj)); } catch (e) {} }
+        }
+
+        // ---------------------------------------------------------------
+        // WebRTC fast path (M2). Star topology: host ↔ each client, one
+        // unordered/unreliable DataChannel for inputs + snapshots. The DO
+        // relays the SDP/ICE signaling; if a pair can't go P2P the WS relay
+        // keeps carrying their traffic (snaps are dual-sent + tick-deduped).
+        // ---------------------------------------------------------------
+        const RTC_CFG = { iceServers: [{ urls: ['stun:stun.l.google.com:19302', 'stun:stun.cloudflare.com:3478'] }] };
+        function rtcAvailable() { return !window.__noRtc && typeof RTCPeerConnection !== 'undefined'; }
+        function rtcDrop(pid) {
+            const r = net.rtc[pid];
+            if (!r) return;
+            try { if (r.ch) r.ch.close(); } catch (e) {}
+            try { if (r.pc) r.pc.close(); } catch (e) {}
+            delete net.rtc[pid];
+        }
+        function rtcTeardown() { for (const pid of Object.keys(net.rtc)) rtcDrop(pid); }
+        function rtcWireChannel(pid, ch) {
+            ch.onopen = () => { if (net.rtc[pid]) net.rtc[pid].open = true; };
+            ch.onclose = () => { if (net.rtc[pid]) net.rtc[pid].open = false; };
+            ch.onmessage = (ev) => {
+                let m;
+                try { m = JSON.parse(ev.data); } catch (e) { return; }
+                if (m.t === 'input') m.from = pid;   // trust the channel, not the payload
+                netHandle(m);
+            };
+        }
+        function rtcInitiate(pid) {      // host side: offer a channel to one client
+            if (!rtcAvailable() || net.rtc[pid]) return;
+            const pc = new RTCPeerConnection(RTC_CFG);
+            const entry = net.rtc[pid] = { pc, ch: null, open: false };
+            const ch = pc.createDataChannel('fast', { ordered: false, maxRetransmits: 0 });
+            entry.ch = ch;
+            rtcWireChannel(pid, ch);
+            pc.onicecandidate = (e) => { if (e.candidate) wsSend({ t: 'rtc', to: pid, ice: e.candidate }); };
+            pc.createOffer()
+                .then((o) => pc.setLocalDescription(o))
+                .then(() => wsSend({ t: 'rtc', to: pid, sdp: pc.localDescription }))
+                .catch(() => {});
+        }
+        function rtcHandleSignal(msg) {
+            if (!rtcAvailable()) return;
+            const pid = msg.from;
+            let entry = net.rtc[pid];
+            if (msg.sdp && msg.sdp.type === 'offer') {       // client side: answer
+                rtcDrop(pid);                                // clear any stale pc
+                const pc = new RTCPeerConnection(RTC_CFG);
+                entry = net.rtc[pid] = { pc, ch: null, open: false };
+                pc.ondatachannel = (e) => { entry.ch = e.channel; rtcWireChannel(pid, e.channel); };
+                pc.onicecandidate = (e) => { if (e.candidate) wsSend({ t: 'rtc', to: pid, ice: e.candidate }); };
+                pc.setRemoteDescription(msg.sdp)
+                    .then(() => pc.createAnswer())
+                    .then((a) => pc.setLocalDescription(a))
+                    .then(() => wsSend({ t: 'rtc', to: pid, sdp: pc.localDescription }))
+                    .catch(() => {});
+            } else if (msg.sdp && msg.sdp.type === 'answer') {
+                if (entry) entry.pc.setRemoteDescription(msg.sdp).catch(() => {});
+            } else if (msg.ice) {
+                if (entry) entry.pc.addIceCandidate(msg.ice).catch(() => {});
+            }
+        }
+        function rtcToHostOpen() {
+            const r = net.rtc[net.hostId];
+            return !!(r && r.open);
+        }
+        function sendToHostFast(obj) {
+            const r = net.rtc[net.hostId];
+            if (r && r.open) { try { r.ch.send(JSON.stringify(obj)); return; } catch (e) {} }
+            wsSend(obj);
+        }
         function myName() {
             const v = (dom.nameInput.value || '').trim().slice(0, 12);
             return v || 'Racer';
@@ -656,7 +738,8 @@
                 net.connected = true;
                 net.myCharIdx = selectedCharIdx;
                 ws.send(JSON.stringify({ t: 'hello', name: myName(), charIdx: net.myCharIdx }));
-                net.pingTimer = setInterval(() => { try { ws.send('ping'); } catch (e) {} }, 20000);
+                // doubles as keepalive and RTT probe
+                net.pingTimer = setInterval(() => wsSend({ t: 'pp', ts: performance.now() }), 2500);
             };
             ws.onmessage = (ev) => {
                 if (ev.data === 'pong') return;
@@ -670,14 +753,36 @@
         function netReset() {
             if (net.pingTimer) { clearInterval(net.pingTimer); net.pingTimer = 0; }
             if (net.ws) { try { net.ws.onclose = null; net.ws.close(); } catch (e) {} }
+            rtcTeardown();
             net.ws = null; net.connected = false; net.mode = 'solo';
-            net.myId = -1; net.isHost = false; net.code = ''; net.players = [];
-            net.myReady = false; net.racing = false;
+            net.myId = -1; net.isHost = false; net.code = ''; net.hostId = 0;
+            net.players = []; net.racePlayers = [];
+            net.myReady = false; net.racing = false; net.rejoinTries = 0;
             net.remoteCtrl = {}; net.snaps = []; net.fireCount = 0;
+            net.lastSnapTick = 0; net.pingMs = 0; net._itemKey = '';
             clearGhosts();
             dom.pauseBtn.style.display = '';
+            dom.netInd.classList.remove('on');
         }
         function netClosed() {
+            // client dropped mid-race: hold the race state and try to rejoin —
+            // own kart keeps driving locally, remote karts freeze on the last snap
+            if (net.racing && state !== 'menu' && net.mode === 'client') {
+                net.connected = false;
+                net.ws = null;
+                if (net.pingTimer) { clearInterval(net.pingTimer); net.pingTimer = 0; }
+                rtcTeardown();
+                if (net.rejoinTries < 4) {
+                    net.rejoinTries++;
+                    flash('RECONNECTING…', '#ffd54a');
+                    setTimeout(() => { if (net.racing && !net.connected) joinRoom(net.code); }, 1000);
+                } else {
+                    flash('CONNECTION LOST', '#ff9a9a');
+                    net.racing = false;
+                    setTimeout(quitToMenu, 1300);
+                }
+                return;
+            }
             const wasRacing = net.racing && state !== 'menu';
             netReset();
             if (wasRacing) {
@@ -693,9 +798,16 @@
             switch (msg.t) {
                 case 'welcome':
                     net.myId = msg.id; net.isHost = msg.host; net.code = msg.code;
-                    net.mode = msg.host ? 'host' : 'client';
-                    netStatusMsg('');
-                    showLobby();
+                    if (msg.rejoin) {
+                        // seat reclaimed mid-race; host will send rejoin-state
+                        net.mode = 'client';
+                        net.rejoinTries = 0;
+                        flash('RECONNECTED!', '#9affc0');
+                    } else {
+                        net.mode = msg.host ? 'host' : 'client';
+                        netStatusMsg('');
+                        showLobby();
+                    }
                     break;
                 case 'roster': {
                     net.players = msg.players; net.phase = msg.phase;
@@ -705,6 +817,12 @@
                         net.mode = me.host ? 'host' : 'client';
                         net.myReady = me.ready;
                         net.myCharIdx = me.charIdx;
+                    }
+                    const hostP = net.players.find((p) => p.host);
+                    if (hostP) net.hostId = hostP.id;
+                    // host pre-warms a P2P channel to every client from the lobby
+                    if (net.isHost && !net.racing) {
+                        for (const p of net.players) if (p.id !== net.myId) rtcInitiate(p.id);
                     }
                     if (net.racing && msg.phase === 'lobby') endOnlineRaceToLobby();
                     else if (state === 'menu') renderLobby();
@@ -721,11 +839,32 @@
                     net.remoteCtrl[msg.from] = msg;
                     break;
                 case 'snap':
+                    if (msg.tick <= net.lastSnapTick) return;   // dual-transport dedupe
+                    net.lastSnapTick = msg.tick;
                     net.snaps.push({ rt: performance.now(), d: msg });
                     if (net.snaps.length > 6) net.snaps.shift();
                     break;
+                case 'rtc':
+                    rtcHandleSignal(msg);
+                    break;
+                case 'pp':
+                    net.pingMs = Math.max(1, Math.round(performance.now() - msg.ts));
+                    break;
+                case 'rejoined':
+                    // host: hand the seat back from AI to its returning human
+                    if (net.mode === 'host' && net.racing) {
+                        hostConvertToRemote(msg.id);
+                        wsSend({ t: 'event', to: msg.id, e: 'rejoin-state',
+                            seed: raceSeed, players: net.racePlayers, snap: netSnapshot() });
+                        showToast('They’re back!', '#9affc0');
+                    }
+                    break;
+                case 'event':
+                    if (msg.e === 'rejoin-state') applyRejoinState(msg);
+                    break;
                 case 'peer-left':
                     showToast((msg.name || 'A racer') + ' left', '#ff9a9a');
+                    rtcDrop(msg.id);
                     if (net.mode === 'host' && net.racing) hostConvertToAI(msg.id);
                     break;
                 case 'host-left':
@@ -794,14 +933,17 @@
         }
 
         // ---------- race wiring ----------
-        function startOnlineRace(seed, players) {
+        function startOnlineRace(seed, players, skipCountdown) {
             raceSeed = (seed >>> 0) || 1;
             net.players = players;
+            net.racePlayers = players;
             net.racing = true;
+            net.rejoinTries = 0;
             net.fireCount = 0;
             net.remoteCtrl = {};
             net.snaps = [];
-            net._lastRoll = 0; net._lastItem = null;
+            net.lastSnapTick = 0;
+            net._lastRoll = 0; net._lastItem = null; net._itemKey = '';
             const roster = players.map((p) => ({
                 kind: p.id === net.myId ? 'local' : 'remote',
                 charIdx: p.charIdx, name: p.name, pid: p.id,
@@ -821,14 +963,29 @@
             dom.resultScreen.classList.add('hidden');
             dom.hud.classList.add('on'); dom.muteBtn.classList.add('on');
             dom.pauseBtn.style.display = 'none';   // nobody pauses a shared race
+            dom.netInd.classList.add('on');
             resetRace();
             startMusic();
-            runCountdown();
+            if (skipCountdown) state = 'racing';
+            else runCountdown();
+        }
+        // client got its seat back mid-race: rebuild if cold, then adopt the
+        // host's authoritative state wholesale
+        function applyRejoinState(msg) {
+            if (!net.racing) startOnlineRace(msg.seed, msg.players, true);
+            netRestore(msg.snap);
+            state = 'racing';
+            dom.countdown.classList.remove('on');
+            net.snaps = []; net.lastSnapTick = 0;
+            net.fireCount = 0;   // host reset our fire counter on reconversion
+            net._itemKey = '';
+            updateItemButton();
         }
         function endOnlineRaceToLobby() {
             net.racing = false;
-            net.snaps = []; net.remoteCtrl = {};
+            net.snaps = []; net.remoteCtrl = {}; net.lastSnapTick = 0;
             clearGhosts();
+            dom.netInd.classList.remove('on');
             stopMusic();
             state = 'menu';
             dom.hud.classList.remove('on'); dom.muteBtn.classList.remove('on');
@@ -848,21 +1005,83 @@
                     phase: rand(0, Math.PI * 2), laneBias: rand(-3, 3), errT: 3, errOff: 0, rival: false };
             }
             delete net.remoteCtrl[pid];
+            rtcDrop(pid);
+        }
+        function hostConvertToRemote(pid) {
+            const k = karts.find((kk) => kk.pid === pid);
+            if (!k) return;
+            k.kind = 'remote';
+            k.controller = remoteController;
+            k.ai = null;
+            k._firedCount = 0;
+            delete net.remoteCtrl[pid];
+            rtcDrop(pid);
+            rtcInitiate(pid);
         }
 
-        // host: remote humans' karts read the latest relayed input packet
+        // host: remote humans' karts are CLIENT-AUTHORITATIVE for pose (M2) —
+        // each player's kart is exactly where they see it, so relay latency
+        // never makes the host sim them on stale steering. The host keeps
+        // authority over items, laps, ranks, bonks and collisions-with-AI.
         function remoteController(k) {
+            // unused while kind === 'remote' (updateRemoteKart drives the kart);
+            // kept as the controller slot so conversions are a kind/controller swap
+            k.ctrl.steer = 0; k.ctrl.drift = false; k.ctrl.brake = false;
+        }
+        function updateRemoteKart(k, dt) {
+            // effect timers still tick host-side (they gate item logic + snapshots)
+            if (k.shieldTimer > 0) k.shieldTimer -= dt;
+            if (k.invuln > 0) k.invuln -= dt;
+            if (k.gooT > 0) k.gooT -= dt;
+            if (k.shrinkT > 0) k.shrinkT -= dt;
+            if (k.spinTimer > 0) k.spinTimer -= dt;
+            if (k.boostTimer > 0) k.boostTimer -= dt;
+            if (k.itemRolling > 0) { k.itemRolling -= dt; if (k.itemRolling <= 0) finishRoll(k); }
             const rc = net.remoteCtrl[k.pid];
-            if (!rc) { k.ctrl.steer = 0; k.ctrl.drift = false; k.ctrl.brake = false; return; }
-            k.ctrl.steer = clamp(+rc.s || 0, -1, 1);
-            k.ctrl.drift = !!rc.d;
-            k.ctrl.brake = false;
-            if ((rc.f | 0) > k._firedCount) { k._firedCount = rc.f | 0; k.ctrl.fire = true; }
+            if (rc) {
+                if ((rc.f | 0) > k._firedCount) {
+                    k._firedCount = rc.f | 0;
+                    if (k.itemRolling > 0) finishRoll(k);
+                    else useItem(k);
+                }
+                if (rc.p) {
+                    const t = clamp(dt * 25, 0, 1);   // smooth toward 30Hz pose updates
+                    k.pos.x = lerp(k.pos.x, rc.p[0], t);
+                    k.pos.z = lerp(k.pos.z, rc.p[1], t);
+                    k.y = lerp(k.y, rc.p[2], t);
+                    k.theta += wrapAngle(rc.p[3] - k.theta) * t;
+                    k.speed = rc.p[4] || 0;
+                    k.grounded = !!rc.p[5];
+                    k.driftDir = rc.p[6] || 0;
+                    k.drifting = k.driftDir !== 0;
+                    k.driftRamp = 1;
+                    k.boostTimer = Math.max(k.boostTimer, rc.p[7] || 0);
+                }
+            }
+            updateProgress(k);   // authoritative laps/rank from the real pose
+            clampToTrack(k);
+            for (const b of itemBoxes) {
+                if (!b.active) continue;
+                const dx = k.pos.x - b.x, dz = k.pos.z - b.z;
+                if (dx * dx + dz * dz < 28) pickupBox(k, b);
+            }
+            if (k.drifting && k.grounded && k.speed > 25) spawnRearSpark(k, 0x4ad6ff, 5);
+            if (k.boostTimer > 0) spawnRearSpark(k, 0xff7a3c, 7);
+            syncKartMesh(k, false, dt);
         }
 
-        // host → everyone: compact per-tick state
+        // host → everyone: compact per-tick state, dual-sent over the WS relay
+        // AND every open P2P channel (clients dedupe by tick, fastest wins)
         function hostSendSnap() {
             if (!net.ws || !net.connected) return;
+            const payload = buildSnapPayload();
+            try { net.ws.send(payload); } catch (e) {}
+            for (const pid of Object.keys(net.rtc)) {
+                const r = net.rtc[pid];
+                if (r.open) { try { r.ch.send(payload); } catch (e) {} }
+            }
+        }
+        function buildSnapPayload() {
             const r2 = (v) => Math.round(v * 100) / 100;
             const msg = {
                 t: 'snap', tick: simTickNo, clock: r2(raceClock),
@@ -878,7 +1097,7 @@
                 haz: hazards.map((h) => [r2(h.x), r2(h.mesh.position.y), r2(h.z)]),
                 proj: projectiles.map((p) => [r2(p.x), r2(p.mesh.position.y), r2(p.z), r2(p.theta)]),
             };
-            try { net.ws.send(JSON.stringify(msg)); } catch (e) {}
+            return JSON.stringify(msg);
         }
         function snapKart(arr) {
             return { x: arr[0], z: arr[1], y: arr[2], theta: arr[3], speed: arr[4],
@@ -940,14 +1159,14 @@
                         k.finished = true; k.finishTime = sb.finishTime; k.bestLap = sb.bestLap;
                         finishRace();
                     }
+                    // our pose is authoritative now (M2): the host copy is just
+                    // our own latency-delayed echo, so never tug toward it —
+                    // only emergency-snap if we've somehow truly diverged
                     const dx = sb.x - k.pos.x, dz = sb.z - k.pos.z;
-                    const d2 = dx * dx + dz * dz;
-                    if (d2 > 900) {           // way off: snap to authority
+                    if (dx * dx + dz * dz > 2000) {
                         k.pos.x = sb.x; k.pos.z = sb.z; k.theta = sb.theta;
                         k.speed = sb.speed; k.y = sb.y; k.vy = 0; k.grounded = sb.grounded;
                         updateProgress(k);
-                    } else if (d2 > 25) {     // drifting apart: ease back
-                        k.pos.x += dx * 0.08; k.pos.z += dz * 0.08;
                     }
                 } else {
                     const sa = snapKart(A.d.karts[i]);
@@ -1044,18 +1263,21 @@
             if (steps === 5) simAcc = 0;
             clientApplySnaps(dt);
             const now = performance.now();
-            if (net.ws && net.connected && now - net.lastInputSent > INPUT_MS) {
+            if (net.connected && now - net.lastInputSent > INPUT_MS) {
                 net.lastInputSent = now;
-                try {
-                    // send what the local controller produced — the same seam a
-                    // remote peer fills, so even an autopiloted player nets correctly
-                    net.ws.send(JSON.stringify({
-                        t: 'input',
-                        s: Math.round(player.ctrl.steer * 100) / 100,
-                        d: player.ctrl.drift,
-                        f: net.fireCount,
-                    }));
-                } catch (e) {}
+                const r2 = (v) => Math.round(v * 100) / 100;
+                // inputs + client-authoritative pose: the host places our kart
+                // exactly where we see it (no stale-steering penalty), keeping
+                // authority only over items/laps/ranks/bonks
+                sendToHostFast({
+                    t: 'input',
+                    s: r2(player.ctrl.steer),
+                    d: player.ctrl.drift,
+                    f: net.fireCount,
+                    p: [r2(player.pos.x), r2(player.pos.z), r2(player.y), r2(player.theta),
+                        Math.round(player.speed), player.grounded ? 1 : 0,
+                        player.drifting ? player.driftDir : 0, r2(player.boostTimer)],
+                });
             }
         }
 
@@ -2303,6 +2525,7 @@
         //  PHYSICS
         // ===================================================================
         function updateKart(k, dt) {
+            if (net.mode === 'host' && k.kind === 'remote') { updateRemoteKart(k, dt); return; }
             if (k.finished) k.speed = lerp(k.speed, 0, 1 - Math.exp(-2 * dt));
 
             if (k.shieldTimer > 0) k.shieldTimer -= dt;
@@ -2885,9 +3108,15 @@
                     const d = Math.hypot(dx, dz);
                     const min = KART_RADIUS * 2;
                     if (d > 0.0001 && d < min) {
-                        const push = (min - d) / 2, nx = dx / d, nz = dz / d;
-                        a.pos.x -= nx * push; a.pos.z -= nz * push;
-                        b.pos.x += nx * push; b.pos.z += nz * push;
+                        // pose-authoritative remote karts are immovable on the
+                        // host — their owners move them; push the simmed kart
+                        const aFixed = net.mode === 'host' && a.kind === 'remote';
+                        const bFixed = net.mode === 'host' && b.kind === 'remote';
+                        const total = min - d, nx = dx / d, nz = dz / d;
+                        const pushA = aFixed ? 0 : (bFixed ? total : total / 2);
+                        const pushB = bFixed ? 0 : (aFixed ? total : total / 2);
+                        a.pos.x -= nx * pushA; a.pos.z -= nz * pushA;
+                        b.pos.x += nx * pushB; b.pos.z += nz * pushB;
                         if (a.shieldTimer > 0 && b.shieldTimer <= 0) bonkKart(b);
                         else if (b.shieldTimer > 0 && a.shieldTimer <= 0) bonkKart(a);
                         else {
@@ -2997,6 +3226,21 @@
 
             miniThrottle += 1;
             if (miniThrottle >= 2) { miniThrottle = 0; drawMinimap(); }
+
+            if (netActive() && net.racing) {
+                let label, p2p = false;
+                if (net.mode === 'host') {
+                    const peers = Object.keys(net.rtc);
+                    const open = peers.filter((pid) => net.rtc[pid].open).length;
+                    p2p = peers.length > 0 && open === peers.length;
+                    label = 'HOST · ' + (peers.length ? open + '/' + peers.length + ' P2P' : 'RELAY');
+                } else {
+                    p2p = rtcToHostOpen();
+                    label = (p2p ? 'P2P' : 'RELAY') + ' · ' + (net.connected ? (net.pingMs || '–') + 'ms' : '⚠ OFFLINE');
+                }
+                dom.netInd.textContent = label;
+                dom.netInd.classList.toggle('p2p', p2p);
+            }
         }
         function updateItemButton() {
             dom.itemBtn.classList.remove('rolling');
@@ -3514,9 +3758,9 @@
                         k.lastLapStart = 0;
                         if (k.ai && rng() < 0.6) k.boostTimer = rand(0.4, 0.8);   // most AI nail the start
                     }
-                    if (driftHeld && net.mode !== 'client') {   // hold DRIFT on GO → rocket start
-                        player.boostTimer = 0.9;                // (client boosts would be phantom —
-                        flash('ROCKET START!', '#ffd54a');      //  host can't see pre-GO inputs yet, M2)
+                    if (driftHeld) {   // hold DRIFT on GO → rocket start (clients too,
+                        player.boostTimer = 0.9;   // now that their pose is authoritative)
+                        flash('ROCKET START!', '#ffd54a');
                         sfxBoost(); vibrate(40);
                     }
                     setTimeout(() => dom.countdown.classList.remove('on'), 700);

--- a/worker/CLAUDE.md
+++ b/worker/CLAUDE.md
@@ -34,8 +34,11 @@ email-locked. The unguessable 5-char code is the credential.
   and a 101 WebSocket response's headers are immutable. Keep it there.
 
 The DO is a lobby (roster/chars/ready/host) + opaque message relay:
-client `input` → host; host `snap`/`event` → everyone else. Protocol lives
-in `apps/kart3/index.html` (`netHandle`) and `apps/kart3/VISION.md`.
+client `input` → host; host `snap`/`event` → everyone else (or one peer via
+`msg.to`); `rtc` relays WebRTC signaling peer→peer; `pp` echoes for RTT.
+At race start it stores `seats` (id+name) so a player who drops mid-race
+can rejoin by name and reclaim their kart. Protocol lives in
+`apps/kart3/index.html` (`netHandle`) and `apps/kart3/VISION.md`.
 Rooms self-destruct via alarm after 45 min or when the last socket leaves.
 
 ## Auth

--- a/worker/src/kart3room.ts
+++ b/worker/src/kart3room.ts
@@ -118,12 +118,30 @@ export class Kart3Room {
     // first message must be hello
     if (!me) {
       if (msg.t !== "hello") { ws.close(1008, "hello first"); return; }
+      const players = this.roster();
+      const name = sanitizeName(msg.name);
       if ((await this.phase()) === "racing") {
-        ws.send(JSON.stringify({ t: "error", msg: "race in progress" }));
-        ws.close(1008, "race in progress");
+        // mid-race REJOIN: a disconnected player can reclaim their seat by
+        // name (host has been driving their kart as AI meanwhile)
+        const seats = (await this.state.storage.get<{ id: number; name: string }[]>("seats")) || [];
+        const connected = new Set(players.map((p) => p.id));
+        const seat = seats.find(
+          (s) => !connected.has(s.id) && s.name.toLowerCase() === name.toLowerCase()
+        );
+        if (!seat) {
+          ws.send(JSON.stringify({ t: "error", msg: "race in progress" }));
+          ws.close(1008, "race in progress");
+          return;
+        }
+        const a: Attachment = { id: seat.id, name: seat.name, charIdx: 0, ready: true, host: false };
+        ws.serializeAttachment(a);
+        const code0 = (await this.state.storage.get<string>("code")) || "";
+        ws.send(JSON.stringify({ t: "welcome", id: a.id, host: false, code: code0, rejoin: true }));
+        // host fetches them back up to speed with a state event
+        this.sendTo((p) => p.host, { t: "rejoined", id: a.id });
+        await this.broadcastRoster();
         return;
       }
-      const players = this.roster();
       if (players.length >= MAX_PLAYERS) {
         ws.send(JSON.stringify({ t: "error", msg: "room full" }));
         ws.close(1008, "room full");
@@ -134,7 +152,7 @@ export class Kart3Room {
       while (used.has(id)) id++;
       const a: Attachment = {
         id,
-        name: sanitizeName(msg.name),
+        name,
         charIdx: Number.isInteger(msg.charIdx) ? Math.max(0, Math.min(7, msg.charIdx)) : 0,
         ready: false,
         host: players.length === 0,
@@ -175,6 +193,8 @@ export class Kart3Room {
           return;
         }
         await this.state.storage.put("phase", "racing");
+        // remember who holds each seat so they can rejoin mid-race by name
+        await this.state.storage.put("seats", players.map((p) => ({ id: p.id, name: p.name })));
         await this.state.storage.setAlarm(Date.now() + ROOM_TTL_MS);
         this.broadcast({ t: "start", seed: msg.seed >>> 0, laps: msg.laps, players });
         return;
@@ -199,9 +219,22 @@ export class Kart3Room {
       }
       case "snap":
       case "event": {
-        // host → everyone else (payload opaque)
+        // host → everyone else, or a single peer when msg.to is set
         if (!me.host) return;
-        this.broadcast(msg, me.id);
+        if (typeof msg.to === "number") this.sendTo((a) => a.id === msg.to, msg);
+        else this.broadcast(msg, me.id);
+        return;
+      }
+      case "rtc": {
+        // WebRTC signaling (offer/answer/ICE) relayed peer→peer
+        if (typeof msg.to !== "number") return;
+        msg.from = me.id;
+        this.sendTo((a) => a.id === msg.to, msg);
+        return;
+      }
+      case "pp": {
+        // latency probe: echo straight back to the sender
+        ws.send(JSON.stringify({ t: "pp", ts: msg.ts }));
         return;
       }
     }


### PR DESCRIPTION
## What

Second milestone from `apps/kart3/VISION.md`: the relay becomes a fallback. Peers race over **direct WebRTC DataChannels**, your kart is **exactly where you see it** on every screen, and **dropping mid-race no longer ends your race** — you reconnect and your kart is handed back from the AI that was keeping it warm.

### WebRTC fast path (relay still under it)
- Host opens one **unordered/unreliable DataChannel per client, pre-warmed from the lobby** so it's live before GO. SDP/ICE signaling rides the existing Room DO (`rtc` messages).
- Snapshots are **dual-sent** (WS relay broadcast + every open channel) and clients **dedupe by tick — the fastest transport wins**. Inputs go P2P when open, relay otherwise. A pair that can't traverse NAT just keeps working on the relay; no TURN server needed.
- Same-WiFi phones get LAN-direct paths automatically (the in-person play goal).

### Client-authoritative pose (fixes M1's biggest flaw)
M1's host simulated client karts from ~50–150ms-stale steering, scrubbing speed their owners never saw, then tugged them backward. Now input packets carry the own-kart pose: the host lerp-applies it (`updateRemoteKart`), keeps authority over **items, laps, ranks, bonks and box pickups**, clamps it to the track, and treats those karts as immovable in collisions. The client-side ease-back is gone (the host echo is just your own delayed pose) — only a >45-unit emergency snap remains. Client rocket starts work again. Fine at this trust level (friends + casual matchmaking), per VISION.

### Mid-race rejoin
- DO stores the race's **seats** (id + name); a `hello` during the racing phase whose name matches a vacant seat reclaims it (`welcome.rejoin`).
- Clients auto-retry 4× on socket loss — your kart keeps driving locally while remotes freeze on the last snapshot — then the host converts your AI stand-in back to remote and sends a targeted `rejoin-state` (seed + roster + full `netSnapshot`). A cold rejoin after a page reload rebuilds the whole race and restores state.

### Connection indicator
Small HUD pill: clients show `P2P · 12ms` (green) or `RELAY · 48ms` (WS RTT via DO echo, doubles as keepalive); the host shows its open-channel count.

## Verification (wrangler dev + THREE headless Chrome instances)
- Host (Matt) + P2P client (Bob) + **forced-relay** client (Cleo, `__noRtc`) raced a full event: Bob negotiated P2P from the lobby, Cleo stayed on relay, both raced identically.
- Pose authority: host-vs-client divergence **1.5 units** with exact progress agreement (M1 had systematic lag).
- Killed Cleo's socket mid-race → auto-rejoined in ~2s, kart converted AI→remote, kept racing to the finish.
- Results with all three names on all three screens; netInd labels correct (`P2P · 1ms` / `RELAY · 1ms`); **zero exceptions on all pages**. Solo regression green on a quiet machine.
- Documented CI caveat: under SwiftShader CPU contention the host page's sim runs slower than wall-time while pose-authoritative clients stay real-time — load distortion, not netcode; real phones at 60fps don't exhibit it.

## Not in this PR (next: M3)
Quick-race matchmaking queue, names/avatars polish. Voice (M5) still rides these same PeerConnections later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)