### PR TITLE
kart3: flip default steering direction and fit title screen

### DIFF
--- a/apps/kart3/index.html
+++ b/apps/kart3/index.html
@@ -248,6 +248,26 @@
         #sensSlider { width: 130px; accent-color: #6fe0ff; }
         .set-hint { font-size: 10px; opacity: 0.55; margin-top: 4px; }
 
+        /* Short viewports (landscape phones): tighten the menus so the title
+           screen fits without vertical scrolling. */
+        @media (max-height: 470px) {
+            .screen { justify-content: flex-start; padding-top: calc(env(safe-area-inset-top) + 8px);
+                padding-bottom: calc(env(safe-area-inset-bottom) + 8px); }
+            .menu-row { gap: 22px; }
+            .logo { font-size: 40px; }
+            .tag { margin-top: 3px; }
+            .trackname { margin-top: 5px; }
+            .bestline { margin-top: 2px; }
+            .section-label { margin: 2px 0 5px; }
+            .btn { margin-top: 10px; padding: 10px 38px; font-size: 18px; }
+            .online-row { margin-top: 8px; }
+            #netStatus { margin-top: 4px; min-height: 0; }
+            #settingsBtn { margin-top: 6px !important; }
+            #settingsPane { margin-top: 6px; padding: 9px 14px; }
+            .hint { margin-top: 8px; line-height: 1.4; }
+            .loader { margin-top: 8px; }
+        }
+
         /* Lobby */
         #roomCode { font-size: 52px; font-weight: 900; font-style: italic; letter-spacing: 8px; line-height: 1;
             margin: 4px 0 2px;
@@ -3973,7 +3993,9 @@
             });
         }
         function computeSteer() {
-            steerInput = clamp(touchSteer * (steerReversed ? -1 : 1) + keySteer, -1, 1);
+            // Standard (default) is the former "reversed" slide direction; the
+            // Reversed option restores the old base mapping.
+            steerInput = clamp(touchSteer * (steerReversed ? 1 : -1) + keySteer, -1, 1);
         }
         function sensToRange(v) { return Math.round(lerp(110, 36, clamp(v, 0, 100) / 100)); }
 


### PR DESCRIPTION
## Summary

Two changes to **Kart 3** (`apps/kart3/index.html`):

1. **Flip the steering modes.** The default **Standard** mode now uses what was previously the *Reversed* slide direction. Selecting **Reversed** restores the old base mapping. Implemented by flipping the sign in `computeSteer()` — this affects touch steering only; arrow keys stay absolute. The settings labels (Standard/Reversed) and hint text are unchanged since Reversed is still the opposite of Standard.

2. **Title screen fits without vertical scrolling.** Added a compact layout (`@media (max-height: 470px)`) that tightens menu spacing on short/landscape phone viewports — smaller logo, reduced margins on the tag/trackname/section labels/button/hint, and `justify-content: flex-start`.

## Verification

Measured start-screen overflow headlessly (Playwright/Chromium) at common landscape iPhone heights, before vs. after:

| Viewport | Before (overflow px) | After |
|----------|------|-------|
| 844×390  | 25   | 0 |
| 812×375  | 33   | 0 |
| 896×414  | 13   | 0 |
| 932×430  | 5    | 0 |

With driver + track cards injected to mimic the populated menu, both columns measure ≤301px (fit in 375). Screenshot confirmed the logo, START, online row, settings, hint, and both card grids are all visible with no clipping. Inline-script syntax checked via `new Function(...)`.

> Note: headless runs render in SwiftShader and couldn't fetch three.js from cdnjs in this environment, so the live 3D backdrop and card population were simulated — layout/overflow assertions are real.

https://claude.ai/code/session_01NiETsMkWcVjUe4KNPK4ouu

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiETsMkWcVjUe4KNPK4ouu)_