### PR TITLE
Kart 3: steering hint at thumb height

### DIFF
--- a/apps/kart3/index.html
+++ b/apps/kart3/index.html
@@ -128,7 +128,7 @@
         #stick.on { opacity: 1; }
         #stickDot { position: absolute; top: 50%; left: 50%; width: 34px; height: 34px; border-radius: 50%;
             transform: translate(-50%, -50%); background: rgba(143,214,255,0.85); box-shadow: 0 0 14px rgba(143,214,255,0.7); }
-        #steerHint { position: absolute; left: calc(env(safe-area-inset-left) + 20px); bottom: calc(env(safe-area-inset-bottom) + 110px);
+        #steerHint { position: absolute; left: calc(env(safe-area-inset-left) + 24px); bottom: calc(env(safe-area-inset-bottom) + 14px);
             font-size: 11px; font-weight: 700; letter-spacing: 1px; opacity: 0.45; }
 
         /* Drift charge bar: centered above the minimap */


### PR DESCRIPTION
One-liner: the "◀ SLIDE THUMB TO STEER ▶" hint sat 110px up the screen — it now sits at the bottom-left edge, right under where the steering thumb actually rests.

Verified with mid-race screenshots at 844×390, 932×430 and 780×360: positioned in the thumb zone, clear of the centered minimap, zero exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)