### PR TITLE
Kart 3: remove the ← Apps button

### DIFF
--- a/apps/kart3/index.html
+++ b/apps/kart3/index.html
@@ -477,7 +477,6 @@
                 <button class="btn" id="againBtn">RACE AGAIN</button>
                 <div class="btn-row">
                     <button class="btn secondary" id="menuBtn">Menu</button>
-                    <a href="../" style="text-decoration:none;"><button class="btn secondary">← Apps</button></a>
                 </div>
             </div>
             <div class="menu-right">


### PR DESCRIPTION
Removes the '← Apps' launcher link from the results screen, per request. Menu/Race-again flow unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)