### PR TITLE
Kart 3: online version gate + visible app version (bumped every PR)

### DIFF
--- a/apps/kart3/CLAUDE.md
+++ b/apps/kart3/CLAUDE.md
@@ -4,6 +4,14 @@ Project notes for **Kart 3** (`apps/kart3/index.html`). Read before changing it.
 Repo-root `CLAUDE.md` covers site-wide rules; `apps/kart2/CLAUDE.md` documents
 the headless render harness in depth and several lessons this app inherits.
 
+## ⚠ Version bump — EVERY PR
+
+**Increment `APP_VER` in `index.html` once per PR.** It is displayed on the
+title screen (bottom-right) and is the manual half of `NET_VER`, the online
+version gate: two phones only share a room when their tags match, so a
+forgotten bump lets a stale build pair with a new one and desync (the hash
+half auto-covers track geometry + core physics, but nothing else).
+
 ## What this is
 
 A single self-contained `index.html` — a **landscape** (horizontal) 3D kart

--- a/apps/kart3/VISION.md
+++ b/apps/kart3/VISION.md
@@ -121,8 +121,10 @@ Add:
   standings. Host migration is a v2 nicety (snapshot + DO re-elects).
 - **Backgrounded phone** (call/notification): treat as disconnect+rejoin;
   never pause the shared race.
-- **Versioning**: room advertises a protocol/app version; mismatched clients
-  get a "refresh to update" message instead of a desync.
+- **Versioning** ✅ *(shipped)*: every `hello` carries `NET_VER` (= `APP_VER`,
+  bumped per PR, + a hash of track/physics data); the room rejects joiners
+  whose tag differs from the host's with a "close and reopen the app"
+  message instead of desyncing.
 
 ### Voice (stretch)
 

--- a/apps/kart3/index.html
+++ b/apps/kart3/index.html
@@ -219,6 +219,9 @@
         .hint { margin-top: 14px; font-size: 12px; line-height: 1.55; opacity: 0.8; max-width: 320px; }
         .hint b { color: #ffd54a; }
         .loader { font-size: 13px; opacity: 0.7; margin-top: 14px; letter-spacing: 2px; }
+        #appVer { position: absolute; right: calc(env(safe-area-inset-right) + 12px);
+            bottom: calc(env(safe-area-inset-bottom) + 8px); font-size: 11px; font-weight: 700;
+            letter-spacing: 1px; opacity: 0.4; font-variant-numeric: tabular-nums; }
 
         /* ===== Online play ===== */
         .online-row { margin-top: 12px; display: flex; gap: 6px; align-items: center; flex-wrap: wrap;
@@ -400,6 +403,7 @@
 
     <!-- Start screen -->
     <div class="screen" id="startScreen">
+        <div id="appVer"></div>
         <div class="menu-row">
             <div class="menu-left">
                 <div class="logo">KART<span class="three">3</span></div>
@@ -790,6 +794,26 @@
         const INPUT_MS = 33;           // client input send interval (~30Hz)
         const INTERP_MS = 130;         // remote karts render this far in the past
 
+        // ---------------------------------------------------------------
+        // Version gate. Two phones on different builds desync horribly
+        // (different track geometry, positional snapshot format), so rooms
+        // only pair clients whose tag matches the host's. NET_PROTO is
+        // bumped by hand for snapshot/protocol changes; the hash part
+        // auto-changes whenever track data or core physics constants do.
+        // ---------------------------------------------------------------
+        // ⚠ APP_VER: increment ONCE PER PR (CLAUDE.md rule). Shown on the
+        // title screen and folded into NET_VER, so any two different builds
+        // refuse to share a room.
+        const APP_VER = 1;
+        function hash32(str) {
+            let h = 2166136261 >>> 0;
+            for (let i = 0; i < str.length; i++) { h ^= str.charCodeAt(i); h = Math.imul(h, 16777619); }
+            return (h >>> 0).toString(36);
+        }
+        const NET_VER = 'v' + APP_VER + '.' + hash32(JSON.stringify(
+            [N, MAX_SPEED, ACCEL, BOOST_CAP, TURN_BASE, TURN_FADE, GRAV,
+             TRACKS.map((t) => [t.ctrl, t.gapLen, t.tunnelIn, t.tunnelOut, t.jumpAt])]));
+
         const net = {
             mode: 'solo',              // 'solo' | 'host' | 'client'
             ws: null, connected: false,
@@ -910,7 +934,7 @@
             ws.onopen = () => {
                 net.connected = true;
                 net.myCharIdx = selectedCharIdx;
-                ws.send(JSON.stringify({ t: 'hello', name: myName(), charIdx: net.myCharIdx }));
+                ws.send(JSON.stringify({ t: 'hello', name: myName(), charIdx: net.myCharIdx, ver: NET_VER }));
                 // doubles as keepalive and RTT probe
                 net.pingTimer = setInterval(() => wsSend({ t: 'pp', ts: performance.now() }), 2500);
             };
@@ -957,6 +981,7 @@
                 return;
             }
             const wasRacing = net.racing && state !== 'menu';
+            const recentError = net.lastErrorAt && performance.now() - net.lastErrorAt < 2000;
             netReset();
             if (wasRacing) {
                 flash('CONNECTION LOST', '#ff9a9a');
@@ -964,7 +989,8 @@
             } else {
                 dom.lobbyScreen.classList.add('hidden');
                 dom.startScreen.classList.remove('hidden');
-                netStatusMsg('Disconnected from room', true);
+                // keep a just-shown server error (e.g. version mismatch) visible
+                if (!recentError) netStatusMsg('Disconnected from room', true);
             }
         }
         function netHandle(msg) {
@@ -1056,6 +1082,7 @@
                     }
                     break;
                 case 'error':
+                    net.lastErrorAt = performance.now();
                     if (state === 'menu') {
                         if (dom.lobbyScreen.classList.contains('hidden')) netStatusMsg(msg.msg, true);
                         else dom.lobbyMsg.textContent = msg.msg;
@@ -4646,6 +4673,7 @@
             buildSelectionUI();
             resetRace();
             dom.loadMsg.style.display = 'none';
+            document.getElementById('appVer').textContent = 'v' + APP_VER;
             try { dom.nameInput.value = localStorage.getItem('kart3_name') || ''; } catch (e) {}
             dom.startBtn.addEventListener('click', startGame);
             dom.againBtn.addEventListener('click', () => {

--- a/worker/src/kart3room.ts
+++ b/worker/src/kart3room.ts
@@ -18,6 +18,7 @@ type Attachment = {
   charIdx: number;
   ready: boolean;
   host: boolean;
+  ver: string;
 };
 
 type Phase = "lobby" | "racing";
@@ -25,6 +26,11 @@ type Phase = "lobby" | "racing";
 const MAX_PLAYERS = 4;
 const ROOM_TTL_MS = 45 * 60 * 1000; // hard kill switch for abandoned rooms
 const NAME_MAX = 12;
+
+function sanitizeVer(raw: unknown): string {
+  // old clients send no version — 'legacy' never matches a tagged build
+  return String(raw ?? "legacy").slice(0, 24);
+}
 
 function sanitizeName(raw: unknown): string {
   const s = String(raw ?? "").replace(/[<>&"'`]/g, "").trim();
@@ -138,7 +144,16 @@ export class Kart3Room {
           ws.close(1008, "race in progress");
           return;
         }
-        const a: Attachment = { id: seat.id, name: seat.name, charIdx: 0, ready: true, host: false };
+        const hostP0 = players.find((p) => p.host);
+        if (hostP0 && sanitizeVer(msg.ver) !== hostP0.ver) {
+          ws.send(JSON.stringify({
+            t: "error",
+            msg: "Game versions differ — close the app fully and reopen it, then rejoin",
+          }));
+          ws.close(1008, "version mismatch");
+          return;
+        }
+        const a: Attachment = { id: seat.id, name: seat.name, charIdx: 0, ready: true, host: false, ver: sanitizeVer(msg.ver) };
         ws.serializeAttachment(a);
         const code0 = (await this.state.storage.get<string>("code")) || "";
         ws.send(JSON.stringify({ t: "welcome", id: a.id, host: false, code: code0, rejoin: true }));
@@ -152,6 +167,17 @@ export class Kart3Room {
         ws.close(1008, "room full");
         return;
       }
+      // version gate: different builds desync (track geometry, snapshot
+      // format) — only pair clients matching the host's version
+      const hostP = players.find((p) => p.host);
+      if (hostP && sanitizeVer(msg.ver) !== hostP.ver) {
+        ws.send(JSON.stringify({
+          t: "error",
+          msg: "Game versions differ — close the app fully and reopen it on the older phone, then rejoin",
+        }));
+        ws.close(1008, "version mismatch");
+        return;
+      }
       const used = new Set(players.map((p) => p.id));
       let id = 0;
       while (used.has(id)) id++;
@@ -161,6 +187,7 @@ export class Kart3Room {
         charIdx: Number.isInteger(msg.charIdx) ? Math.max(0, Math.min(7, msg.charIdx)) : 0,
         ready: false,
         host: players.length === 0,
+        ver: sanitizeVer(msg.ver),
       };
       ws.serializeAttachment(a);
       const code = (await this.state.storage.get<string>("code")) || "";


### PR DESCRIPTION
## The question that prompted this

*"What happens today if you play online with a friend on different versions?"* — Answer: they **join fine, then desync horribly**. Each client builds the track from its own data (tonight's Volcano Bay rework changed the entire layout), karts are pose-authoritative so the host watches the friend drive through hills, their laps count against the wrong centerline, and the positional snapshot format silently garbles on older builds. With GitHub Pages caching (~10 min) and iOS home-screen PWAs keeping instances alive for days, mismatches were the *expected* case after an evening of merges. VISION.md flagged this for M4; now it's real.

## The gate

- `NET_VER = 'v' + APP_VER + '.' + hash(track geometry + core physics constants)` — the hash auto-changes when gameplay data changes; `APP_VER` covers everything else.
- Every `hello` carries it; the Room DO **rejects joiners whose tag differs from the host's**: *"Game versions differ — close the app fully and reopen it on the older phone, then rejoin."* Same gate on the mid-race rejoin path. Old clients send no tag → `legacy` → never matches a tagged build (the rollout case handles itself).
- Also fixed: the generic "Disconnected from room" was overwriting server error messages on socket close — the mismatch explanation now stays visible.

## The visible version

`APP_VER` (now **v1**) shows on the title screen bottom-right, and **must be bumped once per PR** — enforced by a rule at the top of `apps/kart3/CLAUDE.md`. Because it feeds `NET_VER`, every PR automatically strengthens the gate; "which build are you on?" is now answerable by glancing at the title screen.

## Verification
Live against `wrangler dev` with two browsers: a spoofed stale build is rejected with the friendly message and never enters the roster (host roster stays clean); clearing the spoof joins normally. Solo regression green; worker typecheck clean; zero exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)