### PR TITLE
Kart 3: MKDS drift sparks instead of a charge bar

### DIFF
--- a/apps/kart3/index.html
+++ b/apps/kart3/index.html
@@ -804,7 +804,7 @@
         // ⚠ APP_VER: increment ONCE PER PR (CLAUDE.md rule). Shown on the
         // title screen and folded into NET_VER, so any two different builds
         // refuse to share a room.
-        const APP_VER = 1;
+        const APP_VER = 2;
         function hash32(str) {
             let h = 2166136261 >>> 0;
             for (let i = 0; i < str.length; i++) { h ^= str.charCodeAt(i); h = Math.imul(h, 16777619); }


### PR DESCRIPTION
## What

The drift-charge **progress bar is gone**. Charge feedback now lives where Mario Kart DS puts it — at the rear wheels:

- **White wisps** while charging → **blue → orange → pink** spark streams as the three mini-turbo levels arm (the familiar MK color ladder)
- Each level-up fires a **spark burst + rising chirp + haptic buzz**, so you feel the stage change without glancing at any UI
- Sparks are deliberately small, sparse and short-lived. The first cut emitted a glowing cloud that swallowed the kart (screenshot-caught); tuned down to crisp wheel clusters, with the tuning constraint documented in CLAUDE.md so it doesn't regress

`APP_VER` 1 → 2 per the new every-PR rule (this also rotates the online version gate).

## Verification
- Held a scripted drift around the sweep and screenshot each stage: blue/orange/pink clusters crisp at the wheels, kart fully visible, no HUD bar
- Stage-change burst/chirp wiring exercised in the same run (audio code-reviewed, inaudible in CI)
- Full-race regression green; zero exceptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)