### PR TITLE
Kart3: centered settings modal + fix bottom safe-area bar color

### DIFF
--- a/apps/kart3/index.html
+++ b/apps/kart3/index.html
@@ -7,7 +7,7 @@
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="Kart 3">
-    <meta name="theme-color" content="#071a2e">
+    <meta name="theme-color" content="#04101e">
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <!-- Home-screen install: apple-touch-icon for iOS, manifest for Android
          (the manifest also locks landscape orientation on Android installs) -->
@@ -18,7 +18,10 @@
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
         html, body {
-            height: 100%; width: 100%; overflow: hidden; background: #071a2e;
+            /* #04101e = bottom stop of every screen gradient: the page bg is
+               what iOS shows in the safe-area strips, so it must match or a
+               mismatched bar appears along the home indicator */
+            height: 100%; width: 100%; overflow: hidden; background: #04101e;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             color: #fff; -webkit-user-select: none; user-select: none; touch-action: none;
             position: fixed; inset: 0;   /* keep iOS standalone PWA truly fullscreen, no rubber-banding */
@@ -29,7 +32,7 @@
         /* ===== Rotate-to-landscape overlay (game is landscape-only) ===== */
         #rotate { position: fixed; inset: 0; z-index: 100; display: none; flex-direction: column;
             align-items: center; justify-content: center; gap: 14px; text-align: center;
-            background: linear-gradient(180deg, #0a2240, #05101f); }
+            background: linear-gradient(180deg, #0a2240, #04101e); }
         #rotate .ph { font-size: 64px; animation: rot 1.6s ease-in-out infinite; }
         @keyframes rot { 0%,20% { transform: rotate(0deg);} 60%,100% { transform: rotate(90deg);} }
         #rotate .msg { font-size: 18px; font-weight: 800; letter-spacing: 1px; }
@@ -239,11 +242,22 @@
         .mini-btn:disabled { opacity: 0.45; }
         #netStatus { margin-top: 8px; font-size: 12px; font-weight: 700; color: #ffd54a; min-height: 16px; }
 
-        /* Settings pane */
-        #settingsPane { display: none; margin-top: 10px; padding: 12px 16px; border-radius: 14px;
-            background: rgba(6,14,30,0.55); border: 1.5px solid rgba(255,255,255,0.15);
-            pointer-events: auto; width: 100%; max-width: 320px; }
+        /* Settings modal — floats centered over the title screen (inline
+           expansion used to push the menu into a scroll) */
+        #settingsBackdrop { display: none; position: fixed; inset: 0; z-index: 30;
+            background: rgba(2,8,18,0.6); pointer-events: auto; }
+        #settingsBackdrop.open { display: block; }
+        #settingsPane { display: none; position: fixed; left: 50%; top: 50%;
+            transform: translate(-50%, -50%); z-index: 31;
+            width: min(360px, calc(100vw - 36px)); padding: 12px 18px 16px; border-radius: 16px;
+            background: linear-gradient(180deg, rgba(24,46,86,0.97), rgba(7,15,32,0.97));
+            border: 1.5px solid rgba(255,255,255,0.18); box-shadow: 0 18px 48px rgba(0,0,0,0.55);
+            pointer-events: auto; }
         #settingsPane.open { display: block; }
+        .set-title { display: flex; align-items: center; justify-content: space-between;
+            font-size: 13px; font-weight: 900; letter-spacing: 2px; margin-bottom: 4px; }
+        #settingsClose { pointer-events: auto; background: none; border: none; color: #fff;
+            opacity: 0.6; font-size: 18px; font-weight: 700; padding: 2px 0 2px 12px; }
         .set-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin: 7px 0; }
         .set-label { font-size: 12px; font-weight: 700; opacity: 0.85; white-space: nowrap; }
         .seg2 { display: flex; border: 1.5px solid rgba(255,255,255,0.22); border-radius: 999px; overflow: hidden; }
@@ -268,7 +282,7 @@
             .online-row { margin-top: 8px; }
             #netStatus { margin-top: 4px; min-height: 0; }
             #settingsBtn { margin-top: 6px !important; }
-            #settingsPane { margin-top: 6px; padding: 9px 14px; }
+            #settingsPane { padding: 9px 14px 12px; }
             .hint { margin-top: 8px; line-height: 1.4; }
             .loader { margin-top: 8px; }
         }
@@ -420,7 +434,9 @@
                 </div>
                 <div id="netStatus"></div>
                 <button class="mini-btn" id="settingsBtn" style="margin-top:10px">⚙ SETTINGS</button>
+                <div id="settingsBackdrop"></div>
                 <div id="settingsPane">
+                    <div class="set-title">SETTINGS<button id="settingsClose">✕</button></div>
                     <div class="set-row">
                         <span class="set-label">Steering direction</span>
                         <div class="seg2" id="steerDirSeg">
@@ -569,6 +585,7 @@
             leaveBtn: $('leaveBtn'), lobbyMsg: $('lobbyMsg'), netInd: $('netInd'),
             trackPick: $('trackPick'), lobbyTracks: $('lobbyTracks'), raceStandings: $('raceStandings'),
             settingsBtn: $('settingsBtn'), settingsPane: $('settingsPane'),
+            settingsBackdrop: $('settingsBackdrop'), settingsClose: $('settingsClose'),
             steerDirSeg: $('steerDirSeg'), sensSlider: $('sensSlider'), diffSeg: $('diffSeg'),
             muteBtn: $('muteBtn'), itemBtn: $('itemBtn'), driftBtn: $('driftBtn'), pauseBtn: $('pauseBtn'),
             pauseScreen: $('pauseScreen'), resumeBtn: $('resumeBtn'), restartBtn: $('restartBtn'), quitBtn: $('quitBtn'),
@@ -804,7 +821,7 @@
         // ⚠ APP_VER: increment ONCE PER PR (CLAUDE.md rule). Shown on the
         // title screen and folded into NET_VER, so any two different builds
         // refuse to share a room.
-        const APP_VER = 2;
+        const APP_VER = 3;
         function hash32(str) {
             let h = 2166136261 >>> 0;
             for (let i = 0; i < str.length; i++) { h ^= str.charCodeAt(i); h = Math.imul(h, 16777619); }
@@ -4195,8 +4212,15 @@
                 if (document.hidden && state === 'racing' && !netActive()) pauseGame();
             });
 
-            // ---- settings pane ----
-            dom.settingsBtn.addEventListener('click', () => dom.settingsPane.classList.toggle('open'));
+            // ---- settings modal ----
+            const setSettingsOpen = (open) => {
+                dom.settingsPane.classList.toggle('open', open);
+                dom.settingsBackdrop.classList.toggle('open', open);
+            };
+            dom.settingsBtn.addEventListener('click', () =>
+                setSettingsOpen(!dom.settingsPane.classList.contains('open')));
+            dom.settingsClose.addEventListener('click', () => setSettingsOpen(false));
+            dom.settingsBackdrop.addEventListener('click', () => setSettingsOpen(false));
             const reflectSteerDir = () => {
                 dom.steerDirSeg.querySelectorAll('.seg-opt').forEach((b) =>
                     b.classList.toggle('active', b.dataset.v === (steerReversed ? '1' : '0')));

--- a/apps/kart3/manifest.webmanifest
+++ b/apps/kart3/manifest.webmanifest
@@ -6,8 +6,8 @@
   "scope": "/apps/kart3/",
   "display": "fullscreen",
   "orientation": "landscape",
-  "background_color": "#071a2e",
-  "theme_color": "#071a2e",
+  "background_color": "#04101e",
+  "theme_color": "#04101e",
   "icons": [
     { "src": "icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any" },
     { "src": "icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any" },


### PR DESCRIPTION
Two queued UI fixes in one PR.

## Settings modal
The ⚙ settings pane used to expand inline below the menu, pushing the title screen into a scroll. It's now a centered floating modal over a dimmed backdrop, with a ✕ button; tapping the backdrop also closes it.

## Bottom bar color (IMG_9376)
The portrait screenshot showed a lighter-blue bar along the home indicator: the page `html/body` background was `#071a2e` while the rotate overlay's gradient ended at `#05101f`, and iOS paints the bottom safe-area strip with the page background. Unified everything on `#04101e` (the bottom stop the title-screen gradient already used): page background, `theme-color`, manifest `background_color`/`theme_color`, and the rotate overlay gradient end.

`APP_VER` 2 → 3.

## Verification (headless CDP harness)
- Pixel probe: body background and rotate-gradient end stop are both `rgb(4,16,30)` — no seam possible.
- Modal probe: pane centered at (422,195) on an 844×390 viewport, backdrop shown, `scrollTop` stays 0; backdrop click and ✕ both close it. Screenshots attached in session.
- Race-start smoke: state=racing, no exceptions.
- Caveats: no real GPU/audio/touch in CI; the actual safe-area strip only exists on the phone — verified by color equality instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)