### PR TITLE
Launcher: Fable Kart tile uses its real Home Screen icon

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -344,7 +344,8 @@
         .app-racing { background: linear-gradient(135deg, #12c2e9, #c471ed); }
         .app-kart { background: linear-gradient(135deg, #2ecc40, #0074d9); }
         .app-kart2 { background: linear-gradient(135deg, #ff7a3c, #b06bff); }
-        .app-kart3 { background: linear-gradient(135deg, #1d6fe0, #ffd54a); }
+        /* Fable Kart uses its real Home Screen icon instead of an emoji tile */
+        .app-fablekart { background: url('fablekart/icon-192.png') center / cover; }
         .app-glide { background: linear-gradient(135deg, #4a90d9, #ff9e4a); }
         .app-seinfeld { background: linear-gradient(135deg, #7a1f1f, #f7c948); }
         .app-shooter { background: linear-gradient(135deg, #05010f, #ff4ddb 55%, #46f9ff); }
@@ -481,7 +482,7 @@
         </a>
 
         <a href="fablekart/" class="app-link">
-            <div class="app-icon app-kart3">🏝️</div>
+            <div class="app-icon app-fablekart"></div>
             <span class="app-name">Fable Kart</span>
         </a>
 


### PR DESCRIPTION
The launcher showed Fable Kart as a 🏝️ emoji on a blue/gold gradient while the Home Screen install icon is the rendered kart scene. The tile now uses `fablekart/icon-192.png` as a cover background, keeping the launcher's 70px rounded-tile styling.

No game changes, so no `APP_VER` bump (the version gate only cares about builds that can desync online play).

Verified with a headless 390×844 screenshot: the tile renders the kart icon with corners matching the other tiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)