### PR TITLE
Fable Kart: MK64-style jumbotron TV above the tunnel arch

### DIFF
--- a/apps/fablekart/CLAUDE.md
+++ b/apps/fablekart/CLAUDE.md
@@ -189,6 +189,12 @@ work, and don't regress these four seams.
   rotated planes sink/float — the start line vanished into the banked
   chicane (bankSlope at seg 0 is ≈ −0.13).
 - Road/curb ribbons are `side: THREE.DoubleSide` (winding faces down).
+- **Tunnel jumbotron** (`buildTV`, tunnel tracks only): MK64-style screen on
+  posts above the entrance arch. A broadcast cam mounted at the panel tracks
+  the LOCAL player's kart (auto-zoom ≈16u frame) and renders the scene to a
+  320×180 UnsignedByte RT every other frame in `animate()` — the screen mesh
+  hides during its own pass (feedback loop otherwise). Cosmetic only, never
+  touches the sim. Kart meshes are `k.mesh.group` (k.mesh is a wrapper).
 - Guardrails only where `roadY − terrainY(±(HALF_W+26)) > 4.5` (cliff drops).
 - Scenery (palms/rocks/stands/rails-posts/flags…) is baked via `bakeMerge()`
   into ONE vertex-colored mesh (single draw call). Kart bodies likewise: ~45

--- a/apps/fablekart/index.html
+++ b/apps/fablekart/index.html
@@ -735,6 +735,7 @@
         let bankSlope = [], slopeAng = [], curvSm = [], cornerCap = [], raceLine = [];
         let ds = 1, trackLen = 1;
         let tunnelA = -1, tunnelB = -1, jumpSeg = 0;
+        let tvScreen = null, tvLive = null, tvCam = null, tvRT = null, tvFrameNo = 0;
         let gapA = -1, gapB = -1, lavaGapY = 0;   // road gap (lava below) — see Volcano Bay
         let gapMidX = 0, gapMidZ = 0;
         let lavaMats = [], craterLight = null;
@@ -821,7 +822,7 @@
         // ⚠ APP_VER: increment ONCE PER PR (CLAUDE.md rule). Shown on the
         // title screen and folded into NET_VER, so any two different builds
         // refuse to share a room.
-        const APP_VER = 5;
+        const APP_VER = 6;
         function hash32(str) {
             let h = 2166136261 >>> 0;
             for (let i = 0; i < str.length; i++) { h ^= str.charCodeAt(i); h = Math.imul(h, 16777619); }
@@ -2232,6 +2233,51 @@
             }
         }
 
+        // MK64-style jumbotron above the tunnel entrance: a broadcast camera
+        // mounted at the screen tracks the LOCAL player's kart (each phone is
+        // its own star) and renders to a small texture every other frame.
+        // Cosmetic only — nothing here touches the sim, so it can't desync.
+        function buildTV() {
+            if (tvRT) { tvRT.dispose(); tvRT = null; }
+            tvScreen = null; tvLive = null; tvCam = null;
+            if (tunnelA < 0) return;   // only tracks with a tunnel get one
+            const c = centerline[tunnelA], t = tangents[tunnelA];
+            const dir = new THREE.Vector3(-t.x, 0, -t.z).normalize();   // toward oncoming racers
+            const baseY = roadY(tunnelA, 0);
+            const W = 20, H9 = 11.25, SHELL_H = 19;
+
+            // UnsignedByte RT (iOS-safe default); 16:9 to match the panel
+            tvRT = new THREE.WebGLRenderTarget(320, 180, { generateMipmaps: false });
+            tvRT.texture.minFilter = THREE.LinearFilter;
+
+            const g = new THREE.Group();
+            g.position.set(c.x, baseY + SHELL_H + 4 + H9 / 2, c.z);
+            g.rotation.y = Math.atan2(dir.x, dir.z);
+            g.rotateX(-0.08);   // slight down-tilt toward the approach
+
+            const frame = new THREE.Mesh(new THREE.BoxGeometry(W + 1.8, H9 + 1.8, 1.4),
+                new THREE.MeshLambertMaterial({ color: 0x141a26 }));
+            g.add(frame);
+            tvScreen = new THREE.Mesh(new THREE.PlaneGeometry(W, H9),
+                new THREE.MeshBasicMaterial({ map: tvRT.texture }));
+            tvScreen.position.z = 0.75;
+            g.add(tvScreen);
+            tvLive = new THREE.Mesh(new THREE.BoxGeometry(0.9, 0.9, 0.4),
+                new THREE.MeshBasicMaterial({ color: 0xff2b2b }));
+            tvLive.position.set(-(W + 1.8) / 2 + 1.3, (H9 + 1.8) / 2 - 1.1, 0.6);
+            g.add(tvLive);
+            const postMat = new THREE.MeshLambertMaterial({ color: 0x2a3242 });
+            for (const sx of [-(W / 2 - 2.5), W / 2 - 2.5]) {
+                const post = new THREE.Mesh(new THREE.BoxGeometry(1.5, 9, 1.5), postMat);
+                post.position.set(sx, -(H9 / 2 + 3.5), 0);   // sinks into the headland rock
+                g.add(post);
+            }
+            world.add(g);
+
+            tvCam = new THREE.PerspectiveCamera(30, 16 / 9, 1.5, 2600);
+            tvCam.position.set(g.position.x + dir.x * 2, g.position.y + 1.5, g.position.z + dir.z * 2);
+        }
+
         // ===================================================================
         //  START AREA + SCENERY (mostly baked into one merged mesh)
         // ===================================================================
@@ -2546,6 +2592,7 @@
             buildLava();
             buildRoad();
             buildTunnel();
+            buildTV();
             buildScenery();
             buildBoostPads();
             buildItemBoxes();
@@ -4670,6 +4717,27 @@
             }
 
             updateParticles(dt);
+
+            // tunnel jumbotron: broadcast cam → texture at half framerate.
+            // The screen hides during its own render pass (a camera pointed
+            // back at the TV would otherwise create a feedback loop).
+            if (tvScreen && (state === 'racing' || state === 'countdown' || state === 'finished')) {
+                tvFrameNo++;
+                if (tvFrameNo % 2 === 0) {
+                    const m = player.mesh.group.position;
+                    const d = Math.max(tvCam.position.distanceTo(m), 14);
+                    tvCam.fov = clamp(2 * Math.atan(8 / d) * 180 / Math.PI, 6, 42);   // auto-zoom framing ~16u around the kart
+                    tvCam.updateProjectionMatrix();
+                    tvCam.lookAt(m.x, m.y + 1.6, m.z);
+                    tvScreen.visible = false;
+                    renderer.setRenderTarget(tvRT);
+                    renderer.render(scene, tvCam);
+                    renderer.setRenderTarget(null);
+                    tvScreen.visible = true;
+                }
+                tvLive.visible = Math.sin(clock.elapsedTime * 5) > -0.4;
+            }
+
             renderer.render(scene, camera);
 
             if (!dprAdjusted) {


### PR DESCRIPTION
Trackside TV, Luigi Raceway style: a jumbotron on posts above the Coral Cliffs tunnel entrance shows a **live feed of your kart** wherever you are on the track.

## How it works
- `buildTV()` (tunnel tracks only) mounts a framed 20×11 screen + posts above the entrance arch, facing oncoming racers, with a blinking red LIVE lamp.
- A broadcast `PerspectiveCamera` mounted at the panel `lookAt`s the local player's kart each update with auto-zoom (≈16u framing box, fov clamped 6–42°) — proper telephoto tracking as you drive away.
- Renders the scene to a 320×180 `WebGLRenderTarget` every other frame (UnsignedByte default — the iOS-safe choice per the HalfFloat lesson). The screen mesh hides during its own render pass to prevent a feedback loop.
- Online: each phone's TV stars its own kart. Purely render-side — zero sim/netcode impact.
- Volcano Bay has no tunnel → no TV, verified no-op.

`APP_VER` 5 → 6.

## Verification (headless CDP)
- RT pixel readback: feed non-black and changing between samples (live), zero exceptions.
- Free-cam screenshots: arch + TV from the approach; close-up shows the kart centered in the feed with the boost-pad chevrons behind it.
- Full 1-lap regression (drive2): finish, results, pause/resume, jump airborne, snapshot round-trip, race-again — all pass with the TV rendering.
- Caveat: SwiftShader colors are washed out headless; perf impact not measurable in CI (half-rate 320×180 pass, few draw calls — worth a feel-check on the phone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)