### PR TITLE
Fix permanent boost for online clients (boostTimer round-trip ratchet)

### DIFF
--- a/apps/fablekart/index.html
+++ b/apps/fablekart/index.html
@@ -939,7 +939,7 @@
         // ⚠ APP_VER: increment ONCE PER PR (CLAUDE.md rule). Shown on the
         // title screen and folded into NET_VER, so any two different builds
         // refuse to share a room.
-        const APP_VER = 20;
+        const APP_VER = 21;
         function hash32(str) {
             let h = 2166136261 >>> 0;
             for (let i = 0; i < str.length; i++) { h ^= str.charCodeAt(i); h = Math.imul(h, 16777619); }
@@ -1091,7 +1091,7 @@
             net.players = []; net.racePlayers = [];
             net.myReady = false; net.racing = false; net.rejoinTries = 0;
             net.remoteCtrl = {}; net.snaps = []; net.fireCount = 0;
-            net.lastSnapTick = 0; net.pingMs = 0; net._itemKey = '';
+            net.lastSnapTick = 0; net.pingMs = 0; net._itemKey = ''; net._lastSnapBoost = 0;
             clearGhosts();
             dom.pauseBtn.style.display = '';
             dom.netInd.classList.remove('on');
@@ -1340,7 +1340,7 @@
         }
         function endOnlineRaceToLobby() {
             net.racing = false;
-            net.snaps = []; net.remoteCtrl = {}; net.lastSnapTick = 0;
+            net.snaps = []; net.remoteCtrl = {}; net.lastSnapTick = 0; net._lastSnapBoost = 0;
             clearGhosts();
             dom.netInd.classList.remove('on');
             stopMusic();
@@ -1507,7 +1507,18 @@
                     if (sb.gooT > k.gooT) { k.gooT = sb.gooT; sfxGoo(); flash('GOO!', '#b06bff'); }
                     if (sb.shrinkT > k.shrinkT) k.shrinkT = sb.shrinkT;
                     k.shieldTimer = sb.shieldTimer;
-                    k.boostTimer = Math.max(k.boostTimer, sb.boostTimer);
+                    // Adopt host-granted boosts (items, start-boost) on their
+                    // RISING EDGE only; pad/drift boosts are predicted locally
+                    // and decay locally. We must NOT Math.max the snapshot in
+                    // every frame: the host echoes our own reported boostTimer
+                    // (updateRemoteKart), and that echo is a full round-trip
+                    // stale — hence always larger than our decaying local
+                    // value — so maxing it ratcheted the timer back up forever
+                    // (boost for the entire race, client-side only).
+                    if (sb.boostTimer > (net._lastSnapBoost || 0) + 0.05 && sb.boostTimer > k.boostTimer) {
+                        k.boostTimer = sb.boostTimer;
+                    }
+                    net._lastSnapBoost = sb.boostTimer;
                     k.rank = sb.rank;
                     const itemKey = (sb.item || '') + ':' + sb.itemCharges + ':' + (sb.itemRolling > 0 ? 1 : 0);
                     if (net._itemKey !== itemKey) { net._itemKey = itemKey; updateItemButton(); }


### PR DESCRIPTION
## The bug
You had boost for an entire online race (you were the client; the other player hosted). Reproducible with any real ping.

## Root cause — a feedback ratchet on the client's own `boostTimer`
1. The client predicts pad/drift boosts locally and sends its `boostTimer` to the host in every pose packet (`netClientFrame`, `p[7]`).
2. The host **echoes it back**: `updateRemoteKart` does `k.boostTimer = Math.max(k.boostTimer, rc.p[7])` and broadcasts it in snapshots.
3. The client **re-adopts that echo**: `clientApplySnaps` did `k.boostTimer = Math.max(k.boostTimer, sb.boostTimer)`.

`boostTimer` only ever *decreases*, but the echo is a full **round-trip stale** copy — so it's always **larger** than the client's current value. `Math.max`-ing it in every snapshot ratchets the timer back up faster than `dt` drains it. With real latency it never reaches 0 → **boost for the whole match**. Host-only by construction (the host's own kart never round-trips), which is exactly why it hit you and not the host.

## Fix
The client now adopts host-granted boosts (items, rocket-start) on their **rising edge** only, and lets its local prediction own the decay — it never `Math.max`es its own delayed echo back in. The host side is unchanged: its echo now simply follows the client's freely-decaying value, and other clients use plain assignment (never ratcheted). Tracker is reset on net-reset and race→lobby so a stale value can't suppress the next race's first boost.

## Verification
- **Numerical round-trip sim** (faithful: 60Hz local decay, 30Hz pose send, host `Math.max` echo, 12Hz snapshots, 80ms RTT). A single 1.6s item boost granted at t=0.5s:
  - OLD: boost still **1.08** a second+ after it should have ended (pins permanently under higher ping)
  - NEW: decays to **0** exactly ✓
- Solo full-race regression to results, zero exceptions (the fixed branch is client-only, can't run solo, but confirms no shared-code regression).
- I couldn't spin up the full 2-browser WS rig this pass — worth one online race to confirm in the wild, but the mechanism and fix are unambiguous.

`APP_VER` 20 → 21.

Note: held toon PR #197 is now behind on `APP_VER` (it reserved 19); it'll rebump on its pending rebase regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)