### PR TITLE
Mouse steer: no button to hold (default ON for desktop)

### DIFF
--- a/apps/fablekart/index.html
+++ b/apps/fablekart/index.html
@@ -485,7 +485,7 @@
                             <button class="seg-opt" data-v="hard">Hard</button>
                         </div>
                     </div>
-                    <div class="set-hint">Reversed flips steering (thumb / keys / mouse). Mouse steer: move the cursor left/right to steer — smoother than the arrow keys.</div>
+                    <div class="set-hint">Reversed flips steering (thumb / keys / mouse). Mouse steer (on by default on desktop): just move the cursor left/right — no button to hold. Turn off for keys only.</div>
                 </div>
                 <div class="hint"><b>Left thumb</b> slides to steer · hold <b>DRIFT</b> in turns for turbo ·
                     grab <b>?</b> boxes · hold DRIFT on <b>GO!</b> for a rocket start</div>
@@ -915,7 +915,12 @@
                 if (!isNaN(tr) && TRACKS[tr]) currentTrackIdx = tr;
                 muted = localStorage.getItem('kart3_muted') === '1';
                 steerReversed = localStorage.getItem('kart3_steerrev') === '1';
-                mouseSteerOn = localStorage.getItem('kart3_mousesteer') === '1';
+                // default ON for desktop (a real mouse/trackpad), OFF for
+                // touch; an explicit saved choice always wins
+                const ms = localStorage.getItem('kart3_mousesteer');
+                mouseSteerOn = ms === null
+                    ? !(window.matchMedia && window.matchMedia('(pointer: coarse)').matches)
+                    : ms === '1';
                 const df = localStorage.getItem('kart3_diff');
                 if (DIFFS[df]) aiDifficulty = df;
                 const sv = parseInt(localStorage.getItem('kart3_sens'), 10);
@@ -953,7 +958,7 @@
         // ⚠ APP_VER: increment ONCE PER PR (CLAUDE.md rule). Shown on the
         // title screen and folded into NET_VER, so any two different builds
         // refuse to share a room.
-        const APP_VER = 24;
+        const APP_VER = 25;
         function hash32(str) {
             let h = 2166136261 >>> 0;
             for (let i = 0; i < str.length; i++) { h ^= str.charCodeAt(i); h = Math.imul(h, 16777619); }


### PR DESCRIPTION
Fixes your question — *"why do I have to hold the mouse button to steer?"*

## The cause
The no-hold position steering I added in #202 only activated when the **"Mouse steer (desktop)"** setting was ON — and I shipped it **off by default**. So unless you dug into Settings, the only mouse behavior was the *legacy click-and-drag-the-stick* path, which requires holding the button. That defeated the whole point of adding a smoother alternative to the arrow keys.

## The fix
`Mouse steer` now **defaults ON for desktop** — when the primary pointer is fine (`!matchMedia('(pointer: coarse)')`, i.e. a real mouse/trackpad) — and stays **off on touch** so phones are unaffected. An explicit saved choice always wins, and the Settings toggle remains for anyone who wants keys-only. Just move the cursor left/right; no button.

## Verification
- Desktop viewport, fresh prefs, **no mouse button held**: cursor far-left / centre / far-right → `+0.74 / 0 / -0.74`. Works without holding.
- Touch defaults off via the standard `(pointer: coarse)` query (correct on real phones; headless can't fully emulate the media query).
- Solo race regression clean, zero exceptions.

`APP_VER` → 25 (24 was the just-merged Spike Shell PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)