### PR TITLE
Neon City: recompose 'Midnight Drive' (less repetitive, same vibe)

### DIFF
--- a/apps/fablekart/index.html
+++ b/apps/fablekart/index.html
@@ -1011,7 +1011,7 @@
         // ⚠ APP_VER: increment ONCE PER PR (CLAUDE.md rule). Shown on the
         // title screen and folded into NET_VER, so any two different builds
         // refuse to share a room.
-        const APP_VER = 26;
+        const APP_VER = 27;
         function hash32(str) {
             let h = 2166136261 >>> 0;
             for (let i = 0; i < str.length; i++) { h ^= str.charCodeAt(i); h = Math.imul(h, 16777619); }
@@ -5619,15 +5619,37 @@
         // ---- Neon City: "Midnight Drive" — F# minor synthwave, pulsing 8ths
         //      (built from the chord progression to keep it compact)
         const CITY_SONG = (() => {
-            const prog = ['Fsm', 'D', 'A', 'E', 'Fsm', 'D', 'A', 'E', 'D', 'E', 'Fsm', 'Fsm'];
-            const chord = { Fsm: ['Fs', 'A', 'Cs'], D: ['D', 'Fs', 'A'], A: ['A', 'Cs', 'E'], E: ['E', 'Gs', 'B'] };
+            // F# minor synthwave, fully composed (no formula): a melody that
+            // develops over 12 distinct bars — statement (A), a C#m-coloured
+            // answer (B), then a high 16th-run climax that resolves (C).
+            const chord = { Fsm: ['Fs', 'A', 'Cs'], D: ['D', 'Fs', 'A'], A: ['A', 'Cs', 'E'], E: ['E', 'Gs', 'B'], Csm: ['Cs', 'E', 'Gs'] };
+            const prog = ['Fsm', 'D', 'A', 'E', 'Fsm', 'Csm', 'D', 'E', 'D', 'E', 'Fsm', 'E'];
+            const leadBars = [
+                ['Fs5', 0, 'A5', 0, 'Cs6', 0, 'A5', 0, 'Fs5', 0, 0, 0, 'E5', 0, 0, 0],
+                ['D5', 0, 'Fs5', 0, 'A5', 0, 'D6', 0, 'Cs6', 0, 'A5', 0, 'Fs5', 0, 0, 0],
+                ['A5', 0, 'Cs6', 0, 'E6', 0, 'Cs6', 0, 'A5', 0, 0, 0, 'E5', 0, 0, 0],
+                ['E5', 0, 'Gs5', 0, 'B5', 0, 'Gs5', 0, 'E5', 0, 'B4', 0, 0, 0, 0, 0],
+                ['Fs5', 0, 'A5', 'Cs6', 'E6', 0, 'Cs6', 0, 'A5', 'Fs5', 'A5', 0, 'Cs6', 0, 0, 0],
+                ['Cs5', 0, 'E5', 0, 'Gs5', 0, 'E5', 0, 'Cs6', 0, 'Gs5', 0, 'E5', 0, 0, 0],
+                ['D5', 0, 'Fs5', 0, 'A5', 0, 'Cs6', 0, 'D6', 0, 'Cs6', 0, 'A5', 'Fs5', 'D5', 0],
+                ['E5', 0, 'B5', 0, 'Gs5', 0, 'B5', 0, 'E6', 0, 0, 0, 0, 0, 0, 0],
+                ['D6', 0, 'Cs6', 'A5', 'Fs6', 0, 'D6', 0, 'A5', 'Cs6', 'D6', 0, 'Fs6', 0, 0, 0],
+                ['E6', 0, 'D6', 0, 'B5', 0, 'Gs5', 0, 'B5', 0, 'E6', 0, 'Gs5', 0, 0, 0],
+                ['Fs6', 0, 'E6', 0, 'Cs6', 0, 'A5', 0, 'Fs5', 0, 'A5', 'Cs6', 'E6', 0, 0, 0],
+                ['B5', 0, 'Gs5', 0, 'E5', 0, 'Gs5', 0, 'B5', 'Cs6', 'B5', 0, 'Gs5', 0, 0, 0],
+            ];
             const lead = [], bass = [], arp = [], stabs = [];
             prog.forEach((ch, bar) => {
-                const tri = chord[ch], r = tri[0], sec = bar < 4 ? 0 : bar < 8 ? 1 : 2;
-                bass.push(r + '2', 0, r + '2', 0, r + '3', 0, r + '2', 0, r + '2', 0, r + '2', r + '2', r + '3', 0, r + '2', 0);
-                for (let i = 0; i < 16; i++) arp.push(i % 2 === 0 ? tri[(i / 2) % 3] + (i < 8 ? '4' : '5') : 0);
-                lead.push(tri[0] + '5', 0, tri[2] + '5', 0, tri[1] + '5', 0, tri[0] + '5', 0,
-                    tri[2] + '5', 0, (sec ? tri[1] : tri[0]) + '5', 0, tri[0] + (sec === 2 ? '6' : '5'), 0, 0, 0);
+                const tri = chord[ch], r = tri[0], climax = bar >= 8;
+                lead.push(...leadBars[bar]);
+                // bass: steady octave-hop 8ths early; relentless driving 8ths in the climax
+                if (!climax) bass.push(r + '2', 0, r + '2', 0, r + '3', 0, r + '2', 0, r + '2', 0, r + '2', r + '2', r + '3', 0, r + '2', 0);
+                else bass.push(r + '2', 0, r + '2', r + '2', r + '2', 0, r + '2', 0, r + '3', 0, r + '2', r + '2', r + '3', r + '2', r + '3', 0);
+                // arp: triad on 8ths early, full driving 16ths through the climax
+                for (let i = 0; i < 16; i++) {
+                    const oct = i < 8 ? '4' : '5';
+                    arp.push(climax ? tri[i % 3] + oct : (i % 2 === 0 ? tri[(i / 2) % 3] + oct : 0));
+                }
                 stabs.push([tri[0] + '3', tri[1] + '3', tri[2] + '4']);
             });
             return { lead, bass, arp, stabs };


### PR DESCRIPTION
Follow-up to your note that the soundtrack felt repetitive — **city song only**, no randomness, freshly composed. (#205 having merged, this is a clean diff on master.)

## What changed
The old city loop was *generated from a single per-chord formula*, so every one of its 12 bars had the same shape — that's the repetitiveness. I replaced it with a **fully hand-composed** F# minor synthwave piece (still 100% deterministic — no `Math.random`):

- A melody that actually **develops**: an opening statement, a **C#m-coloured** answer section, then a **high 16th-note climax run** (bars 9–11) that resolves on a turnaround back into the loop.
- Bass evolves from steady octave-hop 8ths into **relentless driving 8ths** in the climax; the arp opens from 8ths to **full 16ths**.
- **Same vibe**: identical instruments (saw lead/bass, sine arp), tempo, key, and the four-on-the-floor drums — composed instead of formulaic.

Audio preview (full loop, rendered from the in-game data) sent in chat — compare to the old one.

## Verification
- Renders non-silent at a healthy level (RMS 0.032); Neon City race smoke, zero exceptions. `APP_VER` 26 → 27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)