### PR TITLE
Fable Kart: make haptics fire on iPhone (iOS switch hack)

### DIFF
--- a/apps/fablekart/CLAUDE.md
+++ b/apps/fablekart/CLAUDE.md
@@ -337,6 +337,14 @@ work, and don't regress these four seams.
 
 ## Gameplay conventions (several are explicit user preferences)
 
+- **Haptics — iOS uses a switch hack, NOT `navigator.vibrate`.** `navigator.vibrate()`
+  is a no-op on iPhone. The `vibrate(ms)` helper detects iOS and instead `.click()`s
+  a hidden native switch-styled checkbox (`#hapticSwitch`, kept off-screen but
+  RENDERED — `display:none` kills it), which fires the system selection tap (iOS
+  17.4+). It's a single fixed tap with no duration, so `ms` maps to a burst count
+  (light/medium/strong) and calls are rate-limited (~22ms). Android still honours
+  `navigator.vibrate(ms)`. The `<input switch>` is undocumented behaviour — may
+  break on future iOS; don't "fix" the helper back to plain `navigator.vibrate`.
 - **No spinouts, ever.** Hits = `bonkKart` (speed cut + hop, steering kept).
   Goo slows + wobbles but never removes control.
 - HUD layout (landscape, thumbs at bottom corners): big position +

--- a/apps/fablekart/index.html
+++ b/apps/fablekart/index.html
@@ -403,6 +403,14 @@
 <body>
     <div id="game"></div>
     <div id="speedlines"></div>
+    <!-- iOS programmatic-haptics hack (iOS 17.4+): navigator.vibrate is a no-op
+         on iPhone, but toggling a NATIVE switch-styled checkbox fires the system
+         selection tap. Must stay RENDERED (not display:none) to work, so it's
+         parked off-screen and made inert. Undocumented — may break on future iOS. -->
+    <label id="hapticSwitch" aria-hidden="true"
+           style="position:absolute;left:-9999px;top:0;width:1px;height:1px;opacity:0;pointer-events:none;overflow:hidden">
+        <input type="checkbox" switch tabindex="-1">
+    </label>
 
     <div id="rotate">
         <div class="ph">📱</div>
@@ -607,7 +615,28 @@
             return m + ':' + (sec < 10 ? '0' : '') + sec.toFixed(1);
         }
         function hx(n) { return '#' + n.toString(16).padStart(6, '0'); }
-        function vibrate(ms) { try { if (navigator.vibrate) navigator.vibrate(ms); } catch (e) {} }
+        // Haptics. Android honours navigator.vibrate(ms); iOS ignores it entirely,
+        // so there we toggle a native switch (see #hapticSwitch) which fires the
+        // system selection tap. iOS gives a single fixed tap — no duration — so a
+        // bigger ms maps to a quick burst of taps to read as "stronger".
+        const IS_IOS = /iP(hone|od|ad)/.test(navigator.userAgent) ||
+            (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+        let _hapEl = null, _hapLast = 0;
+        function vibrate(ms) {
+            try {
+                if (IS_IOS) {
+                    if (_hapEl === null) _hapEl = document.getElementById('hapticSwitch') || false;
+                    if (!_hapEl) return;
+                    const now = (performance && performance.now) ? performance.now() : Date.now();
+                    if (now - _hapLast < 22) return;            // coalesce rapid calls
+                    _hapLast = now;
+                    const taps = ms >= 60 ? 3 : ms >= 35 ? 2 : 1; // light / medium / strong
+                    for (let i = 0; i < taps; i++) setTimeout(() => { try { _hapEl.click(); } catch (e) {} }, i * 17);
+                } else if (navigator.vibrate) {
+                    navigator.vibrate(ms);
+                }
+            } catch (e) {}
+        }
 
         // ---------- DOM ----------
         const $ = (id) => document.getElementById(id);
@@ -1089,7 +1118,7 @@
         // ⚠ APP_VER: increment ONCE PER PR (CLAUDE.md rule). Shown on the
         // title screen and folded into NET_VER, so any two different builds
         // refuse to share a room.
-        const APP_VER = 32;
+        const APP_VER = 33;
         function hash32(str) {
             let h = 2166136261 >>> 0;
             for (let i = 0; i < str.length; i++) { h ^= str.charCodeAt(i); h = Math.imul(h, 16777619); }
@@ -6562,12 +6591,12 @@
                     dom.cdNum.textContent = n;
                     dom.cdNum.classList.remove('tick'); void dom.cdNum.offsetWidth; dom.cdNum.classList.add('tick');
                     lamps[3 - n].className = 'lamp red';
-                    sfxBeep(440); n--; setTimeout(tick, 1000);
+                    sfxBeep(440); vibrate(18); n--; setTimeout(tick, 1000);
                 } else {
                     dom.cdNum.textContent = 'GO!';
                     dom.cdNum.classList.remove('tick'); void dom.cdNum.offsetWidth; dom.cdNum.classList.add('tick');
                     lamps.forEach((l) => l.className = 'lamp green');
-                    sfxBeep(880);
+                    sfxBeep(880); vibrate(60);
                     state = 'racing'; raceClock = 0;
                     for (const k of karts) {
                         k.lastLapStart = 0;


### PR DESCRIPTION
The game already calls `vibrate()` on pickups, bonks, curbs, landings, boosts and slipstream — but `navigator.vibrate()` is a **no-op on iOS**, so none of it fired on the device this is actually played on. This wires up the one technique that works.

## The hack
iOS 17.4+ produces the system **selection tap** when a native switch-styled checkbox toggles. So:
- A hidden `<input type="checkbox" switch>` (`#hapticSwitch`) sits off-screen but **rendered** (`display:none` disables the haptic — it must be in the layout).
- `vibrate(ms)` now detects iOS and `.click()`s the switch instead of calling `navigator.vibrate`. The tap is a single fixed pulse with no duration, so `ms` maps to a **burst count** (light / medium / strong) and calls are **rate-limited** (~22ms) so rapid events don't get coalesced. Android keeps `navigator.vibrate(ms)`.
- Added a **countdown haptic** (light tap on 3-2-1, stronger on GO!) so there's an immediate, repeatable way to feel it on the phone right after pressing Start.

## Caveats (it's a hack)
It's **undocumented** iOS behaviour and could break on a future release — hence the graceful fallback (no-op if it doesn't fire). It also can't be feature-detected, so iOS is sniffed via UA / `maxTouchPoints`.

## Verified (headless — the tap itself only manifests on a real iPhone)
- `#hapticSwitch` exists, has the `switch` attribute, and is **rendered** (`display: block`, not none).
- Clicking the label **toggles** the checkbox — that toggle is exactly what fires the haptic.
- `vibrate()` never throws; full countdown (3×light + GO) and a race (curb/boost/bonk vibrates) run with **zero runtime errors**.

The real test is on your iPhone: start a race and you should feel 3-2-1-GO, then taps on item grabs / bonks / boosts. If iOS has changed and it doesn't fire, it silently does nothing. APP_VER → 33; CLAUDE.md documents it so it isn't reverted to plain `navigator.vibrate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)