### PR TITLE
Fable Kart: viaduct piers connect to the deck (were floating beside it)

### DIFF
--- a/apps/fablekart/index.html
+++ b/apps/fablekart/index.html
@@ -6564,12 +6564,12 @@
                     dom.cdNum.textContent = n;
                     dom.cdNum.classList.remove('tick'); void dom.cdNum.offsetWidth; dom.cdNum.classList.add('tick');
                     lamps[3 - n].className = 'lamp red';
-                    sfxBeep(440); n--; setTimeout(tick, 1000);
+                    sfxBeep(440); vibrate(18); n--; setTimeout(tick, 1000);   // countdown buzz (Android; no-op iOS)
                 } else {
                     dom.cdNum.textContent = 'GO!';
                     dom.cdNum.classList.remove('tick'); void dom.cdNum.offsetWidth; dom.cdNum.classList.add('tick');
                     lamps.forEach((l) => l.className = 'lamp green');
-                    sfxBeep(880);
+                    sfxBeep(880); vibrate(60);   // GO! buzz (Android; no-op iOS)
                     state = 'racing'; raceClock = 0;
                     for (const k of karts) {
                         k.lastLapStart = 0;

--- a/apps/fablekart/index.html
+++ b/apps/fablekart/index.html
@@ -1089,7 +1089,7 @@
         // ⚠ APP_VER: increment ONCE PER PR (CLAUDE.md rule). Shown on the
         // title screen and folded into NET_VER, so any two different builds
         // refuse to share a room.
-        const APP_VER = 34;
+        const APP_VER = 35;
         function hash32(str) {
             let h = 2166136261 >>> 0;
             for (let i = 0; i < str.length; i++) { h ^= str.charCodeAt(i); h = Math.imul(h, 16777619); }
@@ -2694,22 +2694,24 @@
                 cap.scale.set(6, 1.4, 6); cap.position.set(px, topY - 0.7, pz); world.add(cap);
             };
             // ---- COLONNADE: a row of piers marching along the elevated deck over
-            // the flat crossover basin. At the deck centerline normally, but where
-            // the deck is directly over the lower road (the crossing) the pier
-            // steps aside into the basin so it never stands in either lane; if it
-            // can't clear, the deck just spans there.
-            const lowClear = (px, pz, m) => { const le = nearestSegExcl(px, pz), lc = centerline[le]; return Math.hypot(px - lc.x, pz - lc.z) > m; };
+            // the flat crossover basin. A pier MUST stand UNDER the deck or its cap
+            // hangs in mid-air not touching the roadway. So try lateral positions
+            // from the centerline out to (but not past) the deck edge, and take the
+            // first that doesn't stand in the lower road; topY is the deck surface
+            // at that exact lateral (bank-aware) so the cap meets the underside.
+            // Where the lower road fills the whole deck width (the crossing) no
+            // offset clears it — the deck just spans, no pier.
+            const EDGE = HALF_W - 3;                          // furthest out a pier can go and still be under the deck
             const segs = Array.from(viaductSegs).sort((a, b) => a - b);
             for (let k = 0; k < segs.length; k += 3) {
                 const i = segs[k], c = centerline[i], n = normals[i];
-                let px = c.x, pz = c.z;
-                if (!lowClear(px, pz, HALF_W + 5)) {        // deck centerline is over the lower road — step aside
-                    const le = nearestSegExcl(c.x, c.z), lc = centerline[le];
-                    const sign = ((c.x - lc.x) * n.x + (c.z - lc.z) * n.z) >= 0 ? 1 : -1;
-                    px = c.x + n.x * (HALF_W + 7) * sign; pz = c.z + n.z * (HALF_W + 7) * sign;
-                    if (!lowClear(px, pz, HALF_W + 3)) continue;  // still over a road — let the deck clear-span
+                for (const lat of [0, EDGE, -EDGE, EDGE * 0.55, -EDGE * 0.55]) {
+                    const px = c.x + n.x * lat, pz = c.z + n.z * lat;
+                    const le = nearestSegExcl(px, pz), lc = centerline[le];
+                    if (Math.hypot(px - lc.x, pz - lc.z) <= HALF_W + 2) continue;  // would stand in the lower road
+                    addPier(px, pz, roadY(i, lat) - 0.6);
+                    break;
                 }
-                addPier(px, pz, roadY(i, 0) - 1.0);
             }
             // ---- TIRE WALLS on the OUTSIDE of the tighter corners (baked)
             const tparts = [];


### PR DESCRIPTION
You were right — most of the colonnade piers didn't touch the roadway above.

## The bug
The "step aside" logic (added to keep piers out of the lower road) offset them by `HALF_W + 7` = **30u** along the deck normal. But the deck half-width is only **23u**, so **12 of 14 piers stood ~7u beyond the deck edge** — caps hanging in mid-air, not connected to the deck.

## The fix
A pier must stay **under** the deck. New placement tries lateral positions from the centerline out to (but never past) the deck edge (`HALF_W - 3`), takes the first that doesn't stand in the lower road, and sets the cap height from the **bank-aware deck surface** at that exact lateral (`roadY(i, lat)`) so it meets the underside. Where the lower road fills the whole deck width (the crossing) no offset clears it, so the deck simply spans — no pier.

## Also in this PR
- **Rebased onto master** to clear the APP_VER conflict (now 35).
- **Restored the Android countdown haptics** that #213's revert removed as collateral (per the review note there): `vibrate(18)` on each 3-2-1 beep, `vibrate(60)` on GO. These are real on Android, no-ops on iOS, and have **no** dependency on the reverted iOS hack.

## Verified (you asked for many angles)
Probe: **0 floating piers** (was 12/14). Examined from 8 camera angles — both side elevations, along the underside, look-up from below, two 3/4 aerials, deck-top, and edge-pier close-ups — every pier reaches the deck and the deck surface is clean. Countdown + race run error-free.

| side elevation | along the underside | aerial |
|---|---|---|
| ![side](https://raw.githubusercontent.com/maattp/maattp.github.io/pier-shots/pc-sideA.png) | ![along](https://raw.githubusercontent.com/maattp/maattp.github.io/pier-shots/pc-along.png) | ![aerial](https://raw.githubusercontent.com/maattp/maattp.github.io/pier-shots/pc-aerialB.png) |

APP_VER → 35.