### PR TITLE
Feed: show gallery posts as their full-res cover image

### DIFF
--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -342,11 +342,26 @@ function buildPost(tag: string, block: string): Record<string, unknown> | null {
     return post;
   }
 
-  // Everything else (galleries, self/text, external links) carries no
-  // full-size media we can show. We deliberately do NOT fall back to the
-  // ~140px listing thumbnail: the client hides any image whose natural size
-  // is <200px (and skip-scrolls if it's the current item), so emitting a
-  // thumbnail-only post makes it flash in and collapse mid-scroll — jank.
+  // Reddit galleries: old.reddit only links to /gallery/<id>, and the full
+  // multi-image set lives on the comments page (an extra fetch per post). We
+  // skip that cost: the listing thumbnail is a preview of the gallery COVER
+  // image, so the full-size cover is at i.redd.it/<mediaId>.<ext> — derived
+  // with no extra request. Shows the cover (not swipeable) but at full res,
+  // which is >200px so the client won't hide it.
+  if (attr("is-gallery") === "true" || /\/gallery\//.test(url)) {
+    const cover = (thumbnail || "").match(/(?:preview|i)\.redd\.it\/([a-z0-9]+)\.(jpg|jpeg|png|gif|webp)/i);
+    if (cover) {
+      post.post_hint = "image";
+      post.url = `https://i.redd.it/${cover[1]}.${cover[2].toLowerCase()}`;
+      return post;
+    }
+  }
+
+  // Everything else (self/text, external links) carries no full-size media we
+  // can show. We deliberately do NOT fall back to the ~140px listing
+  // thumbnail: the client hides any image whose natural size is <200px (and
+  // skip-scrolls if it's the current item), so a thumbnail-only post flashes
+  // in and collapses mid-scroll — jank.
   return null;
 }
 


### PR DESCRIPTION
## Why
Galleries don't currently render — they were dropped entirely by #218 (after the old.reddit switch removed the structured `gallery_data`/`media_metadata` the client used). This restores them.

## What
The full multi-image gallery set only lives on the post's comments page — fetching it per gallery would add an extra request each and worsen old.reddit's per-IP rate limiting. Cheaper path used here: the **listing thumbnail is a preview of the gallery cover image**, so the full-size cover is at `i.redd.it/<mediaId>.<ext>`, derived from the thumbnail's media id with **no extra request**.

Galleries now show their cover image at full resolution. Trade-off: it's the cover only, not a swipeable multi-image gallery — but it's full-size (>200px, so the client won't hide it) and costs zero extra fetches.

## Verification
Deployed to the live worker; on r/pics the known gallery post `1u96qv1` is now emitted as `post_hint: image` → `https://i.redd.it/yehmmi7mp18h1.jpg`, which loads HTTP 200 (image/jpeg, 1.3 MB).

## Note
Stacked on #218 (`feed-fix-scroll-jank`) since both touch the same `buildPost` branch. Base should be retargeted to `master` once #218 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)