### PR TITLE
Feed: fix sort dropdown clipped off-screen on narrow widths

### DIFF
--- a/apps/feed/index.html
+++ b/apps/feed/index.html
@@ -45,6 +45,7 @@
         .header {
             display: flex;
             align-items: center;
+            flex-wrap: wrap;
             gap: 6px;
             position: sticky;
             top: 0;
@@ -57,7 +58,11 @@
         .header h1 {
             font-size: 20px;
             font-weight: 600;
-            flex: 1;
+            /* Take the whole first row so the sort dropdowns wrap onto a
+               second row instead of overflowing off the right edge on narrow
+               screens (they previously got clipped — the sort control was
+               pushed off-screen). */
+            flex: 1 1 100%;
             min-width: 0;
             display: flex;
             align-items: center;
@@ -746,7 +751,7 @@
     <div class="home-view" id="home-view">
         <div class="header">
             <h1>
-                Feed <span class="version">v22</span>
+                Feed <span class="version">v23</span>
                 <button class="export-btn" id="export-btn" title="Export data" aria-label="Export data">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>


### PR DESCRIPTION
## The problem
You couldn't find the subreddit **Recent / A-Z** sort control because it was being **pushed off the right edge of the screen**, not removed.

`3a1c0e2` ("Compact feed home header to a single row") dropped `flex-wrap` from `.header` and set `.header h1 { flex: 1 }` while the sort dropdowns are `flex-shrink: 0`. On phone widths the header row overflows: the title grows, shoving the dropdowns past the right edge — the sort control showed only "Rec" at the very edge and the "Hot" dropdown was entirely off-screen.

## The fix
Restore `flex-wrap` and give `.header h1` `flex: 1 1 100%` so the title takes the first row and the dropdowns wrap onto a fully-visible second row.

## Verification
Headless screenshots at 320px and 375px — both now show **Recent** and **Hot** dropdowns in full on the second row. Before/after:

- Before (375px): title … big gap … `Rec` clipped at edge, Hot off-screen
- After (375px): `Feed v23` on row 1; `[Recent ▾] [Hot ▾]` on row 2

Version bumped v22 → v23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)