### PR TITLE
Sichuan Mahjong: local hot-seat + server-authoritative online multiplayer

### DIFF
--- a/apps/index.html
+++ b/apps/index.html
@@ -342,6 +342,7 @@
         .app-dam { background: linear-gradient(135deg, #d9b77f, #6ba5c0); }
         .app-cortex { background: linear-gradient(135deg, #05060a, #2d0a4a 60%, #b8246b); }
         .app-markdown { background: linear-gradient(135deg, #1e293b, #3b82f6); }
+        .app-mahjong { background: linear-gradient(135deg, #0b6b43, #084f31); }
         .app-racing { background: linear-gradient(135deg, #12c2e9, #c471ed); }
         .app-kart { background: linear-gradient(135deg, #2ecc40, #0074d9); }
         .app-kart2 { background: linear-gradient(135deg, #ff7a3c, #b06bff); }
@@ -500,6 +501,11 @@
         <a href="lunar/" class="app-link">
             <div class="app-icon app-lunar">🌙</div>
             <span class="app-name">Lunar</span>
+        </a>
+
+        <a href="mahjong/" class="app-link">
+            <div class="app-icon app-mahjong">🀄</div>
+            <span class="app-name">Mahjong</span>
         </a>
 
         <a href="markdown/" class="app-link">

--- a/apps/mahjong/build-core.mjs
+++ b/apps/mahjong/build-core.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+/* Splice the canonical engine (worker/src/mahjongCore.js, the region between
+ * ==CORE-START== and ==CORE-END==) into apps/mahjong/index.html between the
+ * CORE-INLINE markers. Run from the repo root: `node apps/mahjong/build-core.mjs`.
+ * tests/core-sync.mjs asserts the two regions stay byte-identical. */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const corePath = path.join(root, 'worker/src/mahjongCore.js');
+const htmlPath = path.join(root, 'apps/mahjong/index.html');
+
+const core = fs.readFileSync(corePath, 'utf8');
+const m = core.match(/\/\/ ==CORE-START==[\s\S]*?\/\/ ==CORE-END==/);
+if (!m) { console.error('CORE markers not found in mahjongCore.js'); process.exit(1); }
+const region = m[0];
+
+let html = fs.readFileSync(htmlPath, 'utf8');
+const START = '/* CORE-INLINE-START */';
+const END = '/* CORE-INLINE-END */';
+const si = html.indexOf(START), ei = html.indexOf(END);
+if (si < 0 || ei < 0) { console.error('CORE-INLINE markers not found in index.html'); process.exit(1); }
+html = html.slice(0, si + START.length) + '\n' + region + '\n' + html.slice(ei);
+fs.writeFileSync(htmlPath, html);
+console.log(`Inlined core region (${region.length} bytes) into index.html`);

--- a/apps/mahjong/index.html
+++ b/apps/mahjong/index.html
@@ -485,7 +485,7 @@ function isStandardShape(counts, groupsNeeded) {
   for (let p = 0; p < NUM_TYPES; p++) {
     if (counts[p] >= 2) {
       counts[p] -= 2;
-      const ok = canPartition(counts.slice(), groupsNeeded);
+      const ok = canPartition(counts, groupsNeeded);   // canPartition fully backtracks, so no copy needed
       counts[p] += 2;
       if (ok) return true;
     }
@@ -1132,7 +1132,12 @@ function viewFor(state, seat, opts = {}) {
       isBot: p.isBot,
       connected: p.connected,
       missingSuit: p.missingSuit,             // public after selection (default)
-      melds: p.melds.map((m) => ({ ...m, concealed: m.type === KONG_CONCEALED })),
+      // an opponent's concealed kong (暗杠) stays hidden until the hand ends — never
+      // leak its tile to other seats (this is a hidden-info game)
+      melds: p.melds.map((m) =>
+        (m.type === KONG_CONCEALED && p.seat !== seat && state.phase !== PHASE.HAND_ENDED)
+          ? { type: m.type, tile: -1, hidden: true }
+          : { ...m }),
       discards: p.discards.slice(),
       handCount: countTotal(p.concealed),
       hasWon: p.hasWon,
@@ -1147,7 +1152,7 @@ function viewFor(state, seat, opts = {}) {
     view.results = {
       reason: state.endReason,
       winners: state.winnersThisHand.slice(),
-      records: [].concat(...state.players.map((p) => p.winRecords)),
+      records: state.players.flatMap((p) => p.winRecords),
       scores: state.players.map((p) => p.score),
       nextDealer: state.nextDealer,
     };
@@ -1366,7 +1371,7 @@ function botChooseMeld(state, seat, pung, kong, difficulty) {
   // simulate removing `remove` copies into a meld; return resulting shanten + tenpai
   const evalClaim = (remove) => {
     const snap = p.concealed.slice(), msnap = p.melds.map((m) => ({ ...m }));
-    p.concealed[tile] -= remove; p.melds.push({ type: PUNG, tile });
+    p.concealed[tile] -= remove; p.melds.push({ type: remove === 2 ? PUNG : KONG_EXPOSED_FROM_DISCARD, tile });
     const after = shantenOf(p), ready = isReady(p, state.config);
     p.concealed = snap; p.melds = msnap;
     return { after, ready };
@@ -1404,6 +1409,8 @@ function tileHTML(tile, cls = '') {
 }
 const backHTML = (cls = '') => `<div class="tile back ${cls}"></div>`;
 function meldHTML(m) {
+  // an opponent's concealed kong is redacted (tile hidden) — show four backs
+  if (m.hidden || m.tile == null || m.tile < 0) return `<div class="meld">${'<div class="tile back"></div>'.repeat(4)}</div>`;
   const n = m.type === PUNG ? 3 : 4;
   let t = '';
   for (let i = 0; i < n; i++) {

--- a/apps/mahjong/index.html
+++ b/apps/mahjong/index.html
@@ -395,7 +395,7 @@ function createGame(opts = {}) {
     pendingDiscard: null, reactions: null, robReactions: null,
     turnFlags: { needsDraw: false, drewFromKong: false, lastDrawn: null, firstTurn: false, lastTileExhausted: false },
     firstDiscardDone: false,
-    winnersThisHand: [],
+    winnersThisHand: [], firstDealerSeat: null,
     log: [],
     ended: false, endReason: null,
     seatScores: opts.seatScores || [0, 0, 0, 0],   // carry running scores across hands
@@ -602,7 +602,9 @@ function getLegalActions(state, seat) {
     const justDrew = state.turnFlags.lastDrawn != null || state.turnFlags.firstTurn;
     // self-draw win
     if (!holdsMissing && justDrew && winsNow(p, state.config)) acts.push({ type: 'DeclareSelfDrawWin' });
-    if (!holdsMissing && !state.turnFlags.afterPung) {
+    // kongs only gate on the kong tile's suit (spec §6.7/§6.8), not on whether the
+    // player has cleared their own missing suit (that rule restricts discards only, §8.2)
+    if (!state.turnFlags.afterPung) {
       // concealed kong
       for (let t = 0; t < NUM_TYPES; t++) {
         if (p.concealed[t] === 4 && (state.config.allowKongInMissingSuit || tileSuit(t) !== p.missingSuit))
@@ -627,7 +629,8 @@ function getLegalActions(state, seat) {
     const holdsMissing = missingCount(p) > 0;
     if (!holdsMissing && tileSuit(tile) !== p.missingSuit && isWinningHand(p, state.config, tile))
       acts.push({ type: 'DeclareWinFromDiscard', tile });
-    const meldOk = !holdsMissing && (state.config.allowMeldsInMissingSuit || tileSuit(tile) !== p.missingSuit);
+    // peng/kong-from-discard gate on the claimed tile's suit only (spec §6.5/§6.6)
+    const meldOk = (state.config.allowMeldsInMissingSuit || tileSuit(tile) !== p.missingSuit);
     if (meldOk && p.concealed[tile] >= 3) acts.push({ type: 'ClaimKongFromDiscard', tile });
     if (meldOk && p.concealed[tile] >= 2) acts.push({ type: 'ClaimPung', tile });
     acts.push({ type: 'Pass' });
@@ -768,7 +771,7 @@ function doDiscard(state, seat, tile) {
 function reactionOptions(state, seat, tile) {
   const p = state.players[seat];
   const holdsMissing = missingCount(p) > 0;
-  const meldOk = !holdsMissing && (state.config.allowMeldsInMissingSuit || tileSuit(tile) !== p.missingSuit);
+  const meldOk = (state.config.allowMeldsInMissingSuit || tileSuit(tile) !== p.missingSuit);
   return {
     win: !holdsMissing && tileSuit(tile) !== p.missingSuit && isWinningHand(p, state.config, tile),
     kong: meldOk && p.concealed[tile] >= 3,
@@ -793,6 +796,8 @@ function resolveDiscardReactions(state) {
     const ordered = state.config.allowMultipleWinnersOnDiscard ? winners : [nearestInOrder(discarder, winners)];
     state.reactions = null;
     commitDiscardToPile(state);   // the won tile stays visible in the river, counted once
+    // §12.1: first winner becomes next dealer; if multiple win the same discard, the discarder does
+    if (state.winnersThisHand.length === 0) state.firstDealerSeat = (ordered.length >= 2 ? discarder : ordered[0]);
     for (const w of ordered) {
       // The winning tile is scored VIRTUALLY (not added to concealed) so one physical
       // tile can feed multiple winners without breaking conservation (spec §19, §10.1).
@@ -877,8 +882,14 @@ function resolveRobReactions(state) {
     const ordered = state.config.allowMultipleRobKongWinners ? robbers : [nearestInOrder(declarer, robbers)];
     state.robReactions = null;
     logEvent(state, { type: 'KongRobbed', declarer, tile });
+    // The kong tile is consumed by the rob (like a discard handed to the winner):
+    // remove it from the declarer's hand into their river so the declarer returns to
+    // 13 effective tiles and conservation holds. The pung is NOT upgraded (kong cancelled).
+    state.players[declarer].concealed[tile] -= 1;
+    state.players[declarer].discards.push(tile);
+    if (state.winnersThisHand.length === 0) state.firstDealerSeat = (ordered.length >= 2 ? declarer : ordered[0]);
     for (const w of ordered) {
-      // winning tile scored virtually (the declarer keeps the physical tile)
+      // winning tile scored virtually (it now lives in the declarer's river, counted once)
       resolveWin(state, w, { winType: 'ROB_KONG', winningTile: tile, source: declarer, lastTile: false, afterKong: false });
     }
     if (!checkHandEnd(state)) beginTurn(state, nextActiveSeat(state, declarer));
@@ -902,6 +913,7 @@ function doSelfDrawWin(state, seat) {
   const isHeavenly = state.turnFlags.firstTurn && seat === state.dealer && !state.firstDiscardDone;
   const ctx = { winType: 'SELF_DRAW', winningTile: state.turnFlags.lastDrawn, source: null,
     lastTile: state.turnFlags.lastTileExhausted, afterKong: pd.drewFromKong, isHeavenly };
+  if (state.winnersThisHand.length === 0) state.firstDealerSeat = seat;
   resolveWin(state, seat, ctx);
   if (!checkHandEnd(state)) beginTurn(state, nextActiveSeat(state, seat));
 }
@@ -1056,8 +1068,9 @@ function endHand(state, reason) {
       logEvent(state, { type: 'EndPenaltyApplied', seat: h.seat, kind: 'missingSuit' });
     }
   }
-  // next dealer: first winner, else dealer repeats (spec §12.1)
-  state.nextDealer = (state.winnersThisHand.length > 0) ? state.winnersThisHand[0] : state.dealer;
+  // next dealer (spec §12.1): the first winner (or discarder if the first win was a
+  // simultaneous multi-winner discard, tracked in firstDealerSeat); else dealer repeats
+  state.nextDealer = (state.firstDealerSeat != null) ? state.firstDealerSeat : state.dealer;
   state.seatScores = state.players.map((p) => p.score);
   logEvent(state, { type: 'HandEnded', reason, winners: state.winnersThisHand.slice() });
 }
@@ -1238,7 +1251,13 @@ function opponentDanger(state, seat) {
     if (s === seat) continue;
     const o = state.players[s];
     if (o.hasWon) continue;
-    const d = o.melds.length * 0.18 + (missingCount(o) === 0 ? 0.15 : 0) + Math.min(o.discards.length, 12) * 0.02;
+    // PUBLIC signals only — never inspect an opponent's concealed hand. We infer
+    // "has cleared their missing suit" from their discard river: they discarded
+    // missing-suit tiles earlier and their recent discards are no longer that suit.
+    const dumpedMissing = o.missingSuit != null && o.discards.some((t) => tileSuit(t) === o.missingSuit);
+    const recentOffMissing = o.discards.slice(-2).every((t) => o.missingSuit == null || tileSuit(t) !== o.missingSuit);
+    const voidedLikely = dumpedMissing && recentOffMissing && o.discards.length >= 3;
+    const d = o.melds.length * 0.2 + (voidedLikely ? 0.15 : 0) + Math.min(o.discards.length, 12) * 0.02;
     worst = Math.max(worst, Math.min(1, d));
   }
   return worst;
@@ -1411,7 +1430,7 @@ function onUpdate(view, meta = {}) {
 function render() {
   const view = curView; if (!view) return;
   $('round-info').textContent =
-    `Wall ${view.wallRemaining} · ${view.mode === 'bloody' ? '血战' : 'Single'} · Won ${view.winnersThisHand.length}/3`;
+    `Wall ${view.wallRemaining} · ${view.mode === 'bloody' ? '血战' : 'Single'} · Won ${view.winnersThisHand.length}${view.mode === 'bloody' ? '/3' : ''}`;
   const v = view.mySeat;
   for (let rel = 0; rel < 4; rel++) renderSeat(view, (v + rel) % 4, rel);
   renderCenter(view);
@@ -1431,10 +1450,7 @@ function renderSeat(view, seat, rel) {
       <span class="dot"></span>${dealer}<span>${escapeHtml(p.name)}</span>${tint}${won}
       <span class="sc">${p.score >= 0 ? '+' : ''}${p.score}</span>${thinking}</div>`;
   const melds = p.melds.length ? `<div class="melds">${p.melds.map(meldHTML).join('')}</div>` : '';
-  const river = `<div class="river">${p.discards.map((t, i) => {
-    const isLast = view.pendingDiscard && view.pendingDiscard.by === seat && false;
-    return tileHTML(t, '');
-  }).join('')}</div>`;
+  const river = `<div class="river">${p.discards.map((t) => tileHTML(t, '')).join('')}</div>`;
 
   if (rel === 0) { el.innerHTML = plate + melds + river; return; }
   let backs = '';
@@ -1456,6 +1472,15 @@ function renderHandArea(view) {
   const area = $('handarea');
   const me = view.me;
   const acts = me.legalActions || [];
+
+  // Hot-seat privacy: while a reveal gate is pending, NEVER paint the incoming
+  // player's real tiles into the DOM (the gate backdrop alone isn't fully opaque).
+  if (pendingReveal) {
+    let backs = '';
+    for (let i = 0; i < (me.concealed ? me.concealed.reduce((s, n) => s + n, 0) : 13); i++) backs += backHTML();
+    area.innerHTML = `<div class="ready-banner"></div><div class="hand-row">${backs}</div><div class="actions"></div>`;
+    return;
+  }
 
   // missing-suit chooser
   if (acts.some((a) => a.type === 'ChooseMissingSuit')) { area.innerHTML = dingQueHTML(view); wireDingque(); return; }
@@ -1543,12 +1568,13 @@ function submit(action) { if (conn) conn.submit(action); }
 /* ---- reveal gate (hot-seat privacy) ---- */
 function showRevealGate(reveal) {
   overlay.style.display = 'flex';
+  overlay.style.background = '#063d26';   // opaque — fully hide the board behind the gate
   overlay.innerHTML = `<div class="modal reveal-gate" id="rg"><div class="big">🀄️</div>
     <h2>${escapeHtml(reveal.name)}</h2>
     <p>Pass the device. Tap when ready — keep your tiles hidden from the others.</p>
     <button class="btn">I'm ready</button></div>`;
   $('rg').querySelector('.btn').addEventListener('click', () => {
-    pendingReveal = null; overlay.style.display = 'none'; overlay.innerHTML = ''; render();
+    pendingReveal = null; overlay.style.display = 'none'; overlay.innerHTML = ''; overlay.style.background = ''; render();
   });
 }
 
@@ -1622,7 +1648,8 @@ function showRules() {
 
 function leaveGame() {
   if (conn && conn.dispose) conn.dispose();
-  conn = null; curView = null; online = false;
+  conn = null; curView = null; online = false; pendingReveal = null;
+  overlay.style.display = 'none'; overlay.innerHTML = ''; overlay.style.background = '';
   $('conpill').style.display = 'none';
   $('game').style.display = 'none'; $('setup').style.display = 'flex';
 }
@@ -1644,8 +1671,8 @@ class LocalConnection {
     this.state = createGame({ seed, config: this.cfg.config, names: this.cfg.names, seats: this.cfg.seats, dealer: this.cfg.dealer || 0, seatScores: this.scores });
     this.drive();
   }
-  dispose() { this.alive = false; this.pendingResolve = null; }
-  again() { this.scores = this.state.players.map((p) => p.score); this.cfg.dealer = this.state.nextDealer; this.newHand(); }
+  dispose() { this.alive = false; const r = this.pendingResolve; this.pendingResolve = null; if (r) r({ type: '__disposed' }); }
+  again() { if (this._dealing) return; this._dealing = true; this.scores = this.state.players.map((p) => p.score); this.cfg.dealer = this.state.nextDealer; this.newHand(); this._dealing = false; }
 
   emit(meta) {
     const viewer = (this.viewerSeat != null) ? this.viewerSeat : (this.lastHuman >= 0 ? this.lastHuman : 0);
@@ -1801,10 +1828,10 @@ class OnlineConnection {
       case 'view':
         if (!this.inGame) { this.inGame = true; overlay.style.display = 'none'; overlay.innerHTML = ''; showGameScreen(); }
         if (m.view.phase !== 'HAND_ENDED' && overlay.style.display === 'flex' && overlay.querySelector('.scoreboard')) { overlay.style.display = 'none'; overlay.innerHTML = ''; }
-        this.awaiting = false;
+        this.awaiting = false; clearTimeout(this._awaitTimer);
         onUpdate(m.view, { conn: { text: 'Online', state: 'ok' } });
         break;
-      case 'reject': this.awaiting = false; toast(m.error && m.error.message ? m.error.message : 'Invalid move', 1500); render(); break;
+      case 'reject': this.awaiting = false; clearTimeout(this._awaitTimer); toast(m.error && m.error.message ? m.error.message : 'Invalid move', 1500); render(); break;
       case 'error': onlineMsg(m.msg || 'Server error', true); updateConnPill({ text: 'Error', state: 'bad' }); this.alive = false; break;
       case 'you-are-host': this.host = true; if (this.lobby && !this.inGame) showOnlineLobby(this, this.lobby); break;
     }
@@ -1819,7 +1846,13 @@ class OnlineConnection {
   setConfig(c) { this.rawsend({ t: 'config', ...c }); }
   startGame() { this.rawsend({ t: 'start' }); }
   again() { if (this.host) this.rawsend({ t: 'rematch' }); }
-  submit(action) { if (this.awaiting) return; this.awaiting = true; this.rawsend({ t: 'action', action }); }
+  submit(action) {
+    if (this.awaiting) return;
+    this.awaiting = true;
+    clearTimeout(this._awaitTimer);
+    this._awaitTimer = setTimeout(() => { this.awaiting = false; }, 4000);  // safety net if a view is dropped
+    this.rawsend({ t: 'action', action });
+  }
   dispose() { this.alive = false; clearInterval(this.ping); try { this.ws.close(); } catch {} }
 }
 function onlineMsg(s, err) { const el = $('online-msg'); el.textContent = s; el.className = 'hostmsg' + (err ? ' err' : ''); }

--- a/apps/mahjong/index.html
+++ b/apps/mahjong/index.html
@@ -1664,15 +1664,19 @@ class LocalConnection {
     this.lastHuman = cfg.seats.findIndex((s) => !s.isBot);
     this.pendingResolve = null;
     this.alive = true;
+    this.gen = 0;                 // drive-loop generation: a new hand supersedes the old loop
     this.newHand();
   }
   newHand() {
+    this.gen++;
+    const myGen = this.gen;
+    const r = this.pendingResolve; this.pendingResolve = null; if (r) r(null);  // unblock any prior loop
     const seed = (Date.now() ^ (Math.random() * 1e9)) | 0;
     this.state = createGame({ seed, config: this.cfg.config, names: this.cfg.names, seats: this.cfg.seats, dealer: this.cfg.dealer || 0, seatScores: this.scores });
-    this.drive();
+    this.drive(myGen);
   }
-  dispose() { this.alive = false; const r = this.pendingResolve; this.pendingResolve = null; if (r) r({ type: '__disposed' }); }
-  again() { if (this._dealing) return; this._dealing = true; this.scores = this.state.players.map((p) => p.score); this.cfg.dealer = this.state.nextDealer; this.newHand(); this._dealing = false; }
+  dispose() { this.alive = false; const r = this.pendingResolve; this.pendingResolve = null; if (r) r(null); }
+  again() { this.scores = this.state.players.map((p) => p.score); this.cfg.dealer = this.state.nextDealer; this.newHand(); }
 
   emit(meta) {
     const viewer = (this.viewerSeat != null) ? this.viewerSeat : (this.lastHuman >= 0 ? this.lastHuman : 0);
@@ -1689,8 +1693,9 @@ class LocalConnection {
     return out;
   }
 
-  async drive() {
-    while (this.alive) {
+  async drive(myGen) {
+    const live = () => this.alive && this.gen === myGen;   // false once a newer hand supersedes us
+    while (live()) {
       if (this.state.phase === 'HAND_ENDED') { this.viewerSeat = this.lastHuman >= 0 ? this.lastHuman : 0; this.emit({}); return; }
       const deciders = pendingDeciders(this.state);
       if (!deciders.length) return;
@@ -1699,7 +1704,7 @@ class LocalConnection {
         this.viewerSeat = this.lastHuman >= 0 ? this.lastHuman : botSeat;
         this.emit({});                                   // show the bot as "thinking"
         await this.botThink(this.state.players[botSeat]);
-        if (!this.alive) return;
+        if (!live()) return;
         const a = botChooseAction(this.state, botSeat);
         const res = applyAction(this.state, botSeat, a);
         this.emit({ toasts: this.eventToasts(res.events || []) });
@@ -1710,7 +1715,7 @@ class LocalConnection {
       const reveal = (this.numHumans > 1 && seat !== this.lastHuman) ? { seat, name: this.state.players[seat].name } : null;
       this.viewerSeat = seat; this.lastHuman = seat;
       const action = await new Promise((r) => { this.pendingResolve = r; this.emit({ reveal }); });
-      if (!this.alive) return;
+      if (!live() || !action) return;
       const res = applyAction(this.state, seat, action);
       if (!res.ok) { this.emit({ toasts: [{ msg: res.error.message, ms: 1600 }] }); continue; }
       this.emit({ toasts: this.eventToasts(res.events || []) });

--- a/apps/mahjong/index.html
+++ b/apps/mahjong/index.html
@@ -11,76 +11,68 @@
 <title>Sichuan Mahjong</title>
 <style>
 :root{
-  --felt:#0b6b43;
-  --felt-dark:#084f31;
-  --gold:#f4d58d;
-  --tile-bg:#fbf7ec;
-  --tile-edge:#d8cfb8;
-  --man:#b23b3b;
-  --sou:#1f8a4c;
-  --pin:#2b6fb5;
-  --ink:#222;
+  --felt:#0b6b43; --felt-dark:#084f31; --gold:#f4d58d;
+  --tile-bg:#fbf7ec; --tile-edge:#d8cfb8;
+  --man:#b23b3b; --sou:#1f8a4c; --pin:#2b6fb5; --ink:#222;
 }
 *{margin:0;padding:0;box-sizing:border-box;-webkit-tap-highlight-color:transparent;}
 html,body{height:100%;}
 body{
   font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   background:radial-gradient(circle at 50% 30%,#0e7a4c,#063d26 75%);
-  color:#fff;
-  overflow:hidden;
-  -webkit-user-select:none;user-select:none;
+  color:#fff; overflow:hidden; -webkit-user-select:none; user-select:none;
   padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
 }
 button{font-family:inherit;cursor:pointer;border:none;}
 
 /* ============ SETUP ============ */
-#setup{
-  position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;
+#setup{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;
   overflow-y:auto;-webkit-overflow-scrolling:touch;
-  padding:calc(env(safe-area-inset-top) + 26px) 20px calc(env(safe-area-inset-bottom) + 26px);
-}
-.brand{text-align:center;margin-bottom:6px;}
-.brand .cn{font-size:clamp(34px,11vw,52px);font-weight:800;letter-spacing:6px;color:var(--gold);text-shadow:0 3px 10px rgba(0,0,0,.5);}
-.brand .en{font-size:13px;letter-spacing:3px;text-transform:uppercase;opacity:.85;margin-top:2px;}
-.card{
-  background:rgba(0,0,0,.28);border:1px solid rgba(255,255,255,.12);border-radius:18px;
-  padding:18px 16px;width:100%;max-width:460px;margin-top:16px;backdrop-filter:blur(6px);
-}
-.card h2{font-size:14px;text-transform:uppercase;letter-spacing:2px;opacity:.8;margin-bottom:12px;font-weight:700;}
+  padding:calc(env(safe-area-inset-top) + 22px) 20px calc(env(safe-area-inset-bottom) + 26px);}
+.brand{text-align:center;margin-bottom:4px;}
+.brand .cn{font-size:clamp(32px,10vw,50px);font-weight:800;letter-spacing:6px;color:var(--gold);text-shadow:0 3px 10px rgba(0,0,0,.5);}
+.brand .en{font-size:12px;letter-spacing:3px;text-transform:uppercase;opacity:.85;margin-top:2px;}
+.mode-tabs{display:flex;gap:8px;margin-top:16px;width:100%;max-width:460px;}
+.mode-tabs button{flex:1;padding:12px;border-radius:12px;background:rgba(255,255,255,.08);color:#fff;font-size:15px;font-weight:700;border:1.5px solid transparent;}
+.mode-tabs button.on{background:var(--gold);color:#1a1a1a;border-color:#fff;}
+.card{background:rgba(0,0,0,.28);border:1px solid rgba(255,255,255,.12);border-radius:18px;
+  padding:16px;width:100%;max-width:460px;margin-top:14px;backdrop-filter:blur(6px);}
+.card h2{font-size:13px;text-transform:uppercase;letter-spacing:2px;opacity:.8;margin-bottom:10px;font-weight:700;}
 .seg{display:flex;gap:8px;flex-wrap:wrap;}
-.seg button{
-  flex:1;min-width:64px;padding:12px 8px;border-radius:12px;background:rgba(255,255,255,.08);
-  color:#fff;font-size:15px;font-weight:600;border:1.5px solid transparent;transition:.15s;
-}
+.seg button{flex:1;min-width:60px;padding:11px 6px;border-radius:11px;background:rgba(255,255,255,.08);
+  color:#fff;font-size:15px;font-weight:600;border:1.5px solid transparent;transition:.15s;}
 .seg button.on{background:var(--gold);color:#1a1a1a;border-color:#fff;}
 .seg button .sub{display:block;font-size:10px;opacity:.7;font-weight:500;margin-top:2px;}
-.seg button.on .sub{opacity:.7;}
 .names{display:flex;flex-direction:column;gap:8px;margin-top:12px;}
-.names input{
-  background:rgba(255,255,255,.1);border:1px solid rgba(255,255,255,.2);border-radius:10px;
-  padding:10px 12px;color:#fff;font-size:15px;
-}
-.names input::placeholder{color:rgba(255,255,255,.5);}
-.start-btn{
-  margin-top:20px;width:100%;max-width:460px;padding:16px;border-radius:14px;
-  background:linear-gradient(135deg,#f4d58d,#e0a93f);color:#3a2600;font-size:18px;font-weight:800;
-  letter-spacing:1px;box-shadow:0 6px 18px rgba(0,0,0,.35);
-}
+.row-inline{display:flex;gap:8px;}
+input.txt{background:rgba(255,255,255,.1);border:1px solid rgba(255,255,255,.2);border-radius:10px;
+  padding:11px 12px;color:#fff;font-size:16px;width:100%;}
+input.txt::placeholder{color:rgba(255,255,255,.5);}
+.toggle-row{display:flex;align-items:center;justify-content:space-between;padding:8px 2px;font-size:14px;}
+.switch{width:46px;height:28px;border-radius:14px;background:rgba(255,255,255,.2);position:relative;transition:.2s;flex-shrink:0;}
+.switch.on{background:var(--sou);}
+.switch::after{content:"";position:absolute;top:3px;left:3px;width:22px;height:22px;border-radius:50%;background:#fff;transition:.2s;}
+.switch.on::after{transform:translateX(18px);}
+.start-btn{margin-top:18px;width:100%;max-width:460px;padding:16px;border-radius:14px;
+  background:linear-gradient(135deg,#f4d58d,#e0a93f);color:#3a2600;font-size:18px;font-weight:800;letter-spacing:1px;
+  box-shadow:0 6px 18px rgba(0,0,0,.35);}
 .start-btn:active{transform:scale(.98);}
-.setup-foot{margin-top:14px;display:flex;gap:14px;font-size:13px;opacity:.8;}
+.start-btn.sec{background:rgba(255,255,255,.14);color:#fff;margin-top:10px;box-shadow:none;}
+.setup-foot{margin-top:14px;display:flex;gap:14px;font-size:13px;opacity:.85;}
 .setup-foot a,.setup-foot button{color:var(--gold);background:none;text-decoration:underline;font-size:13px;}
+.hostmsg{font-size:13px;opacity:.85;margin-top:8px;text-align:center;min-height:18px;}
+.hostmsg.err{color:#ff9a9a;}
 
 /* ============ GAME ============ */
 #game{position:absolute;inset:0;display:none;flex-direction:column;}
-.topbar{
-  display:flex;align-items:center;gap:10px;padding:6px 12px;
-  padding-top:calc(env(safe-area-inset-top) + 4px);
-  background:rgba(0,0,0,.25);font-size:13px;flex-shrink:0;
-}
+.topbar{display:flex;align-items:center;gap:10px;padding:6px 12px;padding-top:calc(env(safe-area-inset-top) + 4px);
+  background:rgba(0,0,0,.25);font-size:13px;flex-shrink:0;}
 .topbar .title{font-weight:700;color:var(--gold);letter-spacing:1px;}
-.topbar .info{opacity:.85;}
+.topbar .info{opacity:.85;font-variant-numeric:tabular-nums;}
 .topbar .spacer{flex:1;}
 .topbar button{background:rgba(255,255,255,.12);color:#fff;border-radius:8px;padding:6px 10px;font-size:13px;}
+.conpill{font-size:11px;padding:3px 8px;border-radius:10px;background:rgba(255,255,255,.12);}
+.conpill.ok{background:rgba(48,209,88,.25);} .conpill.bad{background:rgba(255,120,120,.3);}
 
 .table{flex:1;position:relative;min-height:0;display:flex;flex-direction:column;padding:6px;gap:4px;}
 .seat{display:flex;flex-direction:column;align-items:center;gap:3px;}
@@ -89,73 +81,55 @@ button{font-family:inherit;cursor:pointer;border:none;}
 .seat-left,.seat-right{justify-content:center;flex-shrink:0;width:74px;}
 .center{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;position:relative;min-width:0;}
 .seat-bottom{order:2;}
-
-.nameplate{
-  display:flex;align-items:center;gap:6px;font-size:12px;padding:3px 9px;border-radius:20px;
-  background:rgba(0,0,0,.3);border:1px solid rgba(255,255,255,.1);white-space:nowrap;
-}
+.nameplate{display:flex;align-items:center;gap:6px;font-size:12px;padding:3px 9px;border-radius:20px;
+  background:rgba(0,0,0,.3);border:1px solid rgba(255,255,255,.1);white-space:nowrap;}
 .nameplate.active{background:var(--gold);color:#1a1a1a;font-weight:700;box-shadow:0 0 12px rgba(244,213,141,.7);}
 .nameplate .dot{width:8px;height:8px;border-radius:50%;background:#888;}
-.nameplate.bot .dot{background:#5ac8fa;}
-.nameplate.human .dot{background:#30d158;}
+.nameplate.bot .dot{background:#5ac8fa;} .nameplate.human .dot{background:#30d158;}
+.nameplate.off{opacity:.5;} .nameplate.off .dot{background:#ff6b6b;}
 .nameplate .miss{font-weight:800;}
 .nameplate .sc{font-variant-numeric:tabular-nums;opacity:.9;}
-.nameplate .won{color:#ffd700;font-weight:800;}
-.thinking{font-size:11px;opacity:.7;font-style:italic;}
+.nameplate .won{color:#3a2600;font-weight:800;}
+.nameplate.active .thinking{color:#1a1a1a;}
+.thinking{font-size:11px;opacity:.8;font-style:italic;}
+.dealer-mark{font-size:10px;background:#b23b3b;color:#fff;border-radius:4px;padding:0 3px;font-weight:700;}
 
-/* tiles */
-.tile{
-  position:relative;background:linear-gradient(180deg,#fff,var(--tile-bg));
-  border:1px solid var(--tile-edge);border-bottom-width:3px;border-radius:6px;
-  display:flex;flex-direction:column;align-items:center;justify-content:center;
-  color:var(--ink);flex-shrink:0;box-shadow:0 1px 2px rgba(0,0,0,.25);overflow:hidden;
-}
-.tile .num{font-weight:800;line-height:1;}
-.tile .glyph{line-height:1;opacity:.95;}
+.tile{position:relative;background:linear-gradient(180deg,#fff,var(--tile-bg));border:1px solid var(--tile-edge);
+  border-bottom-width:3px;border-radius:6px;display:flex;flex-direction:column;align-items:center;justify-content:center;
+  color:var(--ink);flex-shrink:0;box-shadow:0 1px 2px rgba(0,0,0,.25);overflow:hidden;}
+.tile .num{font-weight:800;line-height:1;} .tile .glyph{line-height:1;opacity:.95;}
 .tile.m .num,.tile.m .glyph{color:var(--man);}
 .tile.s .num,.tile.s .glyph{color:var(--sou);}
 .tile.p .num,.tile.p .glyph{color:var(--pin);}
 .tile.back{background:linear-gradient(135deg,#1f7a4d,#0c5635);border-color:#0a4329;}
 .tile.back::after{content:"";position:absolute;inset:3px;border:1px solid rgba(255,255,255,.25);border-radius:4px;}
 
-/* hand tiles (big, interactive) */
-.handarea{
-  flex-shrink:0;background:rgba(0,0,0,.32);border-top:1px solid rgba(255,255,255,.1);
-  padding:8px 8px calc(env(safe-area-inset-bottom) + 8px);
-}
-.hand-row{display:flex;justify-content:center;align-items:flex-end;gap:3px;flex-wrap:wrap;min-height:56px;}
-.hand-row .tile{
-  width:clamp(30px,8.4vw,46px);height:clamp(42px,11.6vw,64px);
-  transition:transform .12s;
-}
-.hand-row .tile .num{font-size:clamp(17px,4.6vw,24px);}
-.hand-row .tile .glyph{font-size:clamp(9px,2.4vw,13px);}
-.hand-row .tile.sel{transform:translateY(-12px);box-shadow:0 6px 14px rgba(0,0,0,.5);}
+.handarea{flex-shrink:0;background:rgba(0,0,0,.32);border-top:1px solid rgba(255,255,255,.1);
+  padding:6px 8px calc(env(safe-area-inset-bottom) + 8px);}
+.hand-row{display:flex;justify-content:center;align-items:flex-end;gap:3px;flex-wrap:wrap;min-height:54px;}
+.hand-row .tile{width:clamp(30px,8.4vw,46px);height:clamp(42px,11.6vw,64px);transition:transform .12s;}
+.hand-row .tile .num{font-size:clamp(17px,4.6vw,24px);} .hand-row .tile .glyph{font-size:clamp(9px,2.4vw,13px);}
 .hand-row .tile.drawn{margin-left:12px;}
 .hand-row .tile.dim{opacity:.4;}
 .hand-row .tile.playable{cursor:pointer;}
 .hand-row .tile.playable:active{transform:translateY(-6px);}
+.hand-row .tile.win-hint{outline:2px solid var(--gold);outline-offset:1px;}
 
-/* meld tiles (medium) */
 .melds{display:flex;gap:6px;flex-wrap:wrap;justify-content:center;}
 .meld{display:flex;gap:1px;}
 .meld .tile{width:20px;height:28px;border-bottom-width:2px;}
-.meld .tile .num{font-size:12px;}
-.meld .tile .glyph{font-size:7px;}
+.meld .tile .num{font-size:12px;} .meld .tile .glyph{font-size:7px;}
 .meld .tile.concealed{background:linear-gradient(135deg,#1f7a4d,#0c5635);}
 .meld .tile.concealed .num,.meld .tile.concealed .glyph{visibility:hidden;}
 
-/* opponent hand backs */
 .backs{display:flex;gap:1px;flex-wrap:wrap;justify-content:center;max-width:200px;}
 .backs .tile{width:13px;height:18px;border-bottom-width:2px;}
 .seat-left .backs,.seat-right .backs{max-width:20px;}
 .seat-left .backs .tile,.seat-right .backs .tile{width:18px;height:12px;}
 
-/* discard river */
 .river{display:flex;flex-wrap:wrap;gap:2px;justify-content:center;align-content:flex-start;}
 .river .tile{width:18px;height:25px;border-bottom-width:2px;}
-.river .tile .num{font-size:11px;}
-.river .tile .glyph{font-size:6px;}
+.river .tile .num{font-size:11px;} .river .tile .glyph{font-size:6px;}
 .river .tile.last{outline:2px solid var(--gold);outline-offset:1px;box-shadow:0 0 10px var(--gold);}
 .seat-top .river,.seat-bottom .river{max-width:min(94vw,620px);}
 .seat-left .river,.seat-right .river{max-width:72px;}
@@ -163,121 +137,145 @@ button{font-family:inherit;cursor:pointer;border:none;}
 .center .wall-info{font-size:12px;opacity:.7;margin-bottom:6px;text-align:center;}
 .center .last-played{display:flex;flex-direction:column;align-items:center;gap:4px;}
 .center .last-played .tile{width:34px;height:47px;}
-.center .last-played .tile .num{font-size:20px;}
-.center .last-played .tile .glyph{font-size:11px;}
+.center .last-played .tile .num{font-size:20px;} .center .last-played .tile .glyph{font-size:11px;}
 .center .last-played .lbl{font-size:10px;opacity:.7;}
 
-/* action buttons */
-.actions{display:flex;gap:8px;justify-content:center;flex-wrap:wrap;margin-top:8px;min-height:44px;}
-.actions button{
-  padding:11px 18px;border-radius:11px;font-size:16px;font-weight:800;letter-spacing:1px;
-  background:rgba(255,255,255,.14);color:#fff;border:1.5px solid rgba(255,255,255,.25);
-}
+.ready-banner{font-size:12px;color:var(--gold);text-align:center;margin-bottom:4px;min-height:16px;}
+.actions{display:flex;gap:8px;justify-content:center;flex-wrap:wrap;margin-top:6px;min-height:44px;align-items:center;}
+.actions button{padding:11px 18px;border-radius:11px;font-size:16px;font-weight:800;letter-spacing:1px;
+  background:rgba(255,255,255,.14);color:#fff;border:1.5px solid rgba(255,255,255,.25);}
 .actions button:active{transform:scale(.96);}
 .actions .b-hu{background:linear-gradient(135deg,#ffcb52,#ff9d2e);color:#3a2600;border-color:#fff;}
 .actions .b-peng{background:linear-gradient(135deg,#5ac8fa,#2b6fb5);border-color:#fff;}
 .actions .b-gang{background:linear-gradient(135deg,#bd6cff,#7a3fd6);border-color:#fff;}
 .actions .b-pass{background:rgba(255,255,255,.1);}
-.actions .hint{align-self:center;font-size:13px;opacity:.8;font-weight:500;letter-spacing:0;}
+.actions .hint{font-size:13px;opacity:.8;font-weight:500;letter-spacing:0;}
 
-/* ding que */
-.dingque{display:flex;flex-direction:column;align-items:center;gap:14px;}
-.dingque .q{font-size:16px;text-align:center;}
+.dingque{display:flex;flex-direction:column;align-items:center;gap:12px;}
+.dingque .q{font-size:15px;text-align:center;}
 .dingque .opts{display:flex;gap:12px;}
-.dingque .opts button{
-  display:flex;flex-direction:column;align-items:center;gap:4px;padding:16px 18px;border-radius:14px;
-  background:rgba(255,255,255,.12);color:#fff;border:2px solid rgba(255,255,255,.2);min-width:84px;
-}
+.dingque .opts button{display:flex;flex-direction:column;align-items:center;gap:4px;padding:14px 16px;border-radius:14px;
+  background:rgba(255,255,255,.12);color:#fff;border:2px solid rgba(255,255,255,.2);min-width:80px;}
 .dingque .opts button .big{font-size:30px;font-weight:800;}
 .dingque .opts button .ct{font-size:12px;opacity:.85;}
 .dingque .opts button.rec{border-color:var(--gold);}
 .dingque .opts button.rec .tag{font-size:9px;color:var(--gold);}
 
-/* overlay (reveal gate, toasts, results) */
 #overlay{position:absolute;inset:0;display:none;align-items:center;justify-content:center;z-index:40;
   background:rgba(0,0,0,.6);backdrop-filter:blur(4px);padding:24px;}
 .modal{background:#0d4d33;border:1px solid rgba(255,255,255,.18);border-radius:18px;padding:22px;
   max-width:480px;width:100%;max-height:88vh;overflow-y:auto;box-shadow:0 12px 40px rgba(0,0,0,.5);}
 .modal h2{color:var(--gold);font-size:22px;margin-bottom:10px;text-align:center;}
 .modal p{font-size:14px;line-height:1.5;opacity:.92;margin-bottom:8px;}
-.modal .btn{margin-top:16px;width:100%;padding:14px;border-radius:12px;background:var(--gold);color:#2a1c00;font-weight:800;font-size:16px;}
+.modal .btn{margin-top:14px;width:100%;padding:14px;border-radius:12px;background:var(--gold);color:#2a1c00;font-weight:800;font-size:16px;}
 .modal .btn.alt{background:rgba(255,255,255,.14);color:#fff;margin-top:8px;}
-.reveal-gate{text-align:center;cursor:pointer;}
-.reveal-gate .big{font-size:48px;}
-.reveal-gate h2{margin-top:8px;}
+.reveal-gate{text-align:center;cursor:pointer;} .reveal-gate .big{font-size:48px;}
 .scoreboard{width:100%;border-collapse:collapse;margin-top:8px;font-size:14px;}
 .scoreboard td,.scoreboard th{padding:7px 8px;text-align:left;border-bottom:1px solid rgba(255,255,255,.1);}
 .scoreboard th{opacity:.6;font-size:11px;text-transform:uppercase;}
 .scoreboard .pos{text-align:right;font-variant-numeric:tabular-nums;font-weight:700;}
-.scoreboard .gain-pos{color:#5ad17a;}
-.scoreboard .gain-neg{color:#ff7b7b;}
-.fan-list{display:flex;flex-wrap:wrap;gap:6px;justify-content:center;margin:6px 0;}
-.fan-list span{background:rgba(244,213,141,.18);border:1px solid var(--gold);color:var(--gold);
-  padding:2px 9px;border-radius:14px;font-size:12px;font-weight:600;}
+.scoreboard .gain-pos{color:#5ad17a;} .scoreboard .gain-neg{color:#ff7b7b;}
+.delta{font-variant-numeric:tabular-nums;font-size:12px;opacity:.8;}
 
-.toast{position:absolute;top:18%;left:50%;transform:translateX(-50%);z-index:50;
+.lobby{display:flex;flex-direction:column;gap:10px;}
+.lobby .code{font-size:34px;font-weight:800;letter-spacing:8px;color:var(--gold);text-align:center;
+  background:rgba(0,0,0,.3);border-radius:12px;padding:10px;}
+.lobby .seat-list{display:flex;flex-direction:column;gap:8px;}
+.lobby .seat-card{display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:12px;background:rgba(255,255,255,.08);font-size:15px;}
+.lobby .seat-card .badge{margin-left:auto;font-size:12px;padding:3px 8px;border-radius:8px;background:rgba(255,255,255,.15);}
+.lobby .seat-card .badge.ready{background:var(--sou);} .lobby .seat-card .badge.host{background:var(--gold);color:#1a1a1a;}
+.lobby .seat-card.me{border:1.5px solid var(--gold);}
+
+.toast{position:absolute;top:16%;left:50%;transform:translateX(-50%);z-index:50;
   background:rgba(0,0,0,.82);border:2px solid var(--gold);color:var(--gold);
-  padding:14px 28px;border-radius:14px;font-size:26px;font-weight:800;letter-spacing:3px;
-  pointer-events:none;opacity:0;transition:opacity .2s;white-space:nowrap;}
+  padding:13px 26px;border-radius:14px;font-size:24px;font-weight:800;letter-spacing:3px;
+  pointer-events:none;opacity:0;transition:opacity .2s;white-space:nowrap;text-align:center;}
 .toast.show{opacity:1;}
-
+.rules-content{text-align:left;}
 .rules-content h3{color:var(--gold);font-size:15px;margin:12px 0 4px;}
 .rules-content ul{margin-left:18px;font-size:13px;line-height:1.5;opacity:.92;}
-.rules-content{text-align:left;}
-#testout{font-family:ui-monospace,Menlo,monospace;font-size:11px;white-space:pre-wrap;text-align:left;
-  background:rgba(0,0,0,.4);padding:10px;border-radius:8px;max-height:50vh;overflow:auto;}
 </style>
 </head>
 <body>
 
-<!-- ============ SETUP SCREEN ============ -->
+<!-- ============ SETUP ============ -->
 <div id="setup">
-  <div class="brand">
-    <div class="cn">四川麻將</div>
-    <div class="en">Sichuan Mahjong &middot; Bloody Rules</div>
+  <div class="brand"><div class="cn">四川麻將</div><div class="en">Sichuan Mahjong &middot; Bloody Battle</div></div>
+
+  <div class="mode-tabs">
+    <button data-tab="local" class="on">Local / Hot-seat</button>
+    <button data-tab="online">Play Online</button>
   </div>
 
-  <div class="card">
-    <h2>Players</h2>
-    <div class="seg" id="humans-seg">
-      <button data-h="1" class="on">1<span class="sub">+3 bots</span></button>
-      <button data-h="2">2<span class="sub">+2 bots</span></button>
-      <button data-h="3">3<span class="sub">+1 bot</span></button>
-      <button data-h="4">4<span class="sub">all human</span></button>
+  <!-- LOCAL setup -->
+  <div id="local-setup">
+    <div class="card">
+      <h2>Players at this device</h2>
+      <div class="seg" id="humans-seg">
+        <button data-h="1" class="on">1<span class="sub">+3 bots</span></button>
+        <button data-h="2">2<span class="sub">+2 bots</span></button>
+        <button data-h="3">3<span class="sub">+1 bot</span></button>
+        <button data-h="4">4<span class="sub">all human</span></button>
+      </div>
+      <div class="names" id="name-inputs"></div>
     </div>
-    <div class="names" id="name-inputs"></div>
-  </div>
-
-  <div class="card">
-    <h2>Bot Difficulty</h2>
-    <div class="seg" id="diff-seg">
-      <button data-d="easy">Easy<span class="sub">loose play</span></button>
-      <button data-d="normal" class="on">Normal<span class="sub">solid</span></button>
-      <button data-d="hard">Hard<span class="sub">defends &amp; counts</span></button>
+    <div class="card">
+      <h2>Bot Difficulty</h2>
+      <div class="seg" id="diff-seg">
+        <button data-d="easy">Easy<span class="sub">loose</span></button>
+        <button data-d="normal" class="on">Normal<span class="sub">solid</span></button>
+        <button data-d="hard">Hard<span class="sub">defends</span></button>
+      </div>
     </div>
-  </div>
-
-  <div class="card">
-    <h2>Mode</h2>
-    <div class="seg" id="mode-seg">
-      <button data-m="bloody" class="on">Bloody<span class="sub">play to 3 winners</span></button>
-      <button data-m="single">Single<span class="sub">first win ends hand</span></button>
+    <div class="card">
+      <h2>Rules</h2>
+      <div class="seg" id="mode-seg">
+        <button data-m="bloody" class="on">Bloody<span class="sub">to 3 winners</span></button>
+        <button data-m="single">Single<span class="sub">first win ends</span></button>
+      </div>
+      <div class="toggle-row"><span>Seven Pairs (七对)</span><div class="switch on" id="sw-sevenpairs"></div></div>
     </div>
+    <button class="start-btn" id="start-local">Deal Tiles</button>
   </div>
 
-  <button class="start-btn" id="start-btn">Deal Tiles</button>
+  <!-- ONLINE setup -->
+  <div id="online-setup" style="display:none;width:100%;max-width:460px;">
+    <div class="card">
+      <h2>Your name</h2>
+      <input class="txt" id="online-name" placeholder="Name" maxlength="12">
+    </div>
+    <div class="card">
+      <h2>Bot Difficulty (for empty seats)</h2>
+      <div class="seg" id="odiff-seg">
+        <button data-d="easy">Easy</button>
+        <button data-d="normal" class="on">Normal</button>
+        <button data-d="hard">Hard</button>
+      </div>
+    </div>
+    <button class="start-btn" id="btn-create">Create Game</button>
+    <div class="card">
+      <h2>Join a Game</h2>
+      <div class="row-inline">
+        <input class="txt" id="join-code" placeholder="ROOM CODE" maxlength="5" style="text-transform:uppercase;letter-spacing:4px;font-weight:700;">
+        <button class="start-btn sec" id="btn-join" style="margin:0;width:auto;padding:0 20px;">Join</button>
+      </div>
+    </div>
+    <div class="hostmsg" id="online-msg"></div>
+  </div>
+
   <div class="setup-foot">
     <button id="rules-link">How to play</button>
     <a href="../">&larr; All apps</a>
   </div>
 </div>
 
-<!-- ============ GAME SCREEN ============ -->
+<!-- ============ GAME ============ -->
 <div id="game">
   <div class="topbar">
     <span class="title">四川麻將</span>
     <span class="info" id="round-info"></span>
     <span class="spacer"></span>
+    <span class="conpill" id="conpill" style="display:none;"></span>
     <button id="rules-btn">Rules</button>
     <button id="menu-btn">Menu</button>
   </div>
@@ -296,1435 +294,1471 @@ button{font-family:inherit;cursor:pointer;border:none;}
 <div id="overlay"></div>
 <div class="toast" id="toast"></div>
 
-<script>
+<script type="module">
 "use strict";
-/* ===================================================================
-   SICHUAN MAHJONG  (血战到底)
-   --------------------------------------------------------------------
-   Architecture (per spec):
+/* CORE-INLINE-START */
+// ==CORE-START== (synced region — keep identical with index.html)
 
-      Rules Engine   -> pure, no DOM, no hidden info
-         enumerateLegalActions(state, player, ctx)
-         evaluateHand(state, player)
-         simulate(state, action)
-         score(state, winner, info)
-      Legal Actions  -> the ONLY thing a bot may pick from
-      Bot Decision   -> chooses among legal actions; validated again before use
+/* ---- tile model: suit 0=DOT(筒) 1=BAMBOO(条) 2=CHARACTER(萬), rank 1..9 ---- */
+const DOT = 0, BAMBOO = 1, CHARACTER = 2;
+const SUIT_GLYPH = ['筒', '条', '萬'];
+const SUIT_NAME = ['Dots', 'Bamboo', 'Characters'];
+const tileIndex = (suit, rank) => suit * 9 + (rank - 1);
+const tileSuit = (t) => (t / 9) | 0;
+const tileRank = (t) => (t % 9) + 1;
+const NUM_TYPES = 27;
 
-   No chi/chow (Sichuan).  Mandatory missing-suit (定缺).  Peng / 3 kinds of
-   Gang / Hu (zimo, dianpao, rob-the-kong).  Fan-based scoring + 刮风下雨 gang
-   payments.  Bloody mode continues until 3 players have won.
-   =================================================================== */
+const emptyCounts = () => new Array(NUM_TYPES).fill(0);
+const countTotal = (c) => { let s = 0; for (let i = 0; i < NUM_TYPES; i++) s += c[i]; return s; };
+const countsToList = (c) => { const a = []; for (let t = 0; t < NUM_TYPES; t++) for (let i = 0; i < c[t]; i++) a.push(t); return a; };
 
-/* -------- tile helpers (kind = suit*9 + rank-1, suit 0=萬 1=条 2=筒) -------- */
-const SUIT_GLYPH = ['萬','条','筒'];
-const SUIT_CLASS = ['m','s','p'];
-const SUIT_EN    = ['Characters','Bamboo','Dots'];
-const ksuit = k => (k / 9) | 0;
-const krank = k => (k % 9) + 1;
-const mk = (suit, rank) => suit * 9 + rank - 1;
-const emptyCounts = () => new Array(27).fill(0);
-const handSize = c => { let s = 0; for (let i = 0; i < 27; i++) s += c[i]; return s; };
-const kindsOf = c => { const a = []; for (let k = 0; k < 27; k++) if (c[k] > 0) a.push(k); return a; };
-function listOf(c){ const a=[]; for(let k=0;k<27;k++) for(let i=0;i<c[k];i++) a.push(k); return a; }
+/* ---- deterministic RNG (mulberry32). state.rng is a serializable integer ---- */
+function rngNext(state) {
+  let x = (state.rng + 0x6D2B79F5) | 0;
+  state.rng = x;
+  x = Math.imul(x ^ (x >>> 15), 1 | x);
+  x = (x + Math.imul(x ^ (x >>> 7), 61 | x)) ^ x;
+  return ((x ^ (x >>> 14)) >>> 0) / 4294967296;
+}
+function rngInt(state, n) { return (rngNext(state) * n) | 0; }
+
+/* ---- default table rules (spec §21.4 / §26 "common digital rules") ---- */
+const DEFAULT_CONFIG = {
+  allowSevenPairs: true,
+  fourOfKindCountsAsTwoPairs: true,
+  mustDiscardMissingSuitFirst: true,
+  allowMeldsInMissingSuit: false,
+  allowKongInMissingSuit: false,
+  allowMultipleWinnersOnDiscard: true,
+  allowRobKong: true,
+  allowMultipleRobKongWinners: true,
+  wonPlayersExcludedFromFuturePayments: true,
+  fanLimit: 3,
+  baseWinPoints: 1,
+  selfDrawBonusFan: 1,
+  robKongBonusFan: 1,
+  kongBloomBonusFan: 1,
+  rootFan: 1,
+  allPungsFan: 1,
+  pureOneSuitFan: 2,
+  sevenPairsFan: 2,
+  luxurySevenPairsExtraFanPerQuad: 1,
+  lastTileFan: 1,
+  heavenlyEarthlyFan: 3,       // table-limit
+  enableMissingSuitPenaltyAtExhaustion: true,
+  missingSuitPenalty: 2,
+  kongExposedFromDiscard: 2,   // discarder pays
+  kongAdded: 1,                // each non-won opponent pays
+  kongConcealed: 2,            // each non-won opponent pays
+  mode: 'bloody',              // 'bloody' | 'single'
+};
+
+/* ---- meld types ---- */
+const PUNG = 'PUNG';
+const KONG_EXPOSED_FROM_DISCARD = 'KONG_EXPOSED_FROM_DISCARD';
+const KONG_ADDED = 'KONG_ADDED';
+const KONG_CONCEALED = 'KONG_CONCEALED';
+const isKong = (m) => m.type !== PUNG;
+const meldPhysical = (m) => (m.type === PUNG ? 3 : 4);
+
+/* ---- phases (spec §18) ---- */
+const PHASE = {
+  MISSING_SUIT: 'MISSING_SUIT_SELECTION',
+  ACTIVE_TURN: 'ACTIVE_TURN',
+  DISCARD_REACT: 'AWAITING_DISCARD_REACTIONS',
+  ROB_REACT: 'AWAITING_ROB_KONG_REACTIONS',
+  HAND_ENDED: 'HAND_ENDED',
+};
 
 /* =====================================================================
-   RULES ENGINE — winning-hand detection
-   ===================================================================== */
-function formMelds(c, sets){
-  let i = 0; while (i < 27 && c[i] === 0) i++;
-  if (i === 27) return sets === 0;
-  if (sets === 0) return false;
-  if (c[i] >= 3){ c[i]-=3; if (formMelds(c, sets-1)){ c[i]+=3; return true; } c[i]+=3; }
+ * Game creation & dealing
+ * ===================================================================== */
+function makeConfig(overrides) { return Object.assign({}, DEFAULT_CONFIG, overrides || {}); }
+
+function createGame(opts = {}) {
+  const config = makeConfig(opts.config);
+  const seed = (opts.seed != null ? opts.seed : 0x1a2b3c4d) | 0;
+  const dealer = (opts.dealer || 0) % 4;
+  const names = opts.names || ['East', 'South', 'West', 'North'];
+  const seats = opts.seats || [
+    { isBot: false, difficulty: 'normal' },
+    { isBot: true, difficulty: 'normal' },
+    { isBot: true, difficulty: 'normal' },
+    { isBot: true, difficulty: 'normal' },
+  ];
+
+  const state = {
+    config, seed, rng: seed, handNo: opts.handNo || 1,
+    phase: PHASE.MISSING_SUIT, dealer, active: dealer,
+    wall: [], wallHead: 0, wallTail: 0,
+    players: [],
+    pendingDiscard: null, reactions: null, robReactions: null,
+    turnFlags: { needsDraw: false, drewFromKong: false, lastDrawn: null, firstTurn: false, lastTileExhausted: false },
+    firstDiscardDone: false,
+    winnersThisHand: [],
+    log: [],
+    ended: false, endReason: null,
+    seatScores: opts.seatScores || [0, 0, 0, 0],   // carry running scores across hands
+  };
+
+  for (let i = 0; i < 4; i++) {
+    state.players.push({
+      seat: i,
+      name: names[i] || ('P' + (i + 1)),
+      isBot: seats[i] ? !!seats[i].isBot : true,
+      difficulty: seats[i] ? (seats[i].difficulty || 'normal') : 'normal',
+      connected: true,
+      concealed: emptyCounts(),
+      melds: [],
+      discards: [],
+      missingSuit: null,
+      hasWon: false,
+      winOrder: null,
+      winRecords: [],
+      score: state.seatScores[i] || 0,
+      isDealer: i === dealer,
+    });
+  }
+
+  // build & shuffle the 108-tile wall (spec §3.1)
+  const wall = [];
+  for (let suit = 0; suit < 3; suit++)
+    for (let rank = 1; rank <= 9; rank++)
+      for (let k = 0; k < 4; k++) wall.push(tileIndex(suit, rank));
+  for (let i = wall.length - 1; i > 0; i--) {
+    const j = rngInt(state, i + 1);
+    const tmp = wall[i]; wall[i] = wall[j]; wall[j] = tmp;
+  }
+  state.wall = wall;
+  state.wallHead = 0;
+  state.wallTail = wall.length;
+  logEvent(state, { type: 'WallShuffled', seed });
+
+  // deal: dealer 14, others 13 (spec §3.2)
+  for (let i = 0; i < 4; i++) {
+    const p = state.players[(dealer + i) % 4];
+    const n = p.isDealer ? 14 : 13;
+    for (let k = 0; k < n; k++) p.concealed[drawFront(state)]++;
+  }
+  logEvent(state, { type: 'TilesDealt' });
+
+  // dealer keeps the 14th and acts first WITHOUT drawing (enables Heavenly Hand)
+  state.turnFlags.needsDraw = false;
+  state.turnFlags.firstTurn = true;
+  return state;
+}
+
+function drawFront(state) {
+  if (state.wallHead >= state.wallTail) return -1;
+  return state.wall[state.wallHead++];
+}
+function drawBack(state) {
+  if (state.wallTail <= state.wallHead) return -1;
+  return state.wall[--state.wallTail];
+}
+const wallRemaining = (state) => state.wallTail - state.wallHead;
+
+function logEvent(state, ev) { state.log.push(ev); return ev; }
+
+/* =====================================================================
+ * Winning-hand validation (spec §7)
+ * ===================================================================== */
+function canPartition(counts, groupsNeeded) {
+  let i = 0; while (i < NUM_TYPES && counts[i] === 0) i++;
+  if (i === NUM_TYPES) return groupsNeeded === 0;
+  if (groupsNeeded === 0) return false;
+  // pung
+  if (counts[i] >= 3) {
+    counts[i] -= 3;
+    if (canPartition(counts, groupsNeeded - 1)) { counts[i] += 3; return true; }
+    counts[i] += 3;
+  }
+  // chow (same suit, consecutive) — allowed in concealed shape only
   const r = i % 9;
-  if (r <= 6 && c[i+1] > 0 && c[i+2] > 0){
-    c[i]--; c[i+1]--; c[i+2]--;
-    if (formMelds(c, sets-1)){ c[i]++; c[i+1]++; c[i+2]++; return true; }
-    c[i]++; c[i+1]++; c[i+2]++;
+  if (r <= 6 && counts[i + 1] > 0 && counts[i + 2] > 0) {
+    counts[i]--; counts[i + 1]--; counts[i + 2]--;
+    if (canPartition(counts, groupsNeeded - 1)) { counts[i]++; counts[i + 1]++; counts[i + 2]++; return true; }
+    counts[i]++; counts[i + 1]++; counts[i + 2]++;
   }
   return false;
 }
-function isStandardWin(c, sets){
-  for (let p = 0; p < 27; p++){
-    if (c[p] >= 2){ c[p]-=2; const ok = formMelds(c.slice(), sets); c[p]+=2; if (ok) return true; }
+function isStandardShape(counts, groupsNeeded) {
+  for (let p = 0; p < NUM_TYPES; p++) {
+    if (counts[p] >= 2) {
+      counts[p] -= 2;
+      const ok = canPartition(counts.slice(), groupsNeeded);
+      counts[p] += 2;
+      if (ok) return true;
+    }
   }
   return false;
 }
-function isSevenPairs(c){
-  if (handSize(c) !== 14) return false;
-  for (let k = 0; k < 27; k++) if (c[k] % 2 !== 0) return false;
-  return true;
-}
-function onlyTriplets(c, sets){
-  let i = 0; while (i < 27 && c[i] === 0) i++;
-  if (i === 27) return sets === 0;
-  if (sets > 0 && c[i] >= 3){ c[i]-=3; if (onlyTriplets(c, sets-1)){ c[i]+=3; return true; } c[i]+=3; }
-  return false;
-}
-function isAllPungs(c, sets){
-  for (let p = 0; p < 27; p++){
-    if (c[p] >= 2){ const cc = c.slice(); cc[p]-=2; if (onlyTriplets(cc, sets)) return true; }
+function isSevenPairs(counts, config) {
+  if (countTotal(counts) !== 14) return false;
+  let pairs = 0;
+  for (let t = 0; t < NUM_TYPES; t++) {
+    const c = counts[t];
+    if (c === 1 || c === 3) return false;
+    if (c === 2) pairs += 1;
+    if (c === 4) pairs += (config.fourOfKindCountsAsTwoPairs ? 2 : -100);
   }
+  return pairs === 7;
+}
+function hasMissingSuitInCounts(counts, missingSuit) {
+  if (missingSuit == null) return false;
+  for (let r = 0; r < 9; r++) if (counts[missingSuit * 9 + r] > 0) return true;
   return false;
 }
-const missingCount = p => { if (p.missing == null) return 0; let s = 0; for (let r = 0; r < 9; r++) s += p.hand[p.missing*9+r]; return s; };
+/* Does player p's concealed counts (already at winning size) form a legal win? */
+function isWinningCounts(counts, melds, missingSuit, config) {
+  if (hasMissingSuitInCounts(counts, missingSuit)) return false;
+  const groupsNeeded = 4 - melds.length;
+  const total = countTotal(counts);
+  if (total !== groupsNeeded * 3 + 2) return false;
+  if (melds.length === 0 && config.allowSevenPairs && isSevenPairs(counts, config)) return true;
+  return isStandardShape(counts.slice(), groupsNeeded);
+}
+/* Player-level helper: would adding `tile` (or nothing) make a win? */
+function isWinningHand(player, config, addTile = null) {
+  const c = player.concealed.slice();
+  if (addTile != null) {
+    if (tileSuit(addTile) === player.missingSuit) return false;
+    c[addTile]++;
+  }
+  return isWinningCounts(c, player.melds, player.missingSuit, config);
+}
+const winsNow = (player, config) => isWinningHand(player, config, null);
 
-/* Does the player's CURRENT concealed hand (already winning size) form a win? */
-function winsNow(p){
-  const c = p.hand;
-  if (missingCount(p) > 0) return false;                 // 缺一门 not satisfied
-  const sets = 4 - p.melds.length;
-  if (handSize(c) !== sets * 3 + 2) return false;
-  if (p.melds.length === 0 && isSevenPairs(c)) return true;
-  return isStandardWin(c.slice(), sets);
-}
-/* Could the player win by adding `kind`?  (kind must not be their missing suit) */
-function canHu(p, kind){
-  if (ksuit(kind) === p.missing) return false;
-  p.hand[kind]++; const r = winsNow(p); p.hand[kind]--; return r;
-}
-/* Tenpai = one tile away from a legal win (used for draw-game settlement & AI). */
-function isTenpai(p){
-  if (missingCount(p) > 0) return false;
-  for (let k = 0; k < 27; k++){
-    if (ksuit(k) === p.missing) continue;
-    if (p.hand[k] >= 4) continue;
-    p.hand[k]++; const w = winsNow(p); p.hand[k]--;
-    if (w) return true;
+/* ---- ready / ting detection (spec §16) ---- */
+function getWinningTiles(player, config, state = null) {
+  const tiles = [];
+  if (hasMissingSuitInCounts(player.concealed, player.missingSuit)) return tiles;
+  for (let t = 0; t < NUM_TYPES; t++) {
+    if (tileSuit(t) === player.missingSuit) continue;
+    if (player.concealed[t] >= 4) continue;
+    if (state && remainingOf(state, t, player.seat) <= 0) continue;
+    if (isWinningHand(player, config, t)) tiles.push(t);
   }
-  return false;
+  return tiles;
+}
+const isReady = (player, config, state = null) => getWinningTiles(player, config, state).length > 0;
+
+/* count of tile-type t not visible to seat `me` (public info + own hand) */
+function remainingOf(state, t, me) {
+  let seen = 0;
+  for (let s = 0; s < 4; s++) {
+    const p = state.players[s];
+    if (s === me) seen += p.concealed[t];
+    for (const m of p.melds) if (m.tile === t) seen += meldPhysical(m);
+    for (const d of p.discards) if (d === t) seen++;
+  }
+  if (state.pendingDiscard && state.pendingDiscard.tile === t) seen++;
+  return 4 - seen;
 }
 
 /* =====================================================================
-   RULES ENGINE — shanten (distance to tenpai) for the AI
-   ===================================================================== */
-function sevenPairsShanten(c){
-  let pairs = 0, kinds = 0;
-  for (let k = 0; k < 27; k++){ if (c[k] > 0) kinds++; if (c[k] >= 2) pairs++; }
-  let sh = 6 - pairs;
-  if (kinds < 7) sh += 7 - kinds;
-  return sh;
+ * Legal-action generation (spec §17)
+ * Action shapes:
+ *   {type:'ChooseMissingSuit', suit}
+ *   {type:'Discard', tile}      {type:'Pass'}
+ *   {type:'ClaimPung', tile}    {type:'ClaimKongFromDiscard', tile}
+ *   {type:'DeclareConcealedKong', tile}  {type:'DeclareAddedKong', tile}
+ *   {type:'DeclareWinFromDiscard', tile} {type:'DeclareSelfDrawWin'}
+ *   {type:'RobKong', tile}
+ * ===================================================================== */
+const missingCount = (p) => {
+  if (p.missingSuit == null) return 0;
+  let s = 0; for (let r = 0; r < 9; r++) s += p.concealed[p.missingSuit * 9 + r]; return s;
+};
+function legalDiscards(player, config) {
+  const out = [];
+  const holdsMissing = missingCount(player) > 0;
+  for (let t = 0; t < NUM_TYPES; t++) {
+    if (player.concealed[t] === 0) continue;
+    if (config.mustDiscardMissingSuitFirst && holdsMissing && tileSuit(t) !== player.missingSuit) continue;
+    out.push(t);
+  }
+  return out;
 }
-function stdShanten(c0, openMelds){
-  let best = 8;
-  const c = c0.slice();
-  function rec(i, melds, partials, pairUsed){
-    while (i < 27 && c[i] === 0) i++;
-    if (i === 27){
-      let m = melds + openMelds;
-      let part = partials;
-      if (m + part > 4) part = 4 - m;
-      let sh = (4 - m) * 2 - part - (pairUsed ? 1 : 0);
-      if (sh < best) best = sh;
-      return;
+
+function getLegalActions(state, seat) {
+  const p = state.players[seat];
+  if (state.phase === PHASE.HAND_ENDED) return [];
+  if (p.hasWon) return [];
+
+  if (state.phase === PHASE.MISSING_SUIT) {
+    if (p.missingSuit != null) return [];
+    return [
+      { type: 'ChooseMissingSuit', suit: DOT },
+      { type: 'ChooseMissingSuit', suit: BAMBOO },
+      { type: 'ChooseMissingSuit', suit: CHARACTER },
+    ];
+  }
+
+  if (state.phase === PHASE.ACTIVE_TURN) {
+    if (seat !== state.active) return [];
+    const acts = [];
+    const holdsMissing = missingCount(p) > 0;
+    const justDrew = state.turnFlags.lastDrawn != null || state.turnFlags.firstTurn;
+    // self-draw win
+    if (!holdsMissing && justDrew && winsNow(p, state.config)) acts.push({ type: 'DeclareSelfDrawWin' });
+    if (!holdsMissing && !state.turnFlags.afterPung) {
+      // concealed kong
+      for (let t = 0; t < NUM_TYPES; t++) {
+        if (p.concealed[t] === 4 && (state.config.allowKongInMissingSuit || tileSuit(t) !== p.missingSuit))
+          acts.push({ type: 'DeclareConcealedKong', tile: t });
+      }
+      // added kong (upgrade an exposed pung)
+      for (const m of p.melds) {
+        if (m.type === PUNG && p.concealed[m.tile] >= 1 &&
+            (state.config.allowKongInMissingSuit || tileSuit(m.tile) !== p.missingSuit))
+          acts.push({ type: 'DeclareAddedKong', tile: m.tile });
+      }
     }
-    if (c[i] >= 3){ c[i]-=3; rec(i, melds+1, partials, pairUsed); c[i]+=3; }
-    if (i%9 <= 6 && c[i+1] > 0 && c[i+2] > 0){ c[i]--;c[i+1]--;c[i+2]--; rec(i,melds+1,partials,pairUsed); c[i]++;c[i+1]++;c[i+2]++; }
-    if (!pairUsed && c[i] >= 2){ c[i]-=2; rec(i, melds, partials, true); c[i]+=2; }
-    if (c[i] >= 2){ c[i]-=2; rec(i, melds, partials+1, pairUsed); c[i]+=2; }
-    if (i%9 <= 7 && c[i+1] > 0){ c[i]--;c[i+1]--; rec(i, melds, partials+1, pairUsed); c[i]++;c[i+1]++; }
-    if (i%9 <= 6 && c[i+2] > 0){ c[i]--;c[i+2]--; rec(i, melds, partials+1, pairUsed); c[i]++;c[i+2]++; }
+    for (const t of legalDiscards(p, state.config)) acts.push({ type: 'Discard', tile: t });
+    return acts;
+  }
+
+  if (state.phase === PHASE.DISCARD_REACT) {
+    const r = state.reactions;
+    if (!r || r.discarder === seat || r.responses[seat] != null || !r.eligible.includes(seat)) return [];
+    const tile = r.tile;
+    const acts = [];
+    const holdsMissing = missingCount(p) > 0;
+    if (!holdsMissing && tileSuit(tile) !== p.missingSuit && isWinningHand(p, state.config, tile))
+      acts.push({ type: 'DeclareWinFromDiscard', tile });
+    const meldOk = !holdsMissing && (state.config.allowMeldsInMissingSuit || tileSuit(tile) !== p.missingSuit);
+    if (meldOk && p.concealed[tile] >= 3) acts.push({ type: 'ClaimKongFromDiscard', tile });
+    if (meldOk && p.concealed[tile] >= 2) acts.push({ type: 'ClaimPung', tile });
+    acts.push({ type: 'Pass' });
+    return acts;
+  }
+
+  if (state.phase === PHASE.ROB_REACT) {
+    const r = state.robReactions;
+    if (!r || r.declarer === seat || r.responses[seat] != null || !r.eligible.includes(seat)) return [];
+    const tile = r.tile;
+    const acts = [];
+    if (state.config.allowRobKong && tileSuit(tile) !== p.missingSuit && isWinningHand(p, state.config, tile))
+      acts.push({ type: 'RobKong', tile });
+    acts.push({ type: 'Pass' });
+    return acts;
+  }
+
+  return [];
+}
+
+/* Seats that currently owe a decision (driver: prompt humans, run bots). */
+function pendingDeciders(state) {
+  const out = [];
+  if (state.phase === PHASE.HAND_ENDED) return out;
+  for (let s = 0; s < 4; s++) if (getLegalActions(state, s).length > 0) out.push(s);
+  return out;
+}
+
+const actionsEqual = (a, b) =>
+  a && b && a.type === b.type && (a.tile ?? -1) === (b.tile ?? -1) && (a.suit ?? -1) === (b.suit ?? -1);
+
+/* =====================================================================
+ * applyAction — validates via getLegalActions, mutates state, cascades
+ * through auto-advances, returns {ok, events, error}.
+ * ===================================================================== */
+function invalid(code, message, details, suggested) {
+  return { ok: false, error: { code, message, details: details || '', suggestedActions: suggested || [] } };
+}
+function applyAction(state, seat, action) {
+  const legal = getLegalActions(state, seat);
+  if (!legal.some((o) => actionsEqual(o, action))) {
+    return invalid(...explainIllegal(state, seat, action));
+  }
+  const before = state.log.length;
+  switch (action.type) {
+    case 'ChooseMissingSuit': doChooseMissing(state, seat, action.suit); break;
+    case 'Discard': doDiscard(state, seat, action.tile); break;
+    case 'Pass': doReactionResponse(state, seat, action); break;
+    case 'ClaimPung': doReactionResponse(state, seat, action); break;
+    case 'ClaimKongFromDiscard': doReactionResponse(state, seat, action); break;
+    case 'DeclareWinFromDiscard': doReactionResponse(state, seat, action); break;
+    case 'RobKong': doRobResponse(state, seat, action); break;
+    case 'DeclareConcealedKong': doConcealedKong(state, seat, action.tile); break;
+    case 'DeclareAddedKong': doAddedKong(state, seat, action.tile); break;
+    case 'DeclareSelfDrawWin': doSelfDrawWin(state, seat); break;
+    default: return invalid('UNKNOWN_ACTION', 'Unknown action.');
+  }
+  return { ok: true, events: state.log.slice(before) };
+}
+
+/* ---- missing-suit selection (spec §3.3) ---- */
+function doChooseMissing(state, seat, suit) {
+  const p = state.players[seat];
+  p.missingSuit = suit;
+  logEvent(state, { type: 'MissingSuitChosen', seat, suit });
+  if (state.players.every((q) => q.missingSuit != null)) {
+    // begin play: dealer acts first with 14 tiles, no draw
+    state.phase = PHASE.ACTIVE_TURN;
+    state.active = state.dealer;
+    state.turnFlags = { needsDraw: false, drewFromKong: false, lastDrawn: null, firstTurn: true, afterPung: false, lastTileExhausted: false };
+  }
+}
+
+/* ---- begin a fresh turn for `seat`: draw (unless suppressed), maybe end ---- */
+function beginTurn(state, seat, { draw = true, fromKong = false, afterPung = false } = {}) {
+  // skip won players
+  let guard = 0;
+  while (state.players[seat].hasWon) {
+    seat = (seat + 1) % 4;
+    if (++guard > 4) { endHand(state, 'exhaustion'); return; }
+  }
+  state.active = seat;
+  state.turnFlags = { needsDraw: false, drewFromKong: fromKong, lastDrawn: null, firstTurn: false, afterPung, lastTileExhausted: false };
+  if (draw) {
+    if (wallRemaining(state) <= 0) { endHand(state, 'exhaustion'); return; }
+    const t = fromKong ? drawBack(state) : drawFront(state);
+    state.players[seat].concealed[t]++;
+    state.turnFlags.lastDrawn = t;
+    state.turnFlags.lastTileExhausted = wallRemaining(state) <= 0;
+    logEvent(state, { type: fromKong ? 'ReplacementTileDrawn' : 'TileDrawn', seat, tile: t });
+  }
+  state.phase = PHASE.ACTIVE_TURN;
+}
+
+/* next non-won seat after `from` (exclusive). returns -1 if none. */
+function nextActiveSeat(state, from) {
+  for (let k = 1; k <= 4; k++) {
+    const s = (from + k) % 4;
+    if (!state.players[s].hasWon) return s;
+  }
+  return -1;
+}
+const nonWonCount = (state) => state.players.filter((p) => !p.hasWon).length;
+
+/* ---- discard (spec §6.3) ---- */
+function commitDiscardToPile(state) {
+  // move the pending discard into the discarder's river (unclaimed); §19 keeps the
+  // pending slot and the pile as distinct terms, so the tile lives in exactly one.
+  const pd = state.pendingDiscard;
+  if (!pd) return;
+  state.players[pd.discarder].discards.push(pd.tile);
+  state.pendingDiscard = null;
+}
+function doDiscard(state, seat, tile) {
+  const p = state.players[seat];
+  p.concealed[tile]--;
+  const wasFirstDiscard = !state.firstDiscardDone;
+  const dealerFirstDiscard = wasFirstDiscard && seat === state.dealer;
+  state.firstDiscardDone = true;
+  state.turnFlags.afterPung = false;
+  const cameFromKongDiscard = state.turnFlags.drewFromKong; // 杠上炮 attribution
+  state.pendingDiscard = { tile, discarder: seat, dealerFirstDiscard, afterKong: cameFromKongDiscard, lastTile: wallRemaining(state) <= 0 };
+  logEvent(state, { type: 'TileDiscarded', seat, tile });
+
+  // who can react? (non-won, non-discarder with a real option)
+  const eligible = [];
+  for (let k = 1; k <= 3; k++) {
+    const s = (seat + k) % 4;
+    const q = state.players[s];
+    if (q.hasWon) continue;
+    const opts = reactionOptions(state, s, tile);
+    if (opts.win || opts.kong || opts.pung) eligible.push(s);
+  }
+  if (eligible.length === 0) { commitDiscardToPile(state); beginTurn(state, nextActiveSeat(state, seat)); return; }
+  state.phase = PHASE.DISCARD_REACT;
+  state.reactions = { tile, discarder: seat, eligible, responses: {} };
+}
+function reactionOptions(state, seat, tile) {
+  const p = state.players[seat];
+  const holdsMissing = missingCount(p) > 0;
+  const meldOk = !holdsMissing && (state.config.allowMeldsInMissingSuit || tileSuit(tile) !== p.missingSuit);
+  return {
+    win: !holdsMissing && tileSuit(tile) !== p.missingSuit && isWinningHand(p, state.config, tile),
+    kong: meldOk && p.concealed[tile] >= 3,
+    pung: meldOk && p.concealed[tile] >= 2,
+  };
+}
+
+/* ---- record a discard-reaction response; resolve when all responded ---- */
+function doReactionResponse(state, seat, action) {
+  state.reactions.responses[seat] = action;
+  if (action.type !== 'Pass') logEvent(state, { type: 'Reaction', seat, action: action.type });
+  const r = state.reactions;
+  if (r.eligible.every((s) => r.responses[s] != null)) resolveDiscardReactions(state);
+}
+function resolveDiscardReactions(state) {
+  const r = state.reactions;
+  const tile = r.tile, discarder = r.discarder;
+  const pd = state.pendingDiscard;
+  // 1) wins (possibly multiple) — highest priority
+  const winners = r.eligible.filter((s) => r.responses[s] && r.responses[s].type === 'DeclareWinFromDiscard');
+  if (winners.length) {
+    const ordered = state.config.allowMultipleWinnersOnDiscard ? winners : [nearestInOrder(discarder, winners)];
+    state.reactions = null;
+    commitDiscardToPile(state);   // the won tile stays visible in the river, counted once
+    for (const w of ordered) {
+      // The winning tile is scored VIRTUALLY (not added to concealed) so one physical
+      // tile can feed multiple winners without breaking conservation (spec §19, §10.1).
+      const ctx = { winType: 'DISCARD', winningTile: tile, source: discarder, lastTile: pd.lastTile, afterKong: pd.afterKong, isEarthly: pd.dealerFirstDiscard && w !== state.dealer };
+      resolveWin(state, w, ctx);
+    }
+    if (!checkHandEnd(state)) beginTurn(state, nextActiveSeat(state, discarder));
+    return;
+  }
+  // 2) kong (only one possible holder) — tile is consumed into the meld
+  const konger = r.eligible.find((s) => r.responses[s] && r.responses[s].type === 'ClaimKongFromDiscard');
+  if (konger != null) { state.reactions = null; state.pendingDiscard = null; claimKongFromDiscard(state, konger, tile, discarder); return; }
+  // 3) pung (only one possible holder) — tile is consumed into the meld
+  const punger = r.eligible.find((s) => r.responses[s] && r.responses[s].type === 'ClaimPung');
+  if (punger != null) { state.reactions = null; state.pendingDiscard = null; claimPung(state, punger, tile, discarder); return; }
+  // 4) all pass — tile joins the river
+  state.reactions = null;
+  commitDiscardToPile(state);
+  beginTurn(state, nextActiveSeat(state, discarder));
+}
+function nearestInOrder(from, list) {
+  for (let k = 1; k <= 3; k++) { const s = (from + k) % 4; if (list.includes(s)) return s; }
+  return list[0];
+}
+
+/* ---- claim pung (spec §6.5): take discard, expose, must discard ---- */
+function claimPung(state, seat, tile, discarder) {
+  const p = state.players[seat];
+  p.concealed[tile] -= 2;
+  p.melds.push({ type: PUNG, tile, source: discarder, concealed: false });
+  logEvent(state, { type: 'PungClaimed', seat, tile, source: discarder });
+  state.active = seat;
+  state.phase = PHASE.ACTIVE_TURN;
+  state.turnFlags = { needsDraw: false, drewFromKong: false, lastDrawn: null, firstTurn: false, afterPung: true, lastTileExhausted: false };
+}
+
+/* ---- exposed kong from discard (spec §6.6) ---- */
+function claimKongFromDiscard(state, seat, tile, discarder) {
+  const p = state.players[seat];
+  p.concealed[tile] -= 3;
+  p.melds.push({ type: KONG_EXPOSED_FROM_DISCARD, tile, source: discarder, concealed: false });
+  logEvent(state, { type: 'KongClaimedFromDiscard', seat, tile, source: discarder });
+  payKong(state, seat, KONG_EXPOSED_FROM_DISCARD, discarder);
+  beginTurn(state, seat, { draw: true, fromKong: true });   // replacement draw, may win/kong/discard
+}
+
+/* ---- concealed kong (spec §6.7) ---- */
+function doConcealedKong(state, seat, tile) {
+  const p = state.players[seat];
+  p.concealed[tile] -= 4;
+  p.melds.push({ type: KONG_CONCEALED, tile, source: null, concealed: true });
+  logEvent(state, { type: 'ConcealedKongDeclared', seat, tile });
+  payKong(state, seat, KONG_CONCEALED, null);
+  beginTurn(state, seat, { draw: true, fromKong: true });
+}
+
+/* ---- added kong (spec §6.8) with rob window (spec §6.9) ---- */
+function doAddedKong(state, seat, tile) {
+  // open rob-the-kong window
+  const eligible = [];
+  for (let k = 1; k <= 3; k++) {
+    const s = (seat + k) % 4;
+    const q = state.players[s];
+    if (q.hasWon) continue;
+    if (state.config.allowRobKong && tileSuit(tile) !== q.missingSuit && isWinningHand(q, state.config, tile)) eligible.push(s);
+  }
+  logEvent(state, { type: 'AddedKongDeclared', seat, tile });
+  if (eligible.length === 0) { finalizeAddedKong(state, seat, tile); return; }
+  state.phase = PHASE.ROB_REACT;
+  state.robReactions = { tile, declarer: seat, eligible, responses: {} };
+}
+function doRobResponse(state, seat, action) {
+  state.robReactions.responses[seat] = action;
+  const r = state.robReactions;
+  if (r.eligible.every((s) => r.responses[s] != null)) resolveRobReactions(state);
+}
+function resolveRobReactions(state) {
+  const r = state.robReactions;
+  const tile = r.tile, declarer = r.declarer;
+  const robbers = r.eligible.filter((s) => r.responses[s] && r.responses[s].type === 'RobKong');
+  if (robbers.length) {
+    const ordered = state.config.allowMultipleRobKongWinners ? robbers : [nearestInOrder(declarer, robbers)];
+    state.robReactions = null;
+    logEvent(state, { type: 'KongRobbed', declarer, tile });
+    for (const w of ordered) {
+      // winning tile scored virtually (the declarer keeps the physical tile)
+      resolveWin(state, w, { winType: 'ROB_KONG', winningTile: tile, source: declarer, lastTile: false, afterKong: false });
+    }
+    if (!checkHandEnd(state)) beginTurn(state, nextActiveSeat(state, declarer));
+    return;
+  }
+  state.robReactions = null;
+  finalizeAddedKong(state, declarer, tile);
+}
+function finalizeAddedKong(state, seat, tile) {
+  const p = state.players[seat];
+  const m = p.melds.find((x) => x.type === PUNG && x.tile === tile);
+  m.type = KONG_ADDED;
+  p.concealed[tile] -= 1;
+  payKong(state, seat, KONG_ADDED, null);
+  beginTurn(state, seat, { draw: true, fromKong: true });
+}
+
+/* ---- self-draw win (spec §6.11) ---- */
+function doSelfDrawWin(state, seat) {
+  const pd = state.turnFlags;
+  const isHeavenly = state.turnFlags.firstTurn && seat === state.dealer && !state.firstDiscardDone;
+  const ctx = { winType: 'SELF_DRAW', winningTile: state.turnFlags.lastDrawn, source: null,
+    lastTile: state.turnFlags.lastTileExhausted, afterKong: pd.drewFromKong, isHeavenly };
+  resolveWin(state, seat, ctx);
+  if (!checkHandEnd(state)) beginTurn(state, nextActiveSeat(state, seat));
+}
+
+/* =====================================================================
+ * Win resolution & payments (spec §13)
+ * ===================================================================== */
+function resolveWin(state, seat, ctx) {
+  const p = state.players[seat];
+  const sc = score(state, seat, ctx);
+  p.hasWon = true;
+  p.winOrder = state.winnersThisHand.length;
+  const rec = { winner: seat, winType: ctx.winType, winningTile: ctx.winningTile, source: ctx.source,
+    fanAwards: sc.fanAwards, finalFan: sc.finalFan, points: sc.points, deltas: [0, 0, 0, 0] };
+  // payments
+  if (ctx.winType === 'SELF_DRAW') {
+    for (let s = 0; s < 4; s++) {
+      if (s === seat) continue;
+      const o = state.players[s];
+      if (state.config.wonPlayersExcludedFromFuturePayments && o.hasWon) continue;
+      o.score -= sc.points; p.score += sc.points;
+      rec.deltas[s] -= sc.points; rec.deltas[seat] += sc.points;
+    }
+  } else { // DISCARD or ROB_KONG — single payer
+    const payer = state.players[ctx.source];
+    payer.score -= sc.points; p.score += sc.points;
+    rec.deltas[ctx.source] -= sc.points; rec.deltas[seat] += sc.points;
+  }
+  p.winRecords.push(rec);
+  state.winnersThisHand.push(seat);
+  logEvent(state, { type: 'WinResolved', seat, winType: ctx.winType, points: sc.points, fan: sc.finalFan, fanAwards: sc.fanAwards.map((f) => f.name) });
+}
+
+/* immediate kong payments (spec §11.3) */
+function payKong(state, seat, kongType, discarder) {
+  const g = state.players[seat];
+  const cfg = state.config;
+  let amount, log;
+  if (kongType === KONG_EXPOSED_FROM_DISCARD) {
+    amount = cfg.kongExposedFromDiscard;
+    const d = state.players[discarder];
+    if (!(cfg.wonPlayersExcludedFromFuturePayments && d.hasWon)) { d.score -= amount; g.score += amount; }
+    log = 'exposed';
+  } else {
+    amount = (kongType === KONG_ADDED) ? cfg.kongAdded : cfg.kongConcealed;
+    for (let s = 0; s < 4; s++) {
+      if (s === seat) continue;
+      const o = state.players[s];
+      if (cfg.wonPlayersExcludedFromFuturePayments && o.hasWon) continue;
+      o.score -= amount; g.score += amount;
+    }
+    log = (kongType === KONG_ADDED) ? 'added' : 'concealed';
+  }
+  logEvent(state, { type: 'KongScored', seat, kongType: log, amount });
+}
+
+/* =====================================================================
+ * Scoring / fan detection (spec §14)
+ * ===================================================================== */
+function decomposeAllPungs(counts, groupsNeeded) {
+  // pair + only triplets (no chow). counts = concealed (winning size minus melds)
+  for (let p = 0; p < NUM_TYPES; p++) {
+    if (counts[p] >= 2) {
+      const cc = counts.slice(); cc[p] -= 2;
+      if (onlyTriplets(cc, groupsNeeded)) return true;
+    }
+  }
+  return false;
+}
+function onlyTriplets(c, groups) {
+  let i = 0; while (i < NUM_TYPES && c[i] === 0) i++;
+  if (i === NUM_TYPES) return groups === 0;
+  if (groups > 0 && c[i] >= 3) { c[i] -= 3; if (onlyTriplets(c, groups - 1)) { c[i] += 3; return true; } c[i] += 3; }
+  return false;
+}
+function score(state, seat, ctx) {
+  const cfg = state.config;
+  const p = state.players[seat];
+  // For SELF_DRAW the winning tile is already in concealed (drawn); for DISCARD /
+  // ROB_KONG it is added virtually here only (never persisted) — see §10.1.
+  const concealed = p.concealed.slice();
+  if (ctx.winType !== 'SELF_DRAW' && ctx.winningTile != null) concealed[ctx.winningTile]++;
+  const groupsNeeded = 4 - p.melds.length;
+  const fanAwards = [];
+  const add = (name, fan) => { if (fan > 0) fanAwards.push({ name, fan }); };
+
+  // suits across full hand
+  const suitsUsed = new Set();
+  for (let t = 0; t < NUM_TYPES; t++) if (concealed[t] > 0) suitsUsed.add(tileSuit(t));
+  for (const m of p.melds) suitsUsed.add(tileSuit(m.tile));
+
+  const sevenP = p.melds.length === 0 && cfg.allowSevenPairs && isSevenPairs(concealed, cfg);
+
+  fanAwards.push({ name: 'Base Win', fan: 0 });   // 平胡 — always shown, contributes 0
+  if (ctx.winType === 'SELF_DRAW') add('Self-Draw', cfg.selfDrawBonusFan);
+  if (sevenP) {
+    add('Seven Pairs', cfg.sevenPairsFan);
+    let quads = 0; for (let t = 0; t < NUM_TYPES; t++) if (concealed[t] === 4) quads++;
+    if (quads >= 1) add('Luxury Seven Pairs', cfg.luxurySevenPairsExtraFanPerQuad * quads);
+  } else {
+    // all pungs: every meld is a pung/kong (Sichuan melds always are) AND concealed = triplets + pair
+    const meldsAllPung = p.melds.every((m) => true);
+    if (meldsAllPung && decomposeAllPungs(concealed, groupsNeeded)) add('All Pungs', cfg.allPungsFan);
+  }
+  if (suitsUsed.size === 1) add('Pure One Suit', cfg.pureOneSuitFan);
+
+  // root (gen): 4 physical copies of a type in the full hand
+  let roots = 0;
+  for (let t = 0; t < NUM_TYPES; t++) {
+    let phys = concealed[t];
+    for (const m of p.melds) if (m.tile === t) phys += meldPhysical(m);
+    if (phys === 4) roots++;
+  }
+  if (roots > 0) add('Root', cfg.rootFan * roots);
+
+  if (ctx.afterKong && ctx.winType === 'SELF_DRAW') add('Kong Bloom', cfg.kongBloomBonusFan);
+  if (ctx.winType === 'ROB_KONG') add('Robbing a Kong', cfg.robKongBonusFan);
+  if (ctx.lastTile) add(ctx.winType === 'SELF_DRAW' ? 'Last Tile Draw' : 'Last Discard Win', cfg.lastTileFan);
+  if (ctx.isHeavenly) add('Heavenly Hand', cfg.heavenlyEarthlyFan);
+  if (ctx.isEarthly) add('Earthly Hand', cfg.heavenlyEarthlyFan);
+
+  let fan = fanAwards.reduce((s, f) => s + f.fan, 0);
+  if (cfg.fanLimit != null) fan = Math.min(fan, cfg.fanLimit);
+  const points = cfg.baseWinPoints * Math.pow(2, fan);
+  return { fanAwards, finalFan: fan, points };
+}
+
+/* =====================================================================
+ * End of hand (spec §9, §12)
+ * ===================================================================== */
+function checkHandEnd(state) {
+  if (state.config.mode === 'single' && state.winnersThisHand.length >= 1) { endHand(state, 'win'); return true; }
+  if (nonWonCount(state) <= 1) { endHand(state, 'win'); return true; }
+  return false;
+}
+function endHand(state, reason) {
+  if (state.phase === PHASE.HAND_ENDED) return;
+  state.phase = PHASE.HAND_ENDED;
+  state.ended = true; state.endReason = reason;
+  state.pendingDiscard = null; state.reactions = null; state.robReactions = null;
+
+  if (reason === 'exhaustion' && state.config.enableMissingSuitPenaltyAtExhaustion) {
+    // 查花猪: players still holding missing suit pay each cleared / won player (spec §8.3)
+    const pen = state.config.missingSuitPenalty;
+    const holders = state.players.filter((p) => !p.hasWon && missingCount(p) > 0);
+    for (const h of holders) {
+      for (let s = 0; s < 4; s++) {
+        const o = state.players[s];
+        if (o === h) continue;
+        if (!h.hasWon && (o.hasWon || missingCount(o) === 0)) { h.score -= pen; o.score += pen; }
+      }
+      logEvent(state, { type: 'EndPenaltyApplied', seat: h.seat, kind: 'missingSuit' });
+    }
+  }
+  // next dealer: first winner, else dealer repeats (spec §12.1)
+  state.nextDealer = (state.winnersThisHand.length > 0) ? state.winnersThisHand[0] : state.dealer;
+  state.seatScores = state.players.map((p) => p.score);
+  logEvent(state, { type: 'HandEnded', reason, winners: state.winnersThisHand.slice() });
+}
+
+/* =====================================================================
+ * Tile conservation invariant (spec §19)
+ * ===================================================================== */
+function validateConservation(state) {
+  const total = emptyCounts();
+  for (let i = state.wallHead; i < state.wallTail; i++) total[state.wall[i]]++;
+  for (const p of state.players) {
+    for (let t = 0; t < NUM_TYPES; t++) total[t] += p.concealed[t];
+    for (const m of p.melds) total[m.tile] += meldPhysical(m);
+    for (const d of p.discards) total[d]++;
+  }
+  if (state.pendingDiscard) total[state.pendingDiscard.tile]++;
+  let sum = 0;
+  for (let t = 0; t < NUM_TYPES; t++) { sum += total[t]; if (total[t] !== 4) return { ok: false, tile: t, count: total[t] }; }
+  return { ok: sum === 108, sum };
+}
+
+/* =====================================================================
+ * Redaction — per-seat view for rendering (hides others' concealed tiles)
+ * ===================================================================== */
+function viewFor(state, seat, opts = {}) {
+  const me = state.players[seat];
+  const myActions = getLegalActions(state, seat);
+  const ready = (state.phase !== PHASE.HAND_ENDED) ? getWinningTiles(me, state.config, state) : [];
+  const deciders = pendingDeciders(state);
+  const view = {
+    phase: state.phase,
+    handNo: state.handNo,
+    mode: state.config.mode,
+    wallRemaining: wallRemaining(state),
+    dealer: state.dealer,
+    active: state.active,
+    mySeat: seat,
+    deciders,
+    pendingDiscard: state.pendingDiscard ? { tile: state.pendingDiscard.tile, by: state.pendingDiscard.discarder } : null,
+    lastDrawn: (seat === state.active && state.phase === PHASE.ACTIVE_TURN) ? state.turnFlags.lastDrawn : null,
+    winnersThisHand: state.winnersThisHand.slice(),
+    me: {
+      seat,
+      concealed: me.concealed.slice(),
+      melds: me.melds.map((m) => ({ ...m })),
+      missingSuit: me.missingSuit,
+      discards: me.discards.slice(),
+      hasWon: me.hasWon,
+      winOrder: me.winOrder,
+      score: me.score,
+      legalActions: myActions,
+      ready,
+    },
+    players: state.players.map((p) => ({
+      seat: p.seat,
+      name: p.name,
+      isBot: p.isBot,
+      connected: p.connected,
+      missingSuit: p.missingSuit,             // public after selection (default)
+      melds: p.melds.map((m) => ({ ...m, concealed: m.type === KONG_CONCEALED })),
+      discards: p.discards.slice(),
+      handCount: countTotal(p.concealed),
+      hasWon: p.hasWon,
+      winOrder: p.winOrder,
+      score: p.score,
+      isDealer: p.isDealer,
+      isActive: p.seat === state.active && state.phase === PHASE.ACTIVE_TURN,
+      mustDecide: deciders.includes(p.seat),
+    })),
+  };
+  if (state.phase === PHASE.HAND_ENDED) {
+    view.results = {
+      reason: state.endReason,
+      winners: state.winnersThisHand.slice(),
+      records: [].concat(...state.players.map((p) => p.winRecords)),
+      scores: state.players.map((p) => p.score),
+      nextDealer: state.nextDealer,
+    };
+  }
+  return view;
+}
+
+/* =====================================================================
+ * Invalid-move explanations (spec §20)
+ * ===================================================================== */
+function explainIllegal(state, seat, action) {
+  const p = state.players[seat];
+  if (p.hasWon) return ['PLAYER_ALREADY_WON', 'You have already won this hand. In Bloody Battle, the remaining players continue without you.'];
+  if (state.phase === PHASE.ACTIVE_TURN && seat !== state.active)
+    return ['NOT_YOUR_TURN', 'You cannot do that because it is not your turn.'];
+  if (action.type === 'ClaimPung')
+    return ['PUNG_REQUIRES_TWO_IN_HAND', 'You need two matching tiles in your hand to claim a pung.'];
+  if (action.type === 'ClaimKongFromDiscard')
+    return ['KONG_REQUIRES_THREE_IN_HAND', 'You need three matching tiles in your hand to claim a kong from a discard.'];
+  if (action.type === 'DeclareWinFromDiscard' || action.type === 'DeclareSelfDrawWin' || action.type === 'RobKong') {
+    if (missingCount(p) > 0) {
+      const ms = SUIT_NAME[p.missingSuit];
+      return ['WIN_CONTAINS_MISSING_SUIT', 'You cannot win while holding tiles from your missing suit.', `Your missing suit is ${ms}.`, ['Discard your missing-suit tiles first.']];
+    }
+    return ['HAND_NOT_COMPLETE', 'This is not a legal winning hand.', 'A winning hand needs four groups and one pair (or seven pairs).'];
+  }
+  if (action.type === 'Discard' && state.config.mustDiscardMissingSuitFirst && missingCount(p) > 0)
+    return ['MUST_DISCARD_MISSING_SUIT', 'You still have tiles from your missing suit. You must discard those before discarding other suits.'];
+  return ['ILLEGAL_ACTION', 'That move is not available right now.'];
+}
+
+/* =====================================================================
+ * BOT decision logic (driver-side; reads only public info + own hand)
+ * Follows the addendum priority: win > mandatory > kong > meld > discard.
+ * ===================================================================== */
+function botChooseMissingSuit(player) {
+  const cnt = [0, 0, 0];
+  for (let t = 0; t < NUM_TYPES; t++) cnt[tileSuit(t)] += player.concealed[t];
+  let best = 0, bestScore = Infinity;
+  for (let s = 0; s < 3; s++) {
+    let conn = 0;
+    for (let r = 0; r < 9; r++) {
+      const t = s * 9 + r, v = player.concealed[t];
+      if (v && r < 8) conn += Math.min(v, player.concealed[t + 1]);
+      if (v >= 2) conn += 1;
+    }
+    const sc = cnt[s] * 10 + conn;
+    if (sc < bestScore) { bestScore = sc; best = s; }
+  }
+  return best;
+}
+
+/* shanten estimate (standard + seven pairs), ignoring missing-suit dead tiles */
+function shantenOf(player) {
+  const c = player.concealed.slice();
+  if (player.missingSuit != null) for (let r = 0; r < 9; r++) c[player.missingSuit * 9 + r] = 0;
+  let st = stdShanten(c, player.melds.length);
+  if (player.melds.length === 0) st = Math.min(st, sevenPairsShanten(c));
+  return st;
+}
+function sevenPairsShanten(c) {
+  let pairs = 0, kinds = 0;
+  for (let t = 0; t < NUM_TYPES; t++) { if (c[t] > 0) kinds++; if (c[t] >= 2) pairs++; }
+  let sh = 6 - pairs; if (kinds < 7) sh += 7 - kinds; return sh;
+}
+function stdShanten(c0, openMelds) {
+  let best = 8; const c = c0.slice();
+  function rec(i, melds, partials, pairUsed) {
+    while (i < NUM_TYPES && c[i] === 0) i++;
+    if (i === NUM_TYPES) {
+      let m = melds + openMelds, part = partials;
+      if (m + part > 4) part = 4 - m;
+      const sh = (4 - m) * 2 - part - (pairUsed ? 1 : 0);
+      if (sh < best) best = sh; return;
+    }
+    if (c[i] >= 3) { c[i] -= 3; rec(i, melds + 1, partials, pairUsed); c[i] += 3; }
+    if (i % 9 <= 6 && c[i + 1] > 0 && c[i + 2] > 0) { c[i]--; c[i + 1]--; c[i + 2]--; rec(i, melds + 1, partials, pairUsed); c[i]++; c[i + 1]++; c[i + 2]++; }
+    if (!pairUsed && c[i] >= 2) { c[i] -= 2; rec(i, melds, partials, true); c[i] += 2; }
+    if (c[i] >= 2) { c[i] -= 2; rec(i, melds, partials + 1, pairUsed); c[i] += 2; }
+    if (i % 9 <= 7 && c[i + 1] > 0) { c[i]--; c[i + 1]--; rec(i, melds, partials + 1, pairUsed); c[i]++; c[i + 1]++; }
+    if (i % 9 <= 6 && c[i + 2] > 0) { c[i]--; c[i + 2]--; rec(i, melds, partials + 1, pairUsed); c[i]++; c[i + 2]++; }
     c[i]--; rec(i, melds, partials, pairUsed); c[i]++;
   }
   rec(0, 0, 0, false);
   return best;
 }
-function shanten(p){
-  // tiles of the missing suit are dead weight: a hand still holding them can never win.
-  const c = p.hand.slice();
-  if (p.missing != null) for (let r = 0; r < 9; r++) c[p.missing*9+r] = 0;
-  let st = stdShanten(c, p.melds.length);
-  if (p.melds.length === 0) st = Math.min(st, sevenPairsShanten(c));
-  return st;
-}
-/* evaluateHand — engine-exposed scalar quality measure (lower shanten = better). */
-function evaluateHand(state, pi){
-  const p = state.players[pi];
-  const sh = shanten(p);
-  return { shanten: sh, tenpai: sh <= 0, missingTiles: missingCount(p), ukeire: sh <= 1 ? ukeire(state, p) : 0 };
-}
-/* ukeire — count of live tiles that lower shanten (tile-acceptance). */
-function ukeire(state, p){
-  const base = shanten(p);
+function ukeireOf(state, player) {
+  const base = shantenOf(player);
   let total = 0;
-  for (let k = 0; k < 27; k++){
-    if (ksuit(k) === p.missing) continue;
-    if (p.hand[k] >= 4) continue;
-    const remain = remainingCount(state, k, p);
-    if (remain <= 0) continue;
-    p.hand[k]++; const sh = shanten(p); p.hand[k]--;
-    if (sh < base) total += remain;
+  for (let t = 0; t < NUM_TYPES; t++) {
+    if (tileSuit(t) === player.missingSuit) continue;
+    if (player.concealed[t] >= 4) continue;
+    const rem = remainingOf(state, t, player.seat);
+    if (rem <= 0) continue;
+    player.concealed[t]++; const sh = shantenOf(player); player.concealed[t]--;
+    if (sh < base) total += rem;
   }
   return total;
 }
-/* How many copies of `kind` are not visible to player p (engine: uses only public info). */
-function remainingCount(state, kind, p){
-  let seen = p.hand[kind];
-  for (const m of p.melds) if (m.kind === kind) seen += (m.type === 'peng' ? 3 : 4);
-  for (const q of state.players){
-    for (const d of q.discards) if (d === kind) seen++;
-    for (const m of q.melds) if (m.kind === kind && q !== p) seen += (m.type === 'peng' ? 3 : 4);
-  }
-  return 4 - seen;
-}
-
-/* =====================================================================
-   RULES ENGINE — legal action enumeration
-   ctx: {type:'turn'} | {type:'claim', discarder, kind} | {type:'rob', ganger, kind}
-   ===================================================================== */
-function enumerateLegalActions(state, pi, ctx){
-  const p = state.players[pi];
-  if (p.won) return [{ type:'pass' }];
-  const acts = [];
-  const hasMissing = missingCount(p) > 0;
-
-  if (ctx.type === 'turn'){
-    if (!hasMissing && winsNow(p)) acts.push({ type:'hu', self:true });
-    if (!hasMissing){
-      for (let k = 0; k < 27; k++) if (p.hand[k] === 4 && ksuit(k) !== p.missing) acts.push({ type:'angang', kind:k });
-      for (const m of p.melds) if (m.type === 'peng' && p.hand[m.kind] > 0) acts.push({ type:'bugang', kind:m.kind });
-    }
-    // Missing-suit tiles MUST be played out first.
-    const discardable = hasMissing
-      ? kindsOf(p.hand).filter(k => ksuit(k) === p.missing)
-      : kindsOf(p.hand);
-    for (const k of discardable) acts.push({ type:'discard', kind:k });
-  }
-  else if (ctx.type === 'claim'){
-    const k = ctx.kind;
-    if (!hasMissing && canHu(p, k)) acts.push({ type:'hu', self:false, kind:k });
-    if (!hasMissing && ksuit(k) !== p.missing){
-      if (p.hand[k] >= 2) acts.push({ type:'peng', kind:k });
-      if (p.hand[k] >= 3) acts.push({ type:'minggang', kind:k });
-    }
-    acts.push({ type:'pass' });
-  }
-  else if (ctx.type === 'rob'){
-    const k = ctx.kind;
-    if (!hasMissing && canHu(p, k)) acts.push({ type:'hu', self:false, kind:k, rob:true });
-    acts.push({ type:'pass' });
-  }
-  return acts;
-}
-const sameAction = (a, b) =>
-  a && b && a.type === b.type && (a.kind ?? -1) === (b.kind ?? -1) && !!a.self === !!b.self;
-
-/* =====================================================================
-   RULES ENGINE — simulate (clone + apply, for AI lookahead)
-   ===================================================================== */
-function cloneState(state){
-  return {
-    mode: state.mode,
-    wall: state.wall.slice(),
-    players: state.players.map(p => ({
-      id:p.id, name:p.name, isBot:p.isBot, diff:p.diff,
-      hand:p.hand.slice(), melds:p.melds.map(m => ({...m})),
-      discards:p.discards.slice(), missing:p.missing, won:p.won, score:p.score,
-    })),
-    turn: state.turn,
-  };
-}
-/* Applies a discard or claim to a cloned state; returns the new state. (AI only.) */
-function simulate(state, pi, action){
-  const s = cloneState(state);
-  const p = s.players[pi];
-  if (action.type === 'discard'){ p.hand[action.kind]--; p.discards.push(action.kind); }
-  else if (action.type === 'peng'){ p.hand[action.kind]-=2; p.melds.push({ type:'peng', kind:action.kind }); }
-  else if (action.type === 'minggang'){ p.hand[action.kind]-=3; p.melds.push({ type:'minggang', kind:action.kind }); }
-  else if (action.type === 'angang'){ p.hand[action.kind]-=4; p.melds.push({ type:'angang', kind:action.kind }); }
-  else if (action.type === 'bugang'){ p.hand[action.kind]--; const m = p.melds.find(x => x.type==='peng' && x.kind===action.kind); if (m) m.type='bugang'; }
-  return s;
-}
-
-/* =====================================================================
-   RULES ENGINE — scoring (fan / 番)
-   ===================================================================== */
-function score(state, winnerIdx, info){
-  const p = state.players[winnerIdx];
-  const full = p.hand.slice();
-  if (!info.self && info.kind != null) full[info.kind]++;
-
-  let fan = 1; const names = ['平胡'];
-  const suits = new Set();
-  for (let k = 0; k < 27; k++) if (full[k] > 0) suits.add(ksuit(k));
-  for (const m of p.melds) suits.add(ksuit(m.kind));
-
-  const setsNeeded = 4 - p.melds.length;
-  const sevenP = p.melds.length === 0 && isSevenPairs(full);
-
-  if (sevenP){
-    fan += 2; names.push('七对');
-    for (let k = 0; k < 27; k++) if (full[k] === 4){ fan += 2; names.push('龙七对'); break; }
-  } else if (isAllPungs(full, setsNeeded)){
-    fan += 1; names.push('碰碰胡');
-  }
-  if (suits.size === 1){ fan += 2; names.push('清一色'); }
-  if (p.melds.length === 4 && handSize(p.hand) <= 2){ fan += 1; names.push('金钩钓'); }
-  if (info.self){ fan += 1; names.push('自摸'); }
-  if (info.gangFlower){ fan += 1; names.push('杠上花'); }
-  if (info.gangCannon){ fan += 1; names.push('杠上炮'); }
-  if (info.rob){ fan += 1; names.push('抢杠胡'); }
-  if (info.haidi){ fan += 1; names.push(info.self ? '海底捞月' : '海底炮'); }
-
-  // 根 — every set of four identical tiles (a kong, or 4 concealed) adds a fan.
-  let gen = 0;
-  for (const m of p.melds) if (m.type !== 'peng') gen++;
-  if (!sevenP) for (let k = 0; k < 27; k++) if (full[k] === 4) gen++;
-  if (gen > 0){ fan += gen; for (let i=0;i<gen;i++) names.push('根'); }
-
-  const CAP = 8;
-  if (fan > CAP) fan = CAP;
-  return { fan, names, base: Math.pow(2, fan - 1) }; // 平胡 = 1 point
-}
-
-/* =====================================================================
-   GAME CONTROLLER (drives turns, talks to UI & bots)
-   ===================================================================== */
-let state = null;
-let cfg = { humans:1, diff:'normal', mode:'bloody', names:[] };
-let lastShownHuman = -1;
-
-function newDeck(){
-  const deck = [];
-  for (let k = 0; k < 27; k++) for (let i = 0; i < 4; i++) deck.push(k);
-  for (let i = deck.length - 1; i > 0; i--){ const j = (Math.random()*(i+1))|0; [deck[i],deck[j]] = [deck[j],deck[i]]; }
-  return deck;
-}
-function startGame(){
-  const deck = newDeck();
-  const players = [];
-  for (let i = 0; i < 4; i++){
-    const isBot = i >= cfg.humans;
-    players.push({
-      id:i, name: isBot ? `Bot ${i}` : (cfg.names[i] || `Player ${i+1}`),
-      isBot, diff: cfg.diff,
-      hand: emptyCounts(), melds:[], discards:[], missing:null, won:false,
-      score:0, winInfo:null, justGanged:false, drewFromGang:false,
-    });
-  }
-  for (let n = 0; n < 13; n++) for (let i = 0; i < 4; i++) players[i].hand[deck.pop()]++;
-  state = {
-    mode: cfg.mode, wall: deck, players,
-    dealer: 0, turn: 0, phase:'dingque',
-    lastDiscard:null, winners:[], handNo:1, lastTile:null,
-  };
-  lastShownHuman = -1;
-  showGame();
-  runDingQue();
-}
-
-/* ---- 定缺 missing-suit selection ---- */
-function botPickMissing(p){
-  const cnt = [0,0,0];
-  for (let k = 0; k < 27; k++) cnt[ksuit(k)] += p.hand[k];
-  // weakest suit = fewest tiles, tie-break by least connectivity (sum of adjacency)
-  let best = 0, bestScore = Infinity;
-  for (let s = 0; s < 3; s++){
-    let conn = 0;
-    for (let r = 0; r < 9; r++){
-      const k = s*9+r; const v = p.hand[k];
-      if (v && r < 8) conn += Math.min(v, p.hand[k+1]);
-      if (v >= 2) conn += 1;
-    }
-    const sc = cnt[s]*10 + conn;
-    if (sc < bestScore){ bestScore = sc; best = s; }
-  }
-  return best;
-}
-async function runDingQue(){
-  for (let i = 0; i < 4; i++){
-    const p = state.players[i];
-    if (p.isBot){ p.missing = botPickMissing(p); }
-    else {
-      p.missing = await askMissingSuit(i);
-    }
-  }
-  state.phase = 'play';
-  render();
-  toast('开始 GO', 900);
-  setTimeout(gameLoop, 700);
-}
-
-/* ---- main turn loop ---- */
-function activeCount(){ return state.players.filter(p => !p.won).length; }
-function nextActive(from){
-  for (let s = 1; s <= 4; s++){ const i = (from + s) % 4; if (!state.players[i].won) return i; }
-  return -1;
-}
-function gameEnds(){
-  if (state.mode === 'single' && state.winners.length >= 1) return true;
-  if (activeCount() <= 1) return true;
-  return false;
-}
-
-async function gameLoop(){
-  while (state.phase === 'play'){
-    if (gameEnds()){ endHand('done'); return; }
-    const pi = state.turn;
-    if (state.players[pi].won){ state.turn = nextActive(pi); continue; }
-    if (state.wall.length === 0){ endHand('draw'); return; }
-    const cont = await takeTurn(pi);
-    if (!cont) return;           // hand ended inside the turn
-  }
-}
-
-/* one player's turn: draw, (gang loop), discard, claim window. returns true to continue loop */
-async function takeTurn(pi){
-  const p = state.players[pi];
-  let drewFromGang = false;
-
-  while (true){
-    // ---- draw ----
-    const isLast = state.wall.length === 1;
-    const drawn = state.wall.pop();
-    p.hand[drawn]++;
-    p.drawn = drawn;
-    p.drewFromGang = drewFromGang;
-    render();
-    if (!p.isBot) await sleep(180);
-
-    // ---- decisions: hu / gang / discard ----
-    const ctx = { type:'turn' };
-    const options = enumerateLegalActions(state, pi, ctx);
-    const action = await getAction(pi, ctx, options);
-
-    if (action.type === 'hu'){
-      p.drawn = null;
-      const info = { self:true, haidi:isLast, gangFlower:drewFromGang };
-      await declareWin(pi, info, null);
-      return state.phase === 'play';
-    }
-    if (action.type === 'angang' || action.type === 'bugang'){
-      const robbed = await doGang(pi, action, /*fromDiscard*/false);
-      if (robbed) return state.phase === 'play';   // someone robbed the kong -> hand may end
-      drewFromGang = true;
-      continue;                                    // draw replacement, loop again
-    }
-    // ---- discard ----
-    p.hand[action.kind]--;
-    p.discards.push(action.kind);
-    p.drawn = null;
-    p.justGanged = drewFromGang;            // for 杠上炮 attribution
-    state.lastDiscard = { by:pi, kind:action.kind };
-    state.lastTile = action.kind;
-    render();
-    break;
-  }
-
-  // ---- claim window on the discard ----
-  const result = await resolveClaims(pi);
-  if (state.phase !== 'play') return false;
-  if (result.type === 'win') return true;       // loop will re-evaluate / continue
-  if (result.type === 'claim'){
-    state.turn = result.player;                 // claimer already acted/discarded inside
-    return true;
-  }
-  state.turn = nextActive(pi);
-  return true;
-}
-
-/* Resolve hu / peng / gang claims after player `discarder` discards lastDiscard. */
-async function resolveClaims(discarder){
-  const kind = state.lastDiscard.kind;
-  const isLast = state.wall.length === 0;
-  const dp = state.players[discarder];
-
-  // --- collect hu (ron) claimants, in turn order after discarder ---
-  const huWinners = [];
-  for (let s = 1; s <= 3; s++){
-    const pi = (discarder + s) % 4;
-    const p = state.players[pi];
-    if (p.won) continue;
-    const opts = enumerateLegalActions(state, pi, { type:'claim', discarder, kind });
-    if (!opts.some(o => o.type === 'hu')) continue;
-    const act = await getAction(pi, { type:'claim', discarder, kind }, opts);
-    if (act.type === 'hu'){
-      huWinners.push(pi);
-      if (state.mode === 'single') break;
-    }
-  }
-  if (huWinners.length){
-    for (const wi of huWinners){
-      const info = { self:false, kind, discarder, haidi:isLast, gangCannon:dp.justGanged };
-      await declareWin(wi, info, discarder);
-      if (state.phase !== 'play') break;
-    }
-    return { type:'win' };
-  }
-
-  // --- peng / gang (at most one possible holder) ---
-  for (let s = 1; s <= 3; s++){
-    const pi = (discarder + s) % 4;
-    const p = state.players[pi];
-    if (p.won) continue;
-    const opts = enumerateLegalActions(state, pi, { type:'claim', discarder, kind });
-    const claimable = opts.filter(o => o.type === 'peng' || o.type === 'minggang');
-    if (!claimable.length) continue;
-    const act = await getAction(pi, { type:'claim', discarder, kind }, opts);
-    if (act.type === 'peng' || act.type === 'minggang'){
-      await doClaim(pi, act, discarder);
-      return { type:'claim', player: pi };
-    }
-    if (act.type === 'pass') break;   // only one player can hold peng/gang material
-  }
-  return { type:'pass' };
-}
-
-/* perform a peng or ming-gang from the discard, then that player discards. */
-async function doClaim(pi, act, discarder){
-  const p = state.players[pi];
-  const k = act.kind;
-  dp_removeDiscard(discarder);                 // claimed tile leaves the river
-  toast(act.type === 'peng' ? '碰 PENG' : '杠 GANG', 750);
-  if (act.type === 'peng'){
-    p.hand[k] -= 2;
-    p.melds.push({ type:'peng', kind:k, from:discarder });
-    render(); await sleep(p.isBot ? 350 : 120);
-    await forceDiscard(pi);
-  } else { // minggang from discard (直杠)
-    p.hand[k] -= 3;
-    p.melds.push({ type:'minggang', kind:k, from:discarder });
-    payGang(pi, 'minggang', discarder);
-    render();
-    await drawReplacementAndContinue(pi);
-  }
-}
-function dp_removeDiscard(discarder){
-  const dp = state.players[discarder];
-  dp.discards.pop();
-  state.lastDiscard = null;
-}
-
-/* After a gang the player draws a replacement and may gang/hu again, then discards. */
-async function drawReplacementAndContinue(pi){
-  // mimic takeTurn's draw+decision loop but starting already-melded
-  state.turn = pi;
-  const p = state.players[pi];
-  let drewFromGang = true;
-  while (true){
-    if (state.wall.length === 0){ endHand('draw'); return; }
-    const drawn = state.wall.pop();
-    p.hand[drawn]++; p.drawn = drawn; p.drewFromGang = true;
-    render();
-    const opts = enumerateLegalActions(state, pi, { type:'turn' });
-    const act = await getAction(pi, { type:'turn' }, opts);
-    if (act.type === 'hu'){
-      p.drawn = null;
-      await declareWin(pi, { self:true, gangFlower:true, haidi:state.wall.length===0 }, null);
-      return;
-    }
-    if (act.type === 'angang' || act.type === 'bugang'){
-      const robbed = await doGang(pi, act, false);
-      if (robbed) return;
-      continue;
-    }
-    p.hand[act.kind]--; p.discards.push(act.kind); p.drawn = null;
-    p.justGanged = true;
-    state.lastDiscard = { by:pi, kind:act.kind }; state.lastTile = act.kind;
-    render();
-    const result = await resolveClaims(pi);
-    if (state.phase !== 'play') return;
-    if (result.type === 'claim'){ state.turn = result.player; return; }
-    if (result.type === 'win'){ return; }
-    state.turn = nextActive(pi);
-    return;
-  }
-}
-
-/* perform an gang or bugang on the player's own turn. returns true if robbed (hand control changes). */
-async function doGang(pi, act, fromDiscard){
-  const p = state.players[pi];
-  const k = act.kind;
-  if (act.type === 'bugang'){
-    // rob-the-kong window first
-    for (let s = 1; s <= 3; s++){
-      const ri = (pi + s) % 4;
-      const rp = state.players[ri];
-      if (rp.won) continue;
-      const opts = enumerateLegalActions(state, ri, { type:'rob', ganger:pi, kind:k });
-      if (!opts.some(o => o.type === 'hu')) continue;
-      const a = await getAction(ri, { type:'rob', ganger:pi, kind:k }, opts);
-      if (a.type === 'hu'){
-        toast('抢杠 ROB!', 1000);
-        const info = { self:false, kind:k, discarder:pi, rob:true };
-        await declareWin(ri, info, pi);
-        return true;
-      }
-    }
-    const m = p.melds.find(x => x.type === 'peng' && x.kind === k);
-    m.type = 'bugang';
-    p.hand[k]--;
-    payGang(pi, 'bugang', null);
-    toast('补杠', 700);
-  } else { // angang
-    p.hand[k] -= 4;
-    p.melds.push({ type:'angang', kind:k });
-    payGang(pi, 'angang', null);
-    toast('暗杠', 700);
-  }
-  p.drawn = null;
-  render();
-  await sleep(p.isBot ? 250 : 60);
-  return false;
-}
-
-/* 刮风下雨 gang payments, applied immediately. */
-function payGang(ganger, type, discarder){
-  const g = state.players[ganger];
-  const per = (type === 'angang') ? 2 : (type === 'minggang') ? 2 : 1;
-  if (type === 'minggang'){
-    const d = state.players[discarder];
-    if (!d.won){ d.score -= per; g.score += per; }
-  } else {
-    for (let i = 0; i < 4; i++){
-      if (i === ganger) continue;
-      const o = state.players[i];
-      if (o.won) continue;
-      o.score -= per; g.score += per;
-    }
-  }
-}
-
-/* finalize a win (zimo or dianpao). updates scores; bloody mode keeps the hand going. */
-async function declareWin(pi, info, payerIdx){
-  const p = state.players[pi];
-  if (info.kind != null && !info.self) p.hand[info.kind]++;  // commit the winning tile
-  const sc = score(state, pi, info);
-  p.won = true; p.winInfo = { ...info, ...sc };
-  state.winners.push(pi);
-
-  // payments
-  if (info.self){
-    for (let i = 0; i < 4; i++){
-      if (i === pi) continue;
-      const o = state.players[i];
-      if (o.won) continue;
-      o.score -= sc.base; p.score += sc.base;
-    }
-  } else {
-    const payer = state.players[payerIdx];
-    payer.score -= sc.base; p.score += sc.base;
-  }
-  render();
-  toast((info.self ? '自摸 ZIMO' : info.rob ? '胡 HU' : '胡 HU') + ' +' + sc.base, 1100);
-  await sleep(1000);
-
-  if (state.mode === 'single'){ endHand('done'); return; }
-  if (gameEnds()){ endHand('done'); return; }
-}
-
-/* settle the hand and show the scoreboard. reason: 'done' | 'draw' */
-function endHand(reason){
-  if (state.phase === 'over') return;
-  state.phase = 'over';
-  // draw-game settlement: 查大叫 / 查花猪 (light version)
-  if (reason === 'draw'){
-    const remaining = state.players.filter(p => !p.won);
-    const tenpai = remaining.filter(p => isTenpai(p));
-    const huazhu = remaining.filter(p => missingCount(p) > 0);
-    // 花猪 pays everyone else a flat penalty
-    for (const hz of huazhu){
-      for (let i = 0; i < 4; i++){
-        if (state.players[i] === hz) continue;
-        hz.score -= 4; state.players[i].score += 4;
-      }
-    }
-    // 查大叫: not-tenpai (and not huazhu) pay each tenpai player
-    const notReady = remaining.filter(p => !isTenpai(p) && missingCount(p) === 0);
-    for (const nr of notReady){
-      for (const t of tenpai){ nr.score -= 2; t.score += 2; }
-    }
-  }
-  render();
-  showResults(reason);
-}
-
-/* =====================================================================
-   ACTION ROUTING — human vs bot, with mandatory legality validation
-   ===================================================================== */
-async function getAction(pi, ctx, options){
-  const p = state.players[pi];
-  let act;
-  if (p.isBot){
-    await botThink(p);
-    act = botDecide(state, pi, ctx, options);
-  } else {
-    act = await askHuman(pi, ctx, options);
-  }
-  // SPEC: every action must be validated through the rules engine before execution.
-  const legal = enumerateLegalActions(state, pi, ctx);
-  if (!legal.some(o => sameAction(o, act))){
-    console.warn('Illegal action rejected', act, 'legal:', legal);
-    act = legal.find(o => o.type === 'pass')
-       || legal.find(o => o.type === 'discard')
-       || legal[0];
-  }
-  return act;
-}
-async function forceDiscard(pi){
-  const ctx = { type:'turn-discard-only' };
-  const all = enumerateLegalActions(state, pi, { type:'turn' });
-  const opts = all.filter(o => o.type === 'discard');   // after peng you just discard
-  const act = await getAction2(pi, opts);
-  state.players[pi].hand[act.kind]--;
-  state.players[pi].discards.push(act.kind);
-  state.players[pi].drawn = null;
-  state.players[pi].justGanged = false;
-  state.lastDiscard = { by:pi, kind:act.kind }; state.lastTile = act.kind;
-  render();
-  const result = await resolveClaims(pi);
-  if (state.phase !== 'play') return;
-  if (result.type === 'claim'){ state.turn = result.player; }
-  else if (result.type === 'pass'){ state.turn = nextActive(pi); }
-}
-async function getAction2(pi, options){
-  const p = state.players[pi];
-  let act;
-  if (p.isBot){ await botThink(p); act = botDiscardOnly(state, pi, options); }
-  else { act = await askHuman(pi, { type:'discard-only' }, options); }
-  if (!options.some(o => sameAction(o, act))) act = options[0];
-  return act;
-}
-
-/* =====================================================================
-   BOT DECISION LOGIC (separate from the rules engine)
-   ===================================================================== */
-function botThink(p){
-  const base = p.diff === 'hard' ? 650 : p.diff === 'normal' ? 520 : 380;
-  const jitter = Math.random() * 500;
-  return sleep(base + jitter);
-}
-/* Decide among legal options following the spec priority order. */
-function botDecide(state, pi, ctx, options){
-  const p = state.players[pi];
-
-  // 1. Winning move (always take it)
-  const hu = options.find(o => o.type === 'hu');
-  if (hu){
-    // Hard occasionally passes a tiny dianpao to chase bigger hands — but default: win.
-    return hu;
-  }
-  if (ctx.type === 'rob') return options.find(o => o.type === 'pass');
-
-  if (ctx.type === 'turn' || ctx.type === 'turn-discard-only'){
-    // 3. Kong decisions
-    const gangs = options.filter(o => o.type === 'angang' || o.type === 'bugang');
-    if (gangs.length){
-      const g = chooseGang(state, pi, gangs);
-      if (g) return g;
-    }
-    // 5. Best discard
-    const discards = options.filter(o => o.type === 'discard');
-    return { type:'discard', kind: chooseDiscard(state, pi, discards.map(d => d.kind)) };
-  }
-
-  if (ctx.type === 'claim'){
-    // 4. Meld opportunities (peng / gang from discard)
-    const peng = options.find(o => o.type === 'peng');
-    const gang = options.find(o => o.type === 'minggang');
-    const choice = chooseMeld(state, pi, peng, gang);
-    if (choice) return choice;
-    return options.find(o => o.type === 'pass');
-  }
-  return options.find(o => o.type === 'pass') || options[0];
-}
-function botDiscardOnly(state, pi, options){
-  return { type:'discard', kind: chooseDiscard(state, pi, options.map(o => o.kind)) };
-}
-
-/* Should the bot declare this kong?  Avoid kongs that wreck a near hand. */
-function chooseGang(state, pi, gangs){
-  const p = state.players[pi];
-  if (p.diff === 'easy') return Math.random() < 0.7 ? gangs[0] : null;
-  const before = shanten(p);
-  for (const g of gangs){
-    const snap = p.hand.slice(), msnap = p.melds.map(m => ({...m}));
-    if (g.type === 'angang') p.hand[g.kind] -= 4;
-    else p.hand[g.kind]--;
-    const after = shanten(p);
-    p.hand = snap; p.melds = msnap;
-    // gang is good if it doesn't increase shanten (kong tiles weren't forming a run anyway)
-    if (after <= before) return g;
-  }
-  // Hard: also weigh extra fan (根) — take an gang if not clearly hand-wrecking
-  if (p.diff === 'hard') return gangs.find(g => g.type === 'angang') || null;
-  return null;
-}
-
-/* Should the bot peng/gang a discard?  Maintain suit strategy & shanten progress. */
-function chooseMeld(state, pi, peng, gang){
-  const p = state.players[pi];
-  if (!peng && !gang) return null;
-  const k = (peng || gang).kind;
-  if (ksuit(k) === p.missing) return null;
-
-  if (p.diff === 'easy'){
-    // claims impulsively, sometimes wrongly skips
-    if (Math.random() < 0.45) return null;
-    return peng || gang;
-  }
-
-  // Evaluate: does claiming reduce shanten and keep us toward a real hand?
-  const before = shanten(p);
-  const snap = p.hand.slice(), msnap = p.melds.map(m => ({...m}));
-  p.hand[k] -= (gang && !peng ? 3 : 2);
-  p.melds.push({ type: gang && !peng ? 'minggang' : 'peng', kind:k });
-  const after = shanten(p);
-  const tenpaiAfter = isTenpai(p);
-  p.hand = snap; p.melds = msnap;
-
-  // gang from discard: only if it helps and we're committed to pungs
-  if (gang && !peng){
-    if (after < before || tenpaiAfter) return gang;
-    if (p.diff === 'hard') return after <= before ? gang : null;
-    return after < before ? gang : null;
-  }
-  // peng: claim if it lowers shanten, or reaches tenpai, or strongly supports a pung hand
-  if (after < before || tenpaiAfter){
-    // Hard defends: don't open up if an opponent looks dangerously close
-    if (p.diff === 'hard' && after >= before && opponentDanger(state, pi) > 0.6) return null;
-    return peng;
-  }
-  // Normal/Hard generally avoid pengs that don't progress the hand.
-  if (p.diff === 'hard') return null;
-  return after <= before && Math.random() < 0.25 ? peng : null;
-}
-
-/* Choose the best discard from candidate kinds (spec discard heuristics + defense). */
-function chooseDiscard(state, pi, candidates){
-  const p = state.players[pi];
-  if (!candidates.length) candidates = kindsOf(p.hand);
-
-  // Forced: missing-suit tiles must go first (engine already restricts, but be safe).
-  const miss = candidates.filter(k => ksuit(k) === p.missing);
-  if (miss.length) candidates = miss;
-
-  if (p.diff === 'easy' && Math.random() < 0.35){
-    return candidates[(Math.random()*candidates.length)|0];   // optional mistakes
-  }
-
-  const base = shanten(p);
-  let best = candidates[0], bestScore = -Infinity;
-  for (const k of candidates){
-    p.hand[k]--;
-    const sh = shanten(p);
-    const accept = (p.diff !== 'easy') ? ukeire(state, p) : 0;
-    p.hand[k]++;
-
-    let s = -sh * 1000 + accept * 4;
-    s += discardPreference(p, k);                 // isolated/terminal bias
-    if (p.diff === 'hard') s -= tileDanger(state, pi, k) * 60 * opponentDanger(state, pi);
-    if (s > bestScore){ bestScore = s; best = k; }
-  }
-  return best;
-}
-/* Prefer isolated honors-equivalent (terminals) & dead-ends; keep pairs/run material. */
-function discardPreference(p, k){
-  const suit = ksuit(k), r = krank(k);
-  const c = p.hand;
-  let s = 0;
-  const left2 = r>2 ? c[k-2]:0, left1 = r>1 ? c[k-1]:0, right1 = r<9 ? c[k+1]:0, right2 = r<8 ? c[k+2]:0;
-  const neighbours = left2+left1+right1+right2;
-  if (neighbours === 0 && c[k] === 1) s += 30;          // fully isolated -> dump
-  if ((r === 1 || r === 9) && c[k] === 1) s += 10;       // lone terminal
-  if (c[k] >= 2) s -= 25;                                // protect pair candidates
-  if (left1 && right1) s -= 18;                          // protect run middles
-  if (left1 || right1) s -= 6;                           // some connection
-  s -= Math.abs(r - 5);                                  // mild: terminals less flexible
-  return s;
-}
-/* Danger of discarding kind k: how likely it feeds an opponent. (Hard only.) */
-function tileDanger(state, pi, k){
-  let danger = 0;
-  for (let i = 0; i < 4; i++){
-    if (i === pi) continue;
-    const o = state.players[i];
-    if (o.won) continue;
-    // a tile not yet discarded anywhere that pairs with opponent melds is risky
-    const live = remainingCount(state, k, state.players[pi]);
-    let seenInRivers = 0;
-    for (const q of state.players) for (const d of q.discards) if (d === k) seenInRivers++;
-    danger += (seenInRivers === 0 ? 0.5 : 0.1);
-    // suit they are clearly collecting (their missing suit is safe to them? no — they can't use it)
-    if (o.missing != null && ksuit(k) === o.missing) danger -= 0.4;  // safe vs that opponent
-  }
-  return Math.max(0, danger);
-}
-/* Rough estimate that SOME opponent is close to winning (0..1). */
-function opponentDanger(state, pi){
+function opponentDanger(state, seat) {
   let worst = 0;
-  for (let i = 0; i < 4; i++){
-    if (i === pi) continue;
-    const o = state.players[i];
-    if (o.won) continue;
-    const melds = o.melds.length;
-    const discs = o.discards.length;
-    // heuristic: many melds + has voided + few recent off-suit discards => close
-    let d = melds * 0.18 + (missingCount(o) === 0 ? 0.15 : 0) + Math.min(discs, 12) * 0.02;
+  for (let s = 0; s < 4; s++) {
+    if (s === seat) continue;
+    const o = state.players[s];
+    if (o.hasWon) continue;
+    const d = o.melds.length * 0.18 + (missingCount(o) === 0 ? 0.15 : 0) + Math.min(o.discards.length, 12) * 0.02;
     worst = Math.max(worst, Math.min(1, d));
   }
   return worst;
 }
+function discardPreference(player, t) {
+  const r = tileRank(t), c = player.concealed;
+  let s = 0;
+  const l2 = r > 2 ? c[t - 2] : 0, l1 = r > 1 ? c[t - 1] : 0, r1 = r < 9 ? c[t + 1] : 0, r2 = r < 8 ? c[t + 2] : 0;
+  const nb = l2 + l1 + r1 + r2;
+  if (nb === 0 && c[t] === 1) s += 30;
+  if ((r === 1 || r === 9) && c[t] === 1) s += 10;
+  if (c[t] >= 2) s -= 25;
+  if (l1 && r1) s -= 18;
+  if (l1 || r1) s -= 6;
+  s -= Math.abs(r - 5);
+  return s;
+}
+function botChooseDiscard(state, seat, candidates, difficulty) {
+  const p = state.players[seat];
+  const miss = candidates.filter((t) => tileSuit(t) === p.missingSuit);
+  if (miss.length) candidates = miss;                       // forced clear first
+  if (difficulty === 'easy' && rngNext(state) < 0.35) return candidates[rngInt(state, candidates.length)];
+  let best = candidates[0], bestScore = -Infinity;
+  for (const t of candidates) {
+    p.concealed[t]--;
+    const sh = shantenOf(p);
+    const accept = (difficulty !== 'easy') ? ukeireOf(state, p) : 0;
+    p.concealed[t]++;
+    let sc = -sh * 1000 + accept * 4 + discardPreference(p, t);
+    if (difficulty === 'hard') sc -= tileDanger(state, seat, t) * 60 * opponentDanger(state, seat);
+    if (sc > bestScore) { bestScore = sc; best = t; }
+  }
+  return best;
+}
+function tileDanger(state, seat, t) {
+  let danger = 0;
+  for (let s = 0; s < 4; s++) {
+    if (s === seat) continue;
+    const o = state.players[s];
+    if (o.hasWon) continue;
+    let seenRivers = 0;
+    for (const q of state.players) for (const d of q.discards) if (d === t) seenRivers++;
+    danger += (seenRivers === 0 ? 0.5 : 0.1);
+    if (o.missingSuit != null && tileSuit(t) === o.missingSuit) danger -= 0.4;
+  }
+  return Math.max(0, danger);
+}
+function botChooseAction(state, seat, difficulty) {
+  difficulty = difficulty || state.players[seat].difficulty || 'normal';
+  const acts = getLegalActions(state, seat);
+  if (!acts.length) return null;
+  const p = state.players[seat];
+
+  // missing-suit selection
+  const choose = acts.filter((a) => a.type === 'ChooseMissingSuit');
+  if (choose.length) return { type: 'ChooseMissingSuit', suit: botChooseMissingSuit(p) };
+
+  // 1. winning move
+  const win = acts.find((a) => a.type === 'DeclareSelfDrawWin' || a.type === 'DeclareWinFromDiscard' || a.type === 'RobKong');
+  if (win) return win;
+
+  // reaction window (no win): consider pung/kong, else pass
+  if (state.phase === PHASE.DISCARD_REACT) {
+    const pung = acts.find((a) => a.type === 'ClaimPung');
+    const kong = acts.find((a) => a.type === 'ClaimKongFromDiscard');
+    const m = botChooseMeld(state, seat, pung, kong, difficulty);
+    return m || acts.find((a) => a.type === 'Pass');
+  }
+  if (state.phase === PHASE.ROB_REACT) return acts.find((a) => a.type === 'Pass');
+
+  // 3. kong decisions on own turn
+  const kongs = acts.filter((a) => a.type === 'DeclareConcealedKong' || a.type === 'DeclareAddedKong');
+  if (kongs.length) {
+    const g = botChooseKong(state, seat, kongs, difficulty);
+    if (g) return g;
+  }
+  // 5. best discard
+  const discards = acts.filter((a) => a.type === 'Discard').map((a) => a.tile);
+  if (discards.length) return { type: 'Discard', tile: botChooseDiscard(state, seat, discards, difficulty) };
+  return acts[0];
+}
+function botChooseKong(state, seat, kongs, difficulty) {
+  const p = state.players[seat];
+  if (difficulty === 'easy') return rngNext(state) < 0.7 ? kongs[0] : null;
+  const before = shantenOf(p);
+  for (const g of kongs) {
+    const snap = p.concealed.slice();
+    if (g.type === 'DeclareConcealedKong') p.concealed[g.tile] -= 4; else p.concealed[g.tile] -= 1;
+    const after = shantenOf(p);
+    p.concealed = snap;
+    if (after <= before) return g;
+  }
+  if (difficulty === 'hard') return kongs.find((g) => g.type === 'DeclareConcealedKong') || null;
+  return null;
+}
+function botChooseMeld(state, seat, pung, kong, difficulty) {
+  const p = state.players[seat];
+  if (!pung && !kong) return null;
+  const tile = (pung || kong).tile;
+  if (tileSuit(tile) === p.missingSuit) return null;
+  if (difficulty === 'easy') { if (rngNext(state) < 0.45) return null; return pung || kong; }
+  const before = shantenOf(p);
+  const snap = p.concealed.slice(), msnap = p.melds.map((m) => ({ ...m }));
+  if (kong && !pung) { p.concealed[tile] -= 3; p.melds.push({ type: PUNG, tile }); }
+  else { p.concealed[tile] -= 2; p.melds.push({ type: PUNG, tile }); }
+  const after = shantenOf(p);
+  const ready = isReady(p, state.config);
+  p.concealed = snap; p.melds = msnap;
+  if (kong && !pung) {
+    if (after < before || ready) return kong;
+    return difficulty === 'hard' ? (after <= before ? kong : null) : (after < before ? kong : null);
+  }
+  if (after < before || ready) {
+    if (difficulty === 'hard' && after >= before && opponentDanger(state, seat) > 0.6) return null;
+    return pung;
+  }
+  if (difficulty === 'hard') return null;
+  return after <= before && rngNext(state) < 0.25 ? pung : null;
+}
+
+// ==CORE-END==
+/* CORE-INLINE-END */
 
 /* =====================================================================
-   UI
-   ===================================================================== */
-const $ = id => document.getElementById(id);
+ * CLIENT — rendering + connection seam (Local / Online share one renderer)
+ * ===================================================================== */
+const $ = (id) => document.getElementById(id);
 const overlay = $('overlay');
 
-function tileHTML(kind, cls=''){
-  const s = ksuit(kind), r = krank(kind);
-  return `<div class="tile ${SUIT_CLASS[s]} ${cls}">
-    <span class="num">${r}</span><span class="glyph">${SUIT_GLYPH[s]}</span></div>`;
+/* suit display: core order DOT=0(筒,blue) BAMBOO=1(条,green) CHARACTER=2(萬,red) */
+const SUIT_CSS = ['p', 's', 'm'];
+const SUIT_TINT = ['#8ec5ff', '#7be39a', '#ff8a8a'];
+
+function tileHTML(tile, cls = '') {
+  const s = tileSuit(tile), r = tileRank(tile);
+  return `<div class="tile ${SUIT_CSS[s]} ${cls}"><span class="num">${r}</span><span class="glyph">${SUIT_GLYPH[s]}</span></div>`;
 }
-function backHTML(cls=''){ return `<div class="tile back ${cls}"></div>`; }
-function meldHTML(m){
-  let tiles = '';
-  const n = m.type === 'peng' ? 3 : 4;
-  for (let i = 0; i < n; i++){
-    const concealed = (m.type === 'angang' && (i === 0 || i === 3));
-    tiles += concealed ? `<div class="tile back concealed"></div>` : tileHTML(m.kind);
+const backHTML = (cls = '') => `<div class="tile back ${cls}"></div>`;
+function meldHTML(m) {
+  const n = m.type === PUNG ? 3 : 4;
+  let t = '';
+  for (let i = 0; i < n; i++) {
+    const concealed = (m.type === KONG_CONCEALED && (i === 0 || i === 3));
+    t += concealed ? `<div class="tile back concealed"></div>` : tileHTML(m.tile);
   }
-  return `<div class="meld">${tiles}</div>`;
+  return `<div class="meld">${t}</div>`;
+}
+function escapeHtml(s) { return String(s).replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])); }
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/* ---- module-level render state ---- */
+let curView = null;          // last view received
+let conn = null;             // active connection
+let pendingReveal = null;    // {seat,name} gate not yet acknowledged
+let online = false;
+
+/* =====================================================================
+ * RENDER — pure function of a `view` (+ transient meta)
+ * ===================================================================== */
+function onUpdate(view, meta = {}) {
+  curView = view;
+  if (meta.reveal) pendingReveal = meta.reveal;
+  if (meta.toasts) for (const t of meta.toasts) toast(t.msg, t.ms || 950);
+  if (meta.conn) updateConnPill(meta.conn);
+  if (view.phase === 'HAND_ENDED') { render(); showResults(view); return; }
+  render();
+  if (pendingReveal) showRevealGate(pendingReveal);
 }
 
-let humanResolver = null;
-let uiState = null;   // {pi, ctx, options}
-
-function render(){
-  if (!state) return;
+function render() {
+  const view = curView; if (!view) return;
   $('round-info').textContent =
-    `Wall ${state.wall.length} · ${state.mode === 'bloody' ? '血战' : 'Single'} · Won ${state.winners.length}/3`;
-
-  const view = (uiState && !state.players[uiState.pi].isBot) ? uiState.pi
-             : (state.phase === 'over' ? 0 : 0);
-  // seats are positioned relative to the bottom view player
-  for (let rel = 0; rel < 4; rel++){
-    const pi = (view + rel) % 4;
-    renderSeat(pi, rel);
-  }
-  renderCenter();
+    `Wall ${view.wallRemaining} · ${view.mode === 'bloody' ? '血战' : 'Single'} · Won ${view.winnersThisHand.length}/3`;
+  const v = view.mySeat;
+  for (let rel = 0; rel < 4; rel++) renderSeat(view, (v + rel) % 4, rel);
+  renderCenter(view);
   renderHandArea(view);
 }
 
-function renderSeat(pi, rel){
-  const p = state.players[pi];
+function renderSeat(view, seat, rel) {
+  const p = view.players[seat];
   const el = $('seat-' + rel);
   if (!el) return;
-  const activeTurn = (state.phase === 'play' && state.turn === pi && !p.won);
-  const missLbl = p.missing != null ? `<span class="miss ${SUIT_CLASS[p.missing]}" style="color:${['#ff8a8a','#7be39a','#8ec5ff'][p.missing]}">缺${SUIT_GLYPH[p.missing]}</span>` : '';
-  const plate = `<div class="nameplate ${activeTurn?'active':''} ${p.isBot?'bot':'human'}">
-      <span class="dot"></span>
-      <span>${escapeHtml(p.name)}</span>
-      ${missLbl}
-      ${p.won ? `<span class="won">胡 #${state.winners.indexOf(pi)+1}</span>` : ''}
-      <span class="sc">${p.score>=0?'+':''}${p.score}</span>
-      ${p.isBot && activeTurn ? '<span class="thinking">…</span>' : ''}
-    </div>`;
-
-  if (rel === 0){
-    // bottom — interactive player: plate + melds + river (hand is in handarea)
-    el.innerHTML = plate + meldsRow(p) + riverRow(pi);
-  } else {
-    const backs = backsRow(p, rel);
-    el.innerHTML = (rel === 2)
-      ? plate + meldsRow(p) + backs + riverRow(pi)
-      : plate + backs + meldsRow(p) + riverRow(pi);
-  }
-}
-function meldsRow(p){
-  if (!p.melds.length) return '';
-  return `<div class="melds">${p.melds.map(meldHTML).join('')}</div>`;
-}
-function backsRow(p, rel){
-  const n = handSize(p.hand);
-  let t = ''; for (let i = 0; i < n; i++) t += backHTML();
-  return `<div class="backs">${t}</div>`;
-}
-function riverRow(pi){
-  const p = state.players[pi];
-  const last = state.lastDiscard;
-  return `<div class="river">${p.discards.map((k,i) => {
-    const isLast = last && last.by === pi && i === p.discards.length-1;
-    return tileHTML(k, isLast ? 'last' : '');
+  const tint = p.missingSuit != null ? `<span class="miss" style="color:${SUIT_TINT[p.missingSuit]}">缺${SUIT_GLYPH[p.missingSuit]}</span>` : '';
+  const thinking = (p.mustDecide && p.isBot && !p.hasWon) ? '<span class="thinking">thinking…</span>' : '';
+  const won = p.hasWon ? `<span class="won">胡#${(p.winOrder ?? 0) + 1}</span>` : '';
+  const dealer = p.isDealer ? '<span class="dealer-mark">庄</span>' : '';
+  const offline = (p.connected === false) ? 'off' : '';
+  const plate = `<div class="nameplate ${p.isActive ? 'active' : ''} ${p.isBot ? 'bot' : 'human'} ${offline}">
+      <span class="dot"></span>${dealer}<span>${escapeHtml(p.name)}</span>${tint}${won}
+      <span class="sc">${p.score >= 0 ? '+' : ''}${p.score}</span>${thinking}</div>`;
+  const melds = p.melds.length ? `<div class="melds">${p.melds.map(meldHTML).join('')}</div>` : '';
+  const river = `<div class="river">${p.discards.map((t, i) => {
+    const isLast = view.pendingDiscard && view.pendingDiscard.by === seat && false;
+    return tileHTML(t, '');
   }).join('')}</div>`;
+
+  if (rel === 0) { el.innerHTML = plate + melds + river; return; }
+  let backs = '';
+  for (let i = 0; i < p.handCount; i++) backs += backHTML();
+  backs = `<div class="backs">${backs}</div>`;
+  el.innerHTML = (rel === 2) ? plate + melds + backs + river : plate + backs + melds + river;
 }
-function renderCenter(){
+
+function renderCenter(view) {
   const c = $('center');
-  if (state.phase === 'over'){ c.innerHTML = ''; return; }
-  let inner = `<div class="wall-info">剩 ${state.wall.length} tiles</div>`;
-  if (state.lastDiscard){
-    inner += `<div class="last-played"><span class="lbl">${escapeHtml(state.players[state.lastDiscard.by].name)} discarded</span>${tileHTML(state.lastDiscard.kind)}</div>`;
+  let inner = `<div class="wall-info">剩 ${view.wallRemaining} tiles</div>`;
+  if (view.pendingDiscard) {
+    inner += `<div class="last-played"><span class="lbl">${escapeHtml(view.players[view.pendingDiscard.by].name)} discarded</span>${tileHTML(view.pendingDiscard.tile)}</div>`;
   }
   c.innerHTML = inner;
 }
 
-function renderHandArea(view){
+function renderHandArea(view) {
   const area = $('handarea');
-  const p = state.players[view];
+  const me = view.me;
+  const acts = me.legalActions || [];
 
-  // ding-que prompt handled separately by askMissingSuit (overlay-ish inline)
-  if (state.phase === 'dingque' && uiState && uiState.ctx && uiState.ctx.type === 'dingque'){
-    area.innerHTML = dingQueHTML(view);
-    return;
-  }
+  // missing-suit chooser
+  if (acts.some((a) => a.type === 'ChooseMissingSuit')) { area.innerHTML = dingQueHTML(view); wireDingque(); return; }
 
-  // hand tiles
-  const kinds = [];
-  for (let k = 0; k < 27; k++) for (let i = 0; i < p.hand[k]; i++) kinds.push(k);
-  // place the freshly drawn tile at the end, separated
-  let drawnIdx = -1;
-  if (p.drawn != null){
-    const di = kinds.lastIndexOf(p.drawn);
-    if (di >= 0){ kinds.splice(di, 1); drawnIdx = p.drawn; }
-  }
+  // build hand tiles, pulling the freshly drawn tile to the end
+  const tiles = [];
+  for (let t = 0; t < NUM_TYPES; t++) for (let i = 0; i < me.concealed[t]; i++) tiles.push(t);
+  let drawn = null;
+  if (view.lastDrawn != null && me.concealed[view.lastDrawn] > 0) { const i = tiles.lastIndexOf(view.lastDrawn); if (i >= 0) { tiles.splice(i, 1); drawn = view.lastDrawn; } }
 
-  const canDiscard = uiState && uiState.pi === view &&
-      (uiState.options || []).some(o => o.type === 'discard');
-  const discardKinds = canDiscard ? new Set(uiState.options.filter(o=>o.type==='discard').map(o=>o.kind)) : null;
+  const discardable = new Set(acts.filter((a) => a.type === 'Discard').map((a) => a.tile));
+  const canDiscard = discardable.size > 0;
+  const readySet = new Set(me.ready || []);
 
-  let html = '<div class="hand-row">';
-  for (const k of kinds){
-    const playable = discardKinds && discardKinds.has(k);
-    const dim = discardKinds && !discardKinds.has(k);
-    html += `<div class="tile ${SUIT_CLASS[ksuit(k)]} ${playable?'playable':''} ${dim?'dim':''}" data-k="${k}">
-      <span class="num">${krank(k)}</span><span class="glyph">${SUIT_GLYPH[ksuit(k)]}</span></div>`;
-  }
-  if (drawnIdx >= 0){
-    const playable = discardKinds && discardKinds.has(drawnIdx);
-    const dim = discardKinds && !discardKinds.has(drawnIdx);
-    html += `<div class="tile ${SUIT_CLASS[ksuit(drawnIdx)]} drawn ${playable?'playable':''} ${dim?'dim':''}" data-k="${drawnIdx}">
-      <span class="num">${krank(drawnIdx)}</span><span class="glyph">${SUIT_GLYPH[ksuit(drawnIdx)]}</span></div>`;
-  }
-  html += '</div>';
-  html += `<div class="actions" id="actions"></div>`;
+  let html = '';
+  if (me.ready && me.ready.length && !me.hasWon) {
+    html += `<div class="ready-banner">🀄 Ready — win on ${me.ready.map((t) => tileRank(t) + SUIT_GLYPH[tileSuit(t)]).join(' ')}</div>`;
+  } else html += `<div class="ready-banner"></div>`;
+  html += '<div class="hand-row">';
+  const tileCls = (t) => `${SUIT_CSS[tileSuit(t)]} ${canDiscard ? (discardable.has(t) ? 'playable' : 'dim') : ''}`;
+  for (const t of tiles) html += `<div class="tile ${tileCls(t)}" data-k="${t}"><span class="num">${tileRank(t)}</span><span class="glyph">${SUIT_GLYPH[tileSuit(t)]}</span></div>`;
+  if (drawn != null) html += `<div class="tile ${tileCls(drawn)} drawn" data-k="${drawn}"><span class="num">${tileRank(drawn)}</span><span class="glyph">${SUIT_GLYPH[tileSuit(drawn)]}</span></div>`;
+  html += '</div><div class="actions" id="actions"></div>';
   area.innerHTML = html;
 
-  // wire discard taps
-  if (discardKinds){
-    area.querySelectorAll('.tile.playable').forEach(t => {
-      t.addEventListener('click', () => {
-        const k = +t.dataset.k;
-        resolveHuman({ type:'discard', kind:k });
-      });
-    });
-  }
+  if (canDiscard) area.querySelectorAll('.tile.playable').forEach((el) => el.addEventListener('click', () => submit({ type: 'Discard', tile: +el.dataset.k })));
   renderActions(view);
 }
-function renderActions(view){
-  const ab = $('actions');
-  if (!ab) return;
-  if (!uiState || uiState.pi !== view){ ab.innerHTML = ''; return; }
-  const opts = uiState.options || [];
+
+function renderActions(view) {
+  const ab = $('actions'); if (!ab) return;
+  const me = view.me, acts = me.legalActions || [];
+  // Only the human(s) who must decide see buttons; spectators see waiting text.
+  if (!acts.length) {
+    const active = view.players[view.active];
+    ab.innerHTML = me.hasWon ? `<span class="hint">You won — watching the rest of the hand.</span>`
+      : `<span class="hint">Waiting for ${escapeHtml(active ? active.name : '…')}…</span>`;
+    return;
+  }
   let html = '';
-  const hu = opts.find(o => o.type === 'hu');
-  if (hu) html += `<button class="b-hu" data-act="hu">胡 HU</button>`;
-  // gang buttons (turn): angang/bugang
-  for (const o of opts.filter(o => o.type === 'angang')) html += `<button class="b-gang" data-act="angang" data-k="${o.kind}">暗杠 ${krank(o.kind)}${SUIT_GLYPH[ksuit(o.kind)]}</button>`;
-  for (const o of opts.filter(o => o.type === 'bugang')) html += `<button class="b-gang" data-act="bugang" data-k="${o.kind}">补杠 ${krank(o.kind)}${SUIT_GLYPH[ksuit(o.kind)]}</button>`;
-  // claim window
-  const peng = opts.find(o => o.type === 'peng');
-  const mgang = opts.find(o => o.type === 'minggang');
-  if (peng) html += `<button class="b-peng" data-act="peng" data-k="${peng.kind}">碰 PENG</button>`;
-  if (mgang) html += `<button class="b-gang" data-act="minggang" data-k="${mgang.kind}">杠 GANG</button>`;
-  const pass = opts.find(o => o.type === 'pass');
-  if (pass) html += `<button class="b-pass" data-act="pass">Pass</button>`;
-  if (opts.some(o => o.type === 'discard') && !hu && !peng && !mgang){
-    html += `<span class="hint">Tap a tile to discard${missingCount(state.players[view])>0?' (clear 缺 suit)':''}</span>`;
+  const win = acts.find((a) => a.type === 'DeclareSelfDrawWin' || a.type === 'DeclareWinFromDiscard' || a.type === 'RobKong');
+  if (win) html += `<button class="b-hu" data-i="${acts.indexOf(win)}">胡 HU</button>`;
+  acts.forEach((a, i) => {
+    if (a.type === 'DeclareConcealedKong') html += `<button class="b-gang" data-i="${i}">暗杠 ${tileRank(a.tile)}${SUIT_GLYPH[tileSuit(a.tile)]}</button>`;
+    if (a.type === 'DeclareAddedKong') html += `<button class="b-gang" data-i="${i}">补杠 ${tileRank(a.tile)}${SUIT_GLYPH[tileSuit(a.tile)]}</button>`;
+    if (a.type === 'ClaimKongFromDiscard') html += `<button class="b-gang" data-i="${i}">杠 GANG</button>`;
+    if (a.type === 'ClaimPung') html += `<button class="b-peng" data-i="${i}">碰 PENG</button>`;
+  });
+  const pass = acts.find((a) => a.type === 'Pass');
+  if (pass) html += `<button class="b-pass" data-i="${acts.indexOf(pass)}">Pass</button>`;
+  if (acts.some((a) => a.type === 'Discard') && !win && !acts.some((a) => a.type === 'ClaimPung' || a.type === 'ClaimKongFromDiscard')) {
+    const holdsMissing = missingCount({ concealed: me.concealed, missingSuit: me.missingSuit }) > 0;
+    html += `<span class="hint">Tap a tile to discard${holdsMissing ? ' (clear 缺 suit)' : ''}</span>`;
   }
   ab.innerHTML = html;
-  ab.querySelectorAll('button').forEach(b => {
-    b.addEventListener('click', () => {
-      const a = b.dataset.act;
-      const k = b.dataset.k != null ? +b.dataset.k : undefined;
-      if (a === 'hu') resolveHuman(uiState.options.find(o => o.type === 'hu'));
-      else if (a === 'pass') resolveHuman({ type:'pass' });
-      else resolveHuman({ type:a, kind:k });
-    });
-  });
+  ab.querySelectorAll('button[data-i]').forEach((b) => b.addEventListener('click', () => submit(acts[+b.dataset.i])));
 }
 
-/* ---- human input plumbing ---- */
-function askHuman(pi, ctx, options){
-  return new Promise(async resolve => {
-    // reveal gate for hot-seat (multiple humans)
-    if (cfg.humans > 1 && pi !== lastShownHuman){
-      await revealGate(pi);
-    }
-    lastShownHuman = pi;
-    uiState = { pi, ctx, options };
-    humanResolver = (action) => {
-      humanResolver = null;
-      uiState = null;
-      resolve(action);
-    };
-    render();
-  });
-}
-function resolveHuman(action){ if (humanResolver) humanResolver(action); }
-function revealGate(pi){
-  return new Promise(resolve => {
-    overlay.style.display = 'flex';
-    overlay.innerHTML = `<div class="modal reveal-gate" id="rg">
-      <div class="big">🀄️</div>
-      <h2>${escapeHtml(state.players[pi].name)}</h2>
-      <p>Pass the device. Tap when ready — keep your tiles hidden from the others.</p>
-      <button class="btn">I'm ready</button></div>`;
-    const go = () => { overlay.style.display = 'none'; overlay.innerHTML = ''; resolve(); };
-    $('rg').querySelector('.btn').addEventListener('click', go);
-  });
-}
-
-/* ---- ding que selection ---- */
-function askMissingSuit(pi){
-  return new Promise(async resolve => {
-    if (cfg.humans > 1 && pi !== lastShownHuman) await revealGate(pi);
-    lastShownHuman = pi;
-    uiState = { pi, ctx:{ type:'dingque' }, options:[] };
-    state._dingResolve = resolve;
-    render();
-  });
-}
-function dingQueHTML(pi){
-  const p = state.players[pi];
-  const cnt = [0,0,0];
-  for (let k = 0; k < 27; k++) cnt[ksuit(k)] += p.hand[k];
-  const rec = botPickMissing(p);
-  // show the hand above the chooser
-  const kinds = listOf(p.hand);
-  let hand = '<div class="hand-row" style="margin-bottom:6px">';
-  for (const k of kinds) hand += tileHTML(k);
-  hand += '</div>';
+/* ---- ding que ---- */
+function dingQueHTML(view) {
+  const me = view.me;
+  const cnt = [0, 0, 0];
+  for (let t = 0; t < NUM_TYPES; t++) cnt[tileSuit(t)] += me.concealed[t];
+  const rec = botChooseMissingSuit({ concealed: me.concealed });
+  const tiles = [];
+  for (let t = 0; t < NUM_TYPES; t++) for (let i = 0; i < me.concealed[t]; i++) tiles.push(t);
+  let hand = '<div class="hand-row" style="margin-bottom:6px">' + tiles.map((t) => tileHTML(t)).join('') + '</div>';
   let opts = '<div class="opts">';
-  for (let s = 0; s < 3; s++){
-    opts += `<button class="${s===rec?'rec':''}" data-suit="${s}">
-      <span class="big ${SUIT_CLASS[s]}" style="color:${['#ff8a8a','#7be39a','#8ec5ff'][s]}">${SUIT_GLYPH[s]}</span>
-      <span class="ct">${cnt[s]} tiles</span>
-      ${s===rec?'<span class="tag">suggested</span>':''}</button>`;
+  for (let s = 0; s < 3; s++) {
+    opts += `<button class="${s === rec ? 'rec' : ''}" data-suit="${s}">
+      <span class="big" style="color:${SUIT_TINT[s]}">${SUIT_GLYPH[s]}</span>
+      <span class="ct">${cnt[s]} tiles</span>${s === rec ? '<span class="tag">suggested</span>' : ''}</button>`;
   }
   opts += '</div>';
-  return hand + `<div class="dingque"><div class="q">定缺 — choose the suit you will <b>not</b> use</div>${opts}</div>`;
+  return `<div class="ready-banner"></div>` + hand + `<div class="dingque"><div class="q">定缺 — choose the suit you will <b>not</b> use</div>${opts}</div>`;
 }
-document.addEventListener('click', e => {
-  const b = e.target.closest('.dingque .opts button');
-  if (b && state && state._dingResolve){
-    const s = +b.dataset.suit;
-    const r = state._dingResolve; state._dingResolve = null; uiState = null;
-    r(s);
-  }
-});
+function wireDingque() {
+  document.querySelectorAll('#handarea .dingque .opts button').forEach((b) =>
+    b.addEventListener('click', () => submit({ type: 'ChooseMissingSuit', suit: +b.dataset.suit })));
+}
+
+/* ---- submit routes the chosen action to the active connection ---- */
+function submit(action) { if (conn) conn.submit(action); }
+
+/* ---- reveal gate (hot-seat privacy) ---- */
+function showRevealGate(reveal) {
+  overlay.style.display = 'flex';
+  overlay.innerHTML = `<div class="modal reveal-gate" id="rg"><div class="big">🀄️</div>
+    <h2>${escapeHtml(reveal.name)}</h2>
+    <p>Pass the device. Tap when ready — keep your tiles hidden from the others.</p>
+    <button class="btn">I'm ready</button></div>`;
+  $('rg').querySelector('.btn').addEventListener('click', () => {
+    pendingReveal = null; overlay.style.display = 'none'; overlay.innerHTML = ''; render();
+  });
+}
 
 /* ---- toasts ---- */
 let toastTimer = null;
-function toast(msg, ms=900){
-  const t = $('toast');
-  t.textContent = msg; t.classList.add('show');
-  clearTimeout(toastTimer);
-  toastTimer = setTimeout(() => t.classList.remove('show'), ms);
+function toast(msg, ms = 950) {
+  const t = $('toast'); t.textContent = msg; t.classList.add('show');
+  clearTimeout(toastTimer); toastTimer = setTimeout(() => t.classList.remove('show'), ms);
+}
+function updateConnPill(c) {
+  const el = $('conpill'); el.style.display = 'inline-block';
+  el.textContent = c.text; el.className = 'conpill ' + (c.state || '');
 }
 
-/* ---- results ---- */
-function showResults(reason){
-  const ranked = state.players.map((p,i) => ({ p, i })).sort((a,b) => b.p.score - a.p.score);
+/* ---- results / scoreboard ---- */
+const FAN_CN = { 'Base Win': '平胡', 'Self-Draw': '自摸', 'All Pungs': '碰碰胡', 'Pure One Suit': '清一色',
+  'Seven Pairs': '七对', 'Luxury Seven Pairs': '龙七对', 'Root': '根', 'Kong Bloom': '杠上花',
+  'Robbing a Kong': '抢杠', 'Last Tile Draw': '海底捞月', 'Last Discard Win': '海底炮',
+  'Heavenly Hand': '天胡', 'Earthly Hand': '地胡' };
+function showResults(view) {
+  const res = view.results;
+  const ranked = view.players.map((p) => p).slice().sort((a, b) => b.score - a.score);
   let rows = '';
-  for (const { p, i } of ranked){
-    const wi = p.winInfo;
-    rows += `<tr>
-      <td>${escapeHtml(p.name)} ${p.isBot?'<small style="opacity:.5">bot</small>':''}</td>
-      <td>${wi ? `<small>${wi.names.join(' ')} (${wi.fan}番)</small>` : (state.winners.includes(i)?'':'<small style="opacity:.5">—</small>')}</td>
-      <td class="pos ${p.score>0?'gain-pos':p.score<0?'gain-neg':''}">${p.score>=0?'+':''}${p.score}</td>
-    </tr>`;
+  for (const p of ranked) {
+    const rec = res.records.find((r) => r.winner === p.seat);
+    const hand = rec ? `<small>${rec.fanAwards.map((f) => FAN_CN[f.name] || f.name).join(' ')} (${rec.finalFan}番)</small>`
+      : (res.winners.includes(p.seat) ? '' : '<small style="opacity:.5">—</small>');
+    rows += `<tr><td>${escapeHtml(p.name)} ${p.isBot ? '<small style="opacity:.5">bot</small>' : ''}</td>
+      <td>${hand}</td><td class="pos ${p.score > 0 ? 'gain-pos' : p.score < 0 ? 'gain-neg' : ''}">${p.score >= 0 ? '+' : ''}${p.score}</td></tr>`;
   }
-  const title = reason === 'draw'
-      ? (state.winners.length ? '血战结束 Hand Over' : '荒庄 Draw')
-    : state.mode === 'single' ? '胡牌 Winner!' : '血战结束 Hand Over';
+  const title = res.reason === 'exhaustion'
+    ? (res.winners.length ? '血战结束 Hand Over' : '荒庄 Draw')
+    : (view.mode === 'single' ? '胡牌 Winner!' : '血战结束 Hand Over');
   overlay.style.display = 'flex';
-  overlay.innerHTML = `<div class="modal">
-    <h2>${title}</h2>
+  overlay.innerHTML = `<div class="modal"><h2>${title}</h2>
     <table class="scoreboard"><tr><th>Player</th><th>Hand</th><th class="pos">Score</th></tr>${rows}</table>
-    <button class="btn" id="again">New Hand</button>
-    <button class="btn alt" id="tomenu">Main Menu</button>
-  </div>`;
-  $('again').addEventListener('click', () => { overlay.style.display='none'; overlay.innerHTML=''; startGame(); });
-  $('tomenu').addEventListener('click', () => { overlay.style.display='none'; overlay.innerHTML=''; showSetup(); });
+    ${online ? `<button class="btn" id="again">Back to Lobby</button>` : `<button class="btn" id="again">New Hand</button>`}
+    <button class="btn alt" id="tomenu">Main Menu</button></div>`;
+  $('again').addEventListener('click', () => { overlay.style.display = 'none'; overlay.innerHTML = ''; if (conn && conn.again) conn.again(); });
+  $('tomenu').addEventListener('click', () => { overlay.style.display = 'none'; overlay.innerHTML = ''; leaveGame(); });
 }
 
 /* ---- menu / rules ---- */
-function showMenu(){
+function showMenu() {
   overlay.style.display = 'flex';
-  overlay.innerHTML = `<div class="modal">
-    <h2>Menu</h2>
+  overlay.innerHTML = `<div class="modal"><h2>Menu</h2>
     <button class="btn" id="m-resume">Resume</button>
-    <button class="btn alt" id="m-new">New Hand</button>
     <button class="btn alt" id="m-rules">Rules</button>
-    <button class="btn alt" id="m-menu">Main Menu</button>
-  </div>`;
-  $('m-resume').onclick = () => { overlay.style.display='none'; overlay.innerHTML=''; };
-  $('m-new').onclick = () => { overlay.style.display='none'; overlay.innerHTML=''; startGame(); };
+    <button class="btn alt" id="m-menu">Leave Game</button></div>`;
+  $('m-resume').onclick = () => { overlay.style.display = 'none'; overlay.innerHTML = ''; };
   $('m-rules').onclick = showRules;
-  $('m-menu').onclick = () => { overlay.style.display='none'; overlay.innerHTML=''; showSetup(); };
+  $('m-menu').onclick = () => { overlay.style.display = 'none'; overlay.innerHTML = ''; leaveGame(); };
 }
-function showRules(){
+function showRules() {
   overlay.style.display = 'flex';
   overlay.innerHTML = `<div class="modal"><div class="rules-content">
     <h2>四川麻將 — How to Play</h2>
-    <h3>Tiles</h3>
-    <ul><li>108 tiles: three suits only — 萬 Characters, 条 Bamboo, 筒 Dots, 1–9 ×4. No winds or dragons.</li></ul>
-    <h3>定缺 Missing Suit</h3>
-    <ul><li>After the deal, each player picks one suit they will <b>not</b> use.</li>
-    <li>You must discard all tiles of that suit before doing anything else, and you cannot win while holding any.</li></ul>
-    <h3>Melds</h3>
-    <ul><li><b>碰 Peng</b> — claim a discard to make a triplet.</li>
-    <li><b>杠 Gang</b> — a kong of four: from a discard (直杠), added to a peng (补杠, can be robbed), or concealed (暗杠). Draw a replacement after.</li>
-    <li>No chow — you cannot claim a discard to make a run.</li></ul>
-    <h3>胡 Winning</h3>
-    <ul><li>Four melds + a pair (or seven pairs), using only your two chosen suits.</li>
-    <li>自摸 self-draw: everyone pays. 点炮 on a discard: only the discarder pays.</li></ul>
-    <h3>Scoring (番)</h3>
-    <ul><li>Points double per 番: 平胡, 碰碰胡, 清一色, 七对, 金钩钓, 自摸, 杠上花/炮, 抢杠, 海底, 根…</li>
-    <li>刮风下雨: kongs pay out immediately (暗杠 2 each, 直杠 2 from the discarder, 补杠 1 each).</li></ul>
-    <h3>血战到底 Bloody</h3>
-    <ul><li>Winning doesn't end the hand — play continues until three players have won.</li></ul>
-    </div>
-    <button class="btn" id="r-close">Got it</button></div>`;
-  $('r-close').onclick = () => {
-    if (state && state.phase !== 'over') { overlay.style.display='none'; overlay.innerHTML=''; }
-    else { overlay.style.display='none'; overlay.innerHTML=''; }
-  };
+    <h3>Tiles</h3><ul><li>108 tiles, three suits only: 筒 Dots, 条 Bamboo, 萬 Characters (1–9 ×4). No winds or dragons.</li></ul>
+    <h3>定缺 Missing Suit</h3><ul><li>After the deal each player picks one suit they will <b>not</b> use.</li>
+    <li>You must discard those tiles first and cannot win while holding any.</li></ul>
+    <h3>Melds</h3><ul><li><b>碰 Peng</b> — claim a discard for a triplet. <b>杠 Gang</b> — a kong (4): from a discard, added to a peng (robbable), or concealed; draw a replacement.</li>
+    <li>No chow — you cannot claim a discard to make a run (you may still form runs in your own concealed hand).</li></ul>
+    <h3>胡 Winning</h3><ul><li>Four groups + a pair, or seven pairs, using only your two suits.</li>
+    <li>Self-draw: all pay. On a discard: only the discarder pays. Several players may win on one discard.</li></ul>
+    <h3>血战到底 Bloody Battle</h3><ul><li>Winning doesn't end the hand — play continues until three players have won.</li></ul>
+    </div><button class="btn" id="r-close">Got it</button></div>`;
+  $('r-close').onclick = () => { overlay.style.display = 'none'; overlay.innerHTML = ''; };
+}
+
+function leaveGame() {
+  if (conn && conn.dispose) conn.dispose();
+  conn = null; curView = null; online = false;
+  $('conpill').style.display = 'none';
+  $('game').style.display = 'none'; $('setup').style.display = 'flex';
 }
 
 /* =====================================================================
-   SCREEN SWITCHING + SETUP WIRING
-   ===================================================================== */
-function showSetup(){ $('setup').style.display='flex'; $('game').style.display='none'; }
-function showGame(){ $('setup').style.display='none'; $('game').style.display='flex'; }
+ * LOCAL CONNECTION — drives the core in-browser (hot-seat + bots)
+ * ===================================================================== */
+class LocalConnection {
+  constructor(cfg) {
+    this.cfg = cfg;
+    this.numHumans = cfg.seats.filter((s) => !s.isBot).length;
+    this.lastHuman = cfg.seats.findIndex((s) => !s.isBot);
+    this.pendingResolve = null;
+    this.alive = true;
+    this.newHand();
+  }
+  newHand() {
+    const seed = (Date.now() ^ (Math.random() * 1e9)) | 0;
+    this.state = createGame({ seed, config: this.cfg.config, names: this.cfg.names, seats: this.cfg.seats, dealer: this.cfg.dealer || 0, seatScores: this.scores });
+    this.drive();
+  }
+  dispose() { this.alive = false; this.pendingResolve = null; }
+  again() { this.scores = this.state.players.map((p) => p.score); this.cfg.dealer = this.state.nextDealer; this.newHand(); }
 
-function buildNameInputs(){
-  const box = $('name-inputs');
-  box.innerHTML = '';
-  for (let i = 0; i < cfg.humans; i++){
+  emit(meta) {
+    const viewer = (this.viewerSeat != null) ? this.viewerSeat : (this.lastHuman >= 0 ? this.lastHuman : 0);
+    onUpdate(viewFor(this.state, viewer), meta || {});
+  }
+  eventToasts(events) {
+    const out = [];
+    for (const e of events) {
+      if (e.type === 'PungClaimed') out.push({ msg: '碰 PENG' });
+      else if (e.type === 'KongClaimedFromDiscard' || e.type === 'ConcealedKongDeclared' || e.type === 'AddedKongDeclared') out.push({ msg: '杠 GANG' });
+      else if (e.type === 'KongRobbed') out.push({ msg: '抢杠 ROB!' });
+      else if (e.type === 'WinResolved') out.push({ msg: (e.winType === 'SELF_DRAW' ? '自摸 ZIMO' : '胡 HU') + ' +' + e.points });
+    }
+    return out;
+  }
+
+  async drive() {
+    while (this.alive) {
+      if (this.state.phase === 'HAND_ENDED') { this.viewerSeat = this.lastHuman >= 0 ? this.lastHuman : 0; this.emit({}); return; }
+      const deciders = pendingDeciders(this.state);
+      if (!deciders.length) return;
+      const botSeat = deciders.find((s) => this.state.players[s].isBot);
+      if (botSeat != null) {
+        this.viewerSeat = this.lastHuman >= 0 ? this.lastHuman : botSeat;
+        this.emit({});                                   // show the bot as "thinking"
+        await this.botThink(this.state.players[botSeat]);
+        if (!this.alive) return;
+        const a = botChooseAction(this.state, botSeat);
+        const res = applyAction(this.state, botSeat, a);
+        this.emit({ toasts: this.eventToasts(res.events || []) });
+        continue;
+      }
+      // a human must decide
+      const seat = deciders[0];
+      const reveal = (this.numHumans > 1 && seat !== this.lastHuman) ? { seat, name: this.state.players[seat].name } : null;
+      this.viewerSeat = seat; this.lastHuman = seat;
+      const action = await new Promise((r) => { this.pendingResolve = r; this.emit({ reveal }); });
+      if (!this.alive) return;
+      const res = applyAction(this.state, seat, action);
+      if (!res.ok) { this.emit({ toasts: [{ msg: res.error.message, ms: 1600 }] }); continue; }
+      this.emit({ toasts: this.eventToasts(res.events || []) });
+    }
+  }
+  botThink(p) {
+    const base = p.difficulty === 'hard' ? 560 : p.difficulty === 'normal' ? 460 : 340;
+    return sleep(base + Math.random() * 420);
+  }
+  submit(action) { const r = this.pendingResolve; this.pendingResolve = null; if (r) r(action); }
+}
+
+/* =====================================================================
+ * SETUP wiring
+ * ===================================================================== */
+const localCfg = { humans: 1, diff: 'normal', mode: 'bloody', sevenPairs: true, names: [] };
+const onlineCfg = { name: '', diff: 'normal' };
+
+function buildNameInputs() {
+  const box = $('name-inputs'); box.innerHTML = '';
+  for (let i = 0; i < localCfg.humans; i++) {
     const inp = document.createElement('input');
-    inp.placeholder = `Player ${i+1} name`;
-    inp.value = cfg.names[i] || '';
-    inp.maxLength = 12;
-    inp.addEventListener('input', () => { cfg.names[i] = inp.value; });
+    inp.className = 'txt'; inp.placeholder = `Player ${i + 1} name`; inp.value = localCfg.names[i] || ''; inp.maxLength = 12;
+    inp.addEventListener('input', () => { localCfg.names[i] = inp.value; });
     box.appendChild(inp);
   }
 }
-function wireSetup(){
-  $('humans-seg').addEventListener('click', e => {
+function segWire(id, key, cfg, cast = (x) => x) {
+  $(id).addEventListener('click', (e) => {
     const b = e.target.closest('button'); if (!b) return;
-    [...$('humans-seg').children].forEach(x => x.classList.remove('on'));
-    b.classList.add('on'); cfg.humans = +b.dataset.h; buildNameInputs();
+    [...$(id).children].forEach((x) => x.classList.remove('on')); b.classList.add('on');
+    cfg[key] = cast(b.dataset[Object.keys(b.dataset)[0]]);
+    if (id === 'humans-seg') buildNameInputs();
   });
-  $('diff-seg').addEventListener('click', e => {
+}
+function startLocal() {
+  const seats = [];
+  for (let i = 0; i < 4; i++) seats.push({ isBot: i >= localCfg.humans, difficulty: localCfg.diff });
+  const names = [];
+  for (let i = 0; i < 4; i++) names[i] = i < localCfg.humans ? (localCfg.names[i] || `Player ${i + 1}`) : `Bot ${i}`;
+  const config = makeConfig({ mode: localCfg.mode, allowSevenPairs: localCfg.sevenPairs });
+  online = false;
+  conn = new LocalConnection({ config, names, seats });
+  $('conpill').style.display = 'none';
+  showGameScreen();
+}
+function showGameScreen() { $('setup').style.display = 'none'; $('game').style.display = 'flex'; }
+
+function wireSetup() {
+  // tabs
+  document.querySelector('.mode-tabs').addEventListener('click', (e) => {
     const b = e.target.closest('button'); if (!b) return;
-    [...$('diff-seg').children].forEach(x => x.classList.remove('on'));
-    b.classList.add('on'); cfg.diff = b.dataset.d;
+    document.querySelectorAll('.mode-tabs button').forEach((x) => x.classList.remove('on')); b.classList.add('on');
+    const online = b.dataset.tab === 'online';
+    $('local-setup').style.display = online ? 'none' : 'block';
+    $('online-setup').style.display = online ? 'block' : 'none';
   });
-  $('mode-seg').addEventListener('click', e => {
-    const b = e.target.closest('button'); if (!b) return;
-    [...$('mode-seg').children].forEach(x => x.classList.remove('on'));
-    b.classList.add('on'); cfg.mode = b.dataset.m;
-  });
-  $('start-btn').addEventListener('click', startGame);
+  segWire('humans-seg', 'humans', localCfg, (x) => +x);
+  segWire('diff-seg', 'diff', localCfg);
+  segWire('mode-seg', 'mode', localCfg);
+  segWire('odiff-seg', 'diff', onlineCfg);
+  $('sw-sevenpairs').addEventListener('click', (e) => { e.currentTarget.classList.toggle('on'); localCfg.sevenPairs = e.currentTarget.classList.contains('on'); });
+  $('start-local').addEventListener('click', startLocal);
+  $('online-name').addEventListener('input', (e) => { onlineCfg.name = e.target.value; });
+  $('btn-create').addEventListener('click', () => startOnline('create'));
+  $('btn-join').addEventListener('click', () => startOnline('join'));
   $('rules-link').addEventListener('click', showRules);
   $('rules-btn').addEventListener('click', showRules);
   $('menu-btn').addEventListener('click', showMenu);
   buildNameInputs();
 }
 
-/* utils */
-const sleep = ms => new Promise(r => setTimeout(r, ms));
-function escapeHtml(s){ return String(s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
+/* online entry point — implemented in the Online phase (net.js section below) */
+function startOnline(/* mode */) { $('online-msg').textContent = 'Online play is loading…'; if (window.__startOnline) window.__startOnline(); }
 
 wireSetup();
-
-/* =====================================================================
-   TEST SUITE  (legality + rules engine).  Run with ?test or window.runTests()
-   ===================================================================== */
-function runTests(){
-  let pass = 0, fail = 0; const log = [];
-  const ok = (cond, msg) => { if (cond){ pass++; } else { fail++; log.push('FAIL: ' + msg); } };
-
-  // deck composition
-  const d = newDeck();
-  ok(d.length === 108, '108 tiles');
-  const cc = emptyCounts(); d.forEach(k => cc[k]++);
-  ok(cc.every(x => x === 4), 'exactly 4 of each kind');
-
-  // winning hands
-  const P = (hand, melds=[], missing=2) => ({ hand: listToCounts(hand), melds, missing });
-  function listToCounts(a){ const c = emptyCounts(); a.forEach(k => c[k]++); return c; }
-  // 123 456 789 m  + 11 s  + 11 s pair? need 4 sets + pair. Build: 123m 456m 789m 123s 99s
-  let h = [mk(0,1),mk(0,2),mk(0,3), mk(0,4),mk(0,5),mk(0,6), mk(0,7),mk(0,8),mk(0,9), mk(1,1),mk(1,2),mk(1,3), mk(1,9),mk(1,9)];
-  ok(winsNow(P(h, [], 2)), 'standard 4 sets + pair wins');
-  // missing-suit violation: same hand but missing = bamboo(1)
-  ok(!winsNow(P(h, [], 1)), 'cannot win holding missing suit');
-  // seven pairs
-  let sp = [mk(0,1),mk(0,1),mk(0,3),mk(0,3),mk(0,5),mk(0,5),mk(1,2),mk(1,2),mk(1,4),mk(1,4),mk(1,6),mk(1,6),mk(1,8),mk(1,8)];
-  ok(winsNow(P(sp, [], 2)), 'seven pairs wins');
-  // not a win
-  let no = [mk(0,1),mk(0,2),mk(0,4), mk(0,4),mk(0,5),mk(0,6), mk(0,7),mk(0,8),mk(0,9), mk(1,1),mk(1,2),mk(1,3), mk(1,9),mk(1,8)];
-  ok(!winsNow(P(no, [], 2)), 'non-winning hand rejected');
-  // with a peng meld: 3 sets + pair concealed
-  let hm = [mk(0,1),mk(0,2),mk(0,3), mk(0,4),mk(0,5),mk(0,6), mk(1,1),mk(1,2),mk(1,3), mk(1,9),mk(1,9)];
-  ok(winsNow(P(hm, [{type:'peng',kind:mk(0,7)}], 2)), 'win with one peng meld');
-  // canHu adds a tile
-  let wait = [mk(0,1),mk(0,2),mk(0,3), mk(0,4),mk(0,5),mk(0,6), mk(0,7),mk(0,8),mk(0,9), mk(1,1),mk(1,2),mk(1,3), mk(1,9)];
-  ok(canHu(P(wait, [], 2), mk(1,9)), 'canHu completes the pair');
-  ok(!canHu(P(wait, [], 2), mk(2,5)), 'canHu rejects non-winning tile');
-  // canHu must respect missing suit
-  ok(!canHu(P(wait, [], 1), mk(1,9)), 'canHu rejects tile from forbidden suit / holding missing');
-
-  // shanten sanity
-  ok(stdShanten(listToCounts(h), 0) === -1, 'complete hand shanten = -1');
-  ok(stdShanten(listToCounts(wait), 0) === 0, 'tenpai shanten = 0');
-
-  // enumerateLegalActions — turn context restricts to missing suit when holding it
-  const ts = makeTestState();
-  ts.players[0].missing = 2; // dots
-  ts.players[0].hand = listToCounts([mk(2,1),mk(2,2), mk(0,1),mk(0,2),mk(0,3), mk(0,4),mk(0,5),mk(0,6), mk(1,1),mk(1,2),mk(1,3), mk(1,7),mk(1,8),mk(1,9)]);
-  const turnActs = enumerateLegalActions(ts, 0, { type:'turn' });
-  const discardKinds = turnActs.filter(a => a.type === 'discard').map(a => a.kind);
-  ok(discardKinds.every(k => ksuit(k) === 2), 'must discard missing suit first');
-  ok(discardKinds.length === 2, 'only the two dot tiles are discardable');
-
-  // claim legality: peng requires two in hand
-  ts.players[1].missing = 0; ts.players[1].hand = listToCounts([mk(1,5),mk(1,5), mk(2,1),mk(2,2),mk(2,3), mk(1,1),mk(1,2),mk(1,3),mk(2,7),mk(2,8),mk(2,9),mk(2,4),mk(2,5)]);
-  const claimActs = enumerateLegalActions(ts, 1, { type:'claim', discarder:0, kind:mk(1,5) });
-  ok(claimActs.some(a => a.type === 'peng'), 'peng offered with a pair in hand');
-  ok(!claimActs.some(a => a.type === 'minggang'), 'no gang offered with only a pair');
-  // peng of the missing suit not allowed
-  ts.players[1].missing = 1;
-  const claimActs2 = enumerateLegalActions(ts, 1, { type:'claim', discarder:0, kind:mk(1,5) });
-  ok(!claimActs2.some(a => a.type === 'peng'), 'cannot peng your missing suit');
-
-  // FULL BOT-LEGALITY FUZZ: play many bot-only games, validate EVERY chosen action.
-  let illegal = 0, games = 0, errors = 0;
-  for (let g = 0; g < 60; g++){
-    try { illegal += simulateBotGame(); games++; }
-    catch (e){ errors++; log.push('ERR: ' + (e && e.message)); }
-  }
-  ok(illegal === 0, `bots only chose legal actions (illegal=${illegal} over ${games} games)`);
-  ok(errors === 0, `no engine errors during fuzz (${errors})`);
-
-  const summary = `Mahjong tests: ${pass} passed, ${fail} failed.`;
-  const out = summary + (log.length ? '\n' + log.join('\n') : '');
-  console.log(out);
-  return { pass, fail, log, summary };
-}
-function makeTestState(){
-  return {
-    mode:'bloody', wall:[], winners:[], turn:0,
-    players: [0,1,2,3].map(i => ({ id:i, name:'P'+i, isBot:true, diff:'normal',
-      hand:emptyCounts(), melds:[], discards:[], missing:null, won:false, score:0 })),
-  };
-}
-/* Headless bot-only game using ONLY the engine + bot logic (no DOM, no await). */
-function simulateBotGame(){
-  let illegal = 0;
-  const deck = newDeck();
-  const players = [0,1,2,3].map(i => ({ id:i, name:'Bot'+i, isBot:true, diff:['easy','normal','hard'][i%3],
-    hand:emptyCounts(), melds:[], discards:[], missing:null, won:false, score:0, justGanged:false }));
-  for (let n = 0; n < 13; n++) for (let i = 0; i < 4; i++) players[i].hand[deck.pop()]++;
-  const S = { mode:'bloody', wall:deck, players, winners:[], turn:0 };
-  for (const p of players) p.missing = botPickMissing(p);
-
-  const validate = (pi, ctx, act) => {
-    const legal = enumerateLegalActions(S, pi, ctx);
-    if (!legal.some(o => sameAction(o, act))) illegal++;
-    return legal.some(o => sameAction(o, act)) ? act : (legal.find(o=>o.type==='pass') || legal.find(o=>o.type==='discard') || legal[0]);
-  };
-
-  let turn = 0, guard = 0;
-  const active = () => players.filter(p => !p.won).length;
-  while (S.wall.length > 0 && active() > 1 && guard++ < 400){
-    let pi = turn;
-    if (players[pi].won){ turn = (turn+1)%4; continue; }
-    const p = players[pi];
-    // draw
-    const drawn = S.wall.pop(); p.hand[drawn]++; p.drawn = drawn;
-    // turn decision loop (handle gangs)
-    let acted = false;
-    while (true){
-      const ctx = { type:'turn' };
-      let act = botDecide(S, pi, ctx, enumerateLegalActions(S, pi, ctx));
-      act = validate(pi, ctx, act);
-      if (act.type === 'hu'){ p.won = true; S.winners.push(pi); acted = true; break; }
-      if (act.type === 'angang'){ p.hand[act.kind] -= 4; p.melds.push({type:'angang',kind:act.kind});
-        if (S.wall.length === 0) { acted = true; break; } const r = S.wall.pop(); p.hand[r]++; p.drawn = r; continue; }
-      if (act.type === 'bugang'){ const m = p.melds.find(x => x.type==='peng' && x.kind===act.kind); m.type='bugang'; p.hand[act.kind]--;
-        if (S.wall.length === 0) { acted = true; break; } const r = S.wall.pop(); p.hand[r]++; p.drawn = r; continue; }
-      // discard
-      p.hand[act.kind]--; p.discards.push(act.kind); p.drawn = null;
-      S.lastDiscard = { by:pi, kind:act.kind };
-      // claim window
-      let claimed = -1;
-      // hu
-      for (let s = 1; s <= 3; s++){
-        const qi = (pi+s)%4; const q = players[qi]; if (q.won) continue;
-        const cctx = { type:'claim', discarder:pi, kind:act.kind };
-        const opts = enumerateLegalActions(S, qi, cctx);
-        if (!opts.some(o => o.type==='hu')) continue;
-        let ca = validate(qi, cctx, botDecide(S, qi, cctx, opts));
-        if (ca.type === 'hu'){ q.won = true; S.winners.push(qi); }
-      }
-      if (active() <= 1) { acted = true; break; }
-      // peng/gang
-      for (let s = 1; s <= 3; s++){
-        const qi = (pi+s)%4; const q = players[qi]; if (q.won) continue;
-        const cctx = { type:'claim', discarder:pi, kind:act.kind };
-        const opts = enumerateLegalActions(S, qi, cctx);
-        if (!opts.some(o => o.type==='peng' || o.type==='minggang')) continue;
-        let ca = validate(qi, cctx, botDecide(S, qi, cctx, opts));
-        if (ca.type === 'peng'){ q.hand[act.kind]-=2; q.melds.push({type:'peng',kind:act.kind});
-          // q now discards
-          claimed = qi; break; }
-        if (ca.type === 'minggang'){ q.hand[act.kind]-=3; q.melds.push({type:'minggang',kind:act.kind});
-          if (S.wall.length>0){ const r = S.wall.pop(); q.hand[r]++; q.drawn=r; } claimed = qi; break; }
-        if (ca.type === 'pass') break;
-      }
-      if (claimed >= 0){
-        const q = players[claimed];
-        // q makes a discard (validate)
-        const dctx = { type:'turn' };
-        const dopts = enumerateLegalActions(S, claimed, dctx).filter(o => o.type==='discard');
-        if (dopts.length){
-          let da = validate(claimed, dctx, { type:'discard', kind: chooseDiscard(S, claimed, dopts.map(o=>o.kind)) });
-          q.hand[da.kind]--; q.discards.push(da.kind); q.drawn = null;
-        }
-        turn = claimed; acted = true; break;
-      }
-      acted = true; break;
-    }
-    if (active() <= 1) break;
-    // advance turn if not claimed
-    if (turn === pi) turn = (turn+1)%4;
-    else { /* turn already set to claimer */ }
-  }
-  return illegal;
-}
-
-// Spec-named Rules Engine surface (the only interface the bot is allowed to use).
-const RulesEngine = {
-  enumerate_legal_actions: (state, player, ctx) => enumerateLegalActions(state, player, ctx),
-  evaluate_hand:           (state, player)      => evaluateHand(state, player),
-  simulate:                (state, player, action) => simulate(state, player, action),
-  score:                   (state, winner, info) => score(state, winner, info),
-};
-
-// expose for headless / console
-window.RulesEngine = RulesEngine;
-window.runTests = runTests;
-window.__mahjong = { enumerateLegalActions, winsNow, canHu, score, shanten, newDeck };
-if (location.search.includes('test')){
-  window.addEventListener('load', () => {
-    const r = runTests();
-    document.body.innerHTML = `<div style="padding:24px;font-family:monospace;white-space:pre-wrap;color:#fff">${escapeHtml(r.summary + '\n\n' + r.log.join('\n'))}</div>`;
-    document.title = (r.fail === 0 ? 'PASS ' : 'FAIL ') + r.summary;
-  });
-}
+window.__mahjongClient = { onUpdate, render, get conn() { return conn; }, set conn(c) { conn = c; }, set online(v) { online = v; }, viewFor, createGame, makeConfig };
 </script>
 </body>
 </html>

--- a/apps/mahjong/index.html
+++ b/apps/mahjong/index.html
@@ -1287,7 +1287,17 @@ function discardPreference(player, t) {
 function botChooseDiscard(state, seat, candidates, difficulty) {
   const p = state.players[seat];
   const miss = candidates.filter((t) => tileSuit(t) === p.missingSuit);
-  if (miss.length) candidates = miss;                       // forced clear first
+  if (miss.length) {
+    // forced clear: these tiles are all leaving regardless, and their within-suit
+    // connectivity (which shanten zeroes out anyway) is a meaningless tiebreaker.
+    // Hard bots dump the safest one; others just take the lowest deterministically.
+    if (difficulty === 'hard') {
+      let best = miss[0], bd = Infinity;
+      for (const t of miss) { const d = tileDanger(state, seat, t); if (d < bd) { bd = d; best = t; } }
+      return best;
+    }
+    return miss[0];
+  }
   if (difficulty === 'easy' && rngNext(state) < 0.35) return candidates[rngInt(state, candidates.length)];
   const danger = difficulty === 'hard' ? opponentDanger(state, seat) : 0;   // constant across candidates — hoisted
   let best = candidates[0], bestScore = -Infinity;

--- a/apps/mahjong/index.html
+++ b/apps/mahjong/index.html
@@ -1582,12 +1582,14 @@ function showResults(view) {
   const title = res.reason === 'exhaustion'
     ? (res.winners.length ? '血战结束 Hand Over' : '荒庄 Draw')
     : (view.mode === 'single' ? '胡牌 Winner!' : '血战结束 Hand Over');
+  const canDeal = !online || (conn && conn.host);
+  const againLabel = online ? 'Next Hand' : 'New Hand';
   overlay.style.display = 'flex';
   overlay.innerHTML = `<div class="modal"><h2>${title}</h2>
     <table class="scoreboard"><tr><th>Player</th><th>Hand</th><th class="pos">Score</th></tr>${rows}</table>
-    ${online ? `<button class="btn" id="again">Back to Lobby</button>` : `<button class="btn" id="again">New Hand</button>`}
-    <button class="btn alt" id="tomenu">Main Menu</button></div>`;
-  $('again').addEventListener('click', () => { overlay.style.display = 'none'; overlay.innerHTML = ''; if (conn && conn.again) conn.again(); });
+    ${canDeal ? `<button class="btn" id="again">${againLabel}</button>` : `<p style="text-align:center;opacity:.75;font-size:13px">Waiting for the host to deal the next hand…</p>`}
+    <button class="btn alt" id="tomenu">${online ? 'Leave Game' : 'Main Menu'}</button></div>`;
+  if ($('again')) $('again').addEventListener('click', () => { overlay.style.display = 'none'; overlay.innerHTML = ''; if (conn && conn.again) conn.again(); });
   $('tomenu').addEventListener('click', () => { overlay.style.display = 'none'; overlay.innerHTML = ''; leaveGame(); });
 }
 
@@ -1754,8 +1756,129 @@ function wireSetup() {
   buildNameInputs();
 }
 
-/* online entry point — implemented in the Online phase (net.js section below) */
-function startOnline(/* mode */) { $('online-msg').textContent = 'Online play is loading…'; if (window.__startOnline) window.__startOnline(); }
+/* =====================================================================
+ * ONLINE CONNECTION — same submit/view contract over a WebSocket to the
+ * server-authoritative MahjongRoom Durable Object.
+ * ===================================================================== */
+const NET_HTTP = (location.hostname === 'localhost' || location.hostname === '127.0.0.1')
+  ? `http://${location.hostname}:8787` : 'https://cloudflare-backend.maattp.workers.dev';
+const NET_WS = NET_HTTP.replace(/^http/, 'ws');
+const NET_VER = 'mj.v1';   // bump on any protocol change so mismatched builds can't pair
+
+class OnlineConnection {
+  constructor(opts) {
+    this.name = opts.name; this.difficulty = opts.difficulty;
+    this.code = opts.code || null; this.create = !!opts.create;
+    this.ws = null; this.seat = -1; this.host = false;
+    this.awaiting = false; this.alive = true; this.retries = 0; this.inGame = false; this.lobby = null;
+  }
+  async begin() {
+    if (this.create) {
+      onlineMsg('Creating game…');
+      try {
+        const r = await fetch(NET_HTTP + '/mahjong/rooms', { method: 'POST' });
+        const j = await r.json(); if (!j.code) throw new Error('no code');
+        this.code = j.code;
+      } catch (e) { onlineMsg('Could not reach the server. Try again.', true); return; }
+    }
+    this.connect();
+  }
+  connect() {
+    updateConnPill({ text: 'Connecting…', state: '' });
+    let ws; try { ws = new WebSocket(NET_WS + '/mahjong/rooms/' + this.code + '/ws'); } catch (e) { onlineMsg('Bad room code.', true); return; }
+    this.ws = ws;
+    ws.onopen = () => { this.retries = 0; updateConnPill({ text: 'Online', state: 'ok' }); this.rawsend({ t: 'hello', name: this.name, ver: NET_VER });
+      this.ping = setInterval(() => this.rawsend({ t: 'pp', ts: Date.now() }), 20000); };
+    ws.onmessage = (e) => { let m; try { m = JSON.parse(e.data); } catch { return; } this.handle(m); };
+    ws.onclose = () => { clearInterval(this.ping); this.onClose(); };
+    ws.onerror = () => {};
+  }
+  rawsend(o) { try { this.ws.send(JSON.stringify(o)); } catch {} }
+  handle(m) {
+    switch (m.t) {
+      case 'welcome': this.seat = m.id; this.host = m.host; this.code = m.code; if (m.rejoin) toast('Reconnected', 900); break;
+      case 'lobby': this.lobby = m; if (!this.inGame) showOnlineLobby(this, m); break;
+      case 'view':
+        if (!this.inGame) { this.inGame = true; overlay.style.display = 'none'; overlay.innerHTML = ''; showGameScreen(); }
+        if (m.view.phase !== 'HAND_ENDED' && overlay.style.display === 'flex' && overlay.querySelector('.scoreboard')) { overlay.style.display = 'none'; overlay.innerHTML = ''; }
+        this.awaiting = false;
+        onUpdate(m.view, { conn: { text: 'Online', state: 'ok' } });
+        break;
+      case 'reject': this.awaiting = false; toast(m.error && m.error.message ? m.error.message : 'Invalid move', 1500); render(); break;
+      case 'error': onlineMsg(m.msg || 'Server error', true); updateConnPill({ text: 'Error', state: 'bad' }); this.alive = false; break;
+      case 'you-are-host': this.host = true; if (this.lobby && !this.inGame) showOnlineLobby(this, this.lobby); break;
+    }
+  }
+  onClose() {
+    if (!this.alive) return;
+    updateConnPill({ text: 'Reconnecting…', state: 'bad' });
+    if (this.retries < 6) { this.retries++; setTimeout(() => { if (this.alive) this.connect(); }, 700 * this.retries); }
+    else { updateConnPill({ text: 'Disconnected', state: 'bad' }); toast('Connection lost', 1600); }
+  }
+  setReady(r) { this.rawsend({ t: 'ready', ready: r }); }
+  setConfig(c) { this.rawsend({ t: 'config', ...c }); }
+  startGame() { this.rawsend({ t: 'start' }); }
+  again() { if (this.host) this.rawsend({ t: 'rematch' }); }
+  submit(action) { if (this.awaiting) return; this.awaiting = true; this.rawsend({ t: 'action', action }); }
+  dispose() { this.alive = false; clearInterval(this.ping); try { this.ws.close(); } catch {} }
+}
+function onlineMsg(s, err) { const el = $('online-msg'); el.textContent = s; el.className = 'hostmsg' + (err ? ' err' : ''); }
+
+/* ---- online lobby (rendered into the overlay until the host deals) ---- */
+function showOnlineLobby(conn, lobby) {
+  const me = lobby.players.find((p) => p.id === conn.seat);
+  const seatRows = [];
+  for (let i = 0; i < lobby.maxPlayers; i++) {
+    const p = lobby.players.find((x) => x.id === i);
+    if (p) {
+      const badges = `${p.host ? '<span class="badge host">host</span>' : ''}${p.ready ? '<span class="badge ready">ready</span>' : '<span class="badge">…</span>'}`;
+      seatRows.push(`<div class="seat-card ${p.id === conn.seat ? 'me' : ''}"><span style="width:9px;height:9px;border-radius:50%;background:#30d158;display:inline-block"></span>
+        <span>${escapeHtml(p.name)}${p.id === conn.seat ? ' (you)' : ''}</span>${badges}</div>`);
+    } else {
+      seatRows.push(`<div class="seat-card" style="opacity:.6"><span style="width:9px;height:9px;border-radius:50%;background:#5ac8fa;display:inline-block"></span><span>Bot</span><span class="badge">fills at start</span></div>`);
+    }
+  }
+  const cfg = lobby.cfg || { mode: 'bloody', sevenPairs: true, difficulty: 'normal' };
+  const hostControls = conn.host ? `
+    <div class="card" style="margin-top:8px;background:rgba(0,0,0,.2)">
+      <h2>Table rules</h2>
+      <div class="seg" id="lb-mode"><button data-m="bloody" class="${cfg.mode === 'bloody' ? 'on' : ''}">Bloody</button><button data-m="single" class="${cfg.mode === 'single' ? 'on' : ''}">Single</button></div>
+      <div class="seg" id="lb-diff" style="margin-top:8px"><button data-d="easy" class="${cfg.difficulty === 'easy' ? 'on' : ''}">Easy</button><button data-d="normal" class="${cfg.difficulty === 'normal' ? 'on' : ''}">Normal</button><button data-d="hard" class="${cfg.difficulty === 'hard' ? 'on' : ''}">Hard</button></div>
+      <div class="toggle-row"><span>Seven Pairs</span><div class="switch ${cfg.sevenPairs ? 'on' : ''}" id="lb-sp"></div></div>
+    </div>` : `<p style="text-align:center;opacity:.7;font-size:13px">Bot difficulty &amp; rules: <b>${cfg.difficulty}</b>, ${cfg.mode}${cfg.sevenPairs ? ', 7-pairs' : ''}</p>`;
+
+  overlay.style.display = 'flex';
+  overlay.innerHTML = `<div class="modal lobby">
+    <h2>Online Game</h2>
+    <div class="code">${escapeHtml(lobby.code)}</div>
+    <p style="text-align:center">Share this code. ${lobby.players.length}/${lobby.maxPlayers} seats taken — empty seats become bots.</p>
+    <div class="seat-list">${seatRows.join('')}</div>
+    ${hostControls}
+    <button class="btn ${me && me.ready ? 'alt' : ''}" id="lb-ready">${me && me.ready ? 'Ready ✓ (tap to unready)' : "I'm ready"}</button>
+    ${conn.host ? `<button class="btn" id="lb-start">Deal &amp; Start</button>` : `<p style="text-align:center;opacity:.7;font-size:13px;margin-top:8px">Waiting for the host to start…</p>`}
+    <button class="btn alt" id="lb-leave">Leave</button>
+  </div>`;
+
+  $('lb-ready').onclick = () => conn.setReady(!(me && me.ready));
+  $('lb-leave').onclick = () => leaveGame();
+  if (conn.host) {
+    $('lb-start').onclick = () => conn.startGame();
+    $('lb-mode').onclick = (e) => { const b = e.target.closest('button'); if (b) conn.setConfig({ mode: b.dataset.m, sevenPairs: cfg.sevenPairs, difficulty: cfg.difficulty }); };
+    $('lb-diff').onclick = (e) => { const b = e.target.closest('button'); if (b) conn.setConfig({ mode: cfg.mode, sevenPairs: cfg.sevenPairs, difficulty: b.dataset.d }); };
+    $('lb-sp').onclick = () => conn.setConfig({ mode: cfg.mode, sevenPairs: !cfg.sevenPairs, difficulty: cfg.difficulty });
+  }
+}
+
+function startOnline(mode) {
+  const name = (onlineCfg.name || '').trim() || 'Player';
+  if (mode === 'join') {
+    const code = ($('join-code').value || '').trim().toUpperCase();
+    if (!/^[A-Z2-9]{5}$/.test(code)) { onlineMsg('Enter a valid 5-character room code.', true); return; }
+    online = true; conn = new OnlineConnection({ name, difficulty: onlineCfg.diff, code, create: false }); conn.begin();
+  } else {
+    online = true; conn = new OnlineConnection({ name, difficulty: onlineCfg.diff, create: true }); conn.begin();
+  }
+}
 
 wireSetup();
 window.__mahjongClient = { onUpdate, render, get conn() { return conn; }, set conn(c) { conn = c; }, set online(v) { online = v; }, viewFor, createGame, makeConfig };

--- a/apps/mahjong/index.html
+++ b/apps/mahjong/index.html
@@ -672,6 +672,8 @@ function invalid(code, message, details, suggested) {
   return { ok: false, error: { code, message, details: details || '', suggestedActions: suggested || [] } };
 }
 function applyAction(state, seat, action) {
+  // reject malformed input cleanly (untrusted over the wire) — never throw
+  if (!action || typeof action.type !== 'string') return invalid('BAD_ACTION', 'Malformed action.');
   const legal = getLegalActions(state, seat);
   if (!legal.some((o) => actionsEqual(o, action))) {
     return invalid(...explainIllegal(state, seat, action));

--- a/apps/mahjong/index.html
+++ b/apps/mahjong/index.html
@@ -310,7 +310,6 @@ const NUM_TYPES = 27;
 
 const emptyCounts = () => new Array(NUM_TYPES).fill(0);
 const countTotal = (c) => { let s = 0; for (let i = 0; i < NUM_TYPES; i++) s += c[i]; return s; };
-const countsToList = (c) => { const a = []; for (let t = 0; t < NUM_TYPES; t++) for (let i = 0; i < c[t]; i++) a.push(t); return a; };
 
 /* ---- deterministic RNG (mulberry32). state.rng is a serializable integer ---- */
 function rngNext(state) {
@@ -1280,6 +1279,7 @@ function botChooseDiscard(state, seat, candidates, difficulty) {
   const miss = candidates.filter((t) => tileSuit(t) === p.missingSuit);
   if (miss.length) candidates = miss;                       // forced clear first
   if (difficulty === 'easy' && rngNext(state) < 0.35) return candidates[rngInt(state, candidates.length)];
+  const danger = difficulty === 'hard' ? opponentDanger(state, seat) : 0;   // constant across candidates — hoisted
   let best = candidates[0], bestScore = -Infinity;
   for (const t of candidates) {
     p.concealed[t]--;
@@ -1287,7 +1287,7 @@ function botChooseDiscard(state, seat, candidates, difficulty) {
     const accept = (difficulty !== 'easy') ? ukeireOf(state, p) : 0;
     p.concealed[t]++;
     let sc = -sh * 1000 + accept * 4 + discardPreference(p, t);
-    if (difficulty === 'hard') sc -= tileDanger(state, seat, t) * 60 * opponentDanger(state, seat);
+    if (difficulty === 'hard') sc -= tileDanger(state, seat, t) * 60 * danger;
     if (sc > bestScore) { bestScore = sc; best = t; }
   }
   return best;
@@ -1360,22 +1360,26 @@ function botChooseMeld(state, seat, pung, kong, difficulty) {
   if (tileSuit(tile) === p.missingSuit) return null;
   if (difficulty === 'easy') { if (rngNext(state) < 0.45) return null; return pung || kong; }
   const before = shantenOf(p);
-  const snap = p.concealed.slice(), msnap = p.melds.map((m) => ({ ...m }));
-  if (kong && !pung) { p.concealed[tile] -= 3; p.melds.push({ type: PUNG, tile }); }
-  else { p.concealed[tile] -= 2; p.melds.push({ type: PUNG, tile }); }
-  const after = shantenOf(p);
-  const ready = isReady(p, state.config);
-  p.concealed = snap; p.melds = msnap;
-  if (kong && !pung) {
-    if (after < before || ready) return kong;
-    return difficulty === 'hard' ? (after <= before ? kong : null) : (after < before ? kong : null);
+  // simulate removing `remove` copies into a meld; return resulting shanten + tenpai
+  const evalClaim = (remove) => {
+    const snap = p.concealed.slice(), msnap = p.melds.map((m) => ({ ...m }));
+    p.concealed[tile] -= remove; p.melds.push({ type: PUNG, tile });
+    const after = shantenOf(p), ready = isReady(p, state.config);
+    p.concealed = snap; p.melds = msnap;
+    return { after, ready };
+  };
+  // primary claim decision uses the pung (keeps a spare); fall back to kong if no pung
+  const primary = pung ? evalClaim(2) : evalClaim(3);
+  const claimGood = primary.after < before || primary.ready;
+  if (!claimGood) {
+    if (difficulty === 'hard') return null;
+    return primary.after <= before && rngNext(state) < 0.25 ? (pung || kong) : null;
   }
-  if (after < before || ready) {
-    if (difficulty === 'hard' && after >= before && opponentDanger(state, seat) > 0.6) return null;
-    return pung;
-  }
-  if (difficulty === 'hard') return null;
-  return after <= before && rngNext(state) < 0.25 ? pung : null;
+  if (difficulty === 'hard' && primary.after >= before && opponentDanger(state, seat) > 0.6) return null;
+  // both offered (3 in hand): take the kong for its replacement draw when the spare
+  // tile the pung would keep isn't improving the hand anyway.
+  if (pung && kong && evalClaim(3).after <= primary.after) return kong;
+  return pung || kong;
 }
 
 // ==CORE-END==
@@ -1500,7 +1504,7 @@ function renderHandArea(view) {
     html += `<div class="ready-banner">🀄 Ready — win on ${me.ready.map((t) => tileRank(t) + SUIT_GLYPH[tileSuit(t)]).join(' ')}</div>`;
   } else html += `<div class="ready-banner"></div>`;
   html += '<div class="hand-row">';
-  const tileCls = (t) => `${SUIT_CSS[tileSuit(t)]} ${canDiscard ? (discardable.has(t) ? 'playable' : 'dim') : ''}`;
+  const tileCls = (t) => `${SUIT_CSS[tileSuit(t)]} ${canDiscard ? (discardable.has(t) ? 'playable' : 'dim') : ''} ${readySet.has(t) ? 'win-hint' : ''}`;
   for (const t of tiles) html += `<div class="tile ${tileCls(t)}" data-k="${t}"><span class="num">${tileRank(t)}</span><span class="glyph">${SUIT_GLYPH[tileSuit(t)]}</span></div>`;
   if (drawn != null) html += `<div class="tile ${tileCls(drawn)} drawn" data-k="${drawn}"><span class="num">${tileRank(drawn)}</span><span class="glyph">${SUIT_GLYPH[tileSuit(drawn)]}</span></div>`;
   html += '</div><div class="actions" id="actions"></div>';
@@ -1796,6 +1800,9 @@ const NET_HTTP = (location.hostname === 'localhost' || location.hostname === '12
   ? `http://${location.hostname}:8787` : 'https://cloudflare-backend.maattp.workers.dev';
 const NET_WS = NET_HTTP.replace(/^http/, 'ws');
 const NET_VER = 'mj.v1';   // bump on any protocol change so mismatched builds can't pair
+// per-room reconnect token, persisted so an app restart can still reclaim the seat
+const rtGet = (code) => { try { return code ? localStorage.getItem('mjrt:' + code) : null; } catch { return null; } };
+const rtSet = (code, t) => { try { if (code && t) localStorage.setItem('mjrt:' + code, t); } catch {} };
 
 class OnlineConnection {
   constructor(opts) {
@@ -1819,7 +1826,9 @@ class OnlineConnection {
     updateConnPill({ text: 'Connecting…', state: '' });
     let ws; try { ws = new WebSocket(NET_WS + '/mahjong/rooms/' + this.code + '/ws'); } catch (e) { onlineMsg('Bad room code.', true); return; }
     this.ws = ws;
-    ws.onopen = () => { this.retries = 0; updateConnPill({ text: 'Online', state: 'ok' }); this.rawsend({ t: 'hello', name: this.name, ver: NET_VER });
+    ws.onopen = () => { this.retries = 0; updateConnPill({ text: 'Online', state: 'ok' });
+      const token = this.reconnectToken || rtGet(this.code);   // resend our seat token to reclaim it
+      this.rawsend({ t: 'hello', name: this.name, ver: NET_VER, token });
       this.ping = setInterval(() => this.rawsend({ t: 'pp', ts: Date.now() }), 20000); };
     ws.onmessage = (e) => { let m; try { m = JSON.parse(e.data); } catch { return; } this.handle(m); };
     ws.onclose = () => { clearInterval(this.ping); this.onClose(); };
@@ -1828,7 +1837,9 @@ class OnlineConnection {
   rawsend(o) { try { this.ws.send(JSON.stringify(o)); } catch {} }
   handle(m) {
     switch (m.t) {
-      case 'welcome': this.seat = m.id; this.host = m.host; this.code = m.code; if (m.rejoin) toast('Reconnected', 900); break;
+      case 'welcome': this.seat = m.id; this.host = m.host; this.code = m.code;
+        if (m.reconnect) { this.reconnectToken = m.reconnect; rtSet(this.code, m.reconnect); }
+        if (m.rejoin) toast('Reconnected', 900); break;
       case 'lobby': this.lobby = m; if (!this.inGame) showOnlineLobby(this, m); break;
       case 'view':
         if (!this.inGame) { this.inGame = true; overlay.style.display = 'none'; overlay.innerHTML = ''; showGameScreen(); }

--- a/apps/mahjong/index.html
+++ b/apps/mahjong/index.html
@@ -1,0 +1,1730 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="theme-color" content="#0b3d2e">
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+<link rel="apple-touch-icon" href="../icon.png">
+<title>Sichuan Mahjong</title>
+<style>
+:root{
+  --felt:#0b6b43;
+  --felt-dark:#084f31;
+  --gold:#f4d58d;
+  --tile-bg:#fbf7ec;
+  --tile-edge:#d8cfb8;
+  --man:#b23b3b;
+  --sou:#1f8a4c;
+  --pin:#2b6fb5;
+  --ink:#222;
+}
+*{margin:0;padding:0;box-sizing:border-box;-webkit-tap-highlight-color:transparent;}
+html,body{height:100%;}
+body{
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  background:radial-gradient(circle at 50% 30%,#0e7a4c,#063d26 75%);
+  color:#fff;
+  overflow:hidden;
+  -webkit-user-select:none;user-select:none;
+  padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+button{font-family:inherit;cursor:pointer;border:none;}
+
+/* ============ SETUP ============ */
+#setup{
+  position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;
+  overflow-y:auto;-webkit-overflow-scrolling:touch;
+  padding:calc(env(safe-area-inset-top) + 26px) 20px calc(env(safe-area-inset-bottom) + 26px);
+}
+.brand{text-align:center;margin-bottom:6px;}
+.brand .cn{font-size:clamp(34px,11vw,52px);font-weight:800;letter-spacing:6px;color:var(--gold);text-shadow:0 3px 10px rgba(0,0,0,.5);}
+.brand .en{font-size:13px;letter-spacing:3px;text-transform:uppercase;opacity:.85;margin-top:2px;}
+.card{
+  background:rgba(0,0,0,.28);border:1px solid rgba(255,255,255,.12);border-radius:18px;
+  padding:18px 16px;width:100%;max-width:460px;margin-top:16px;backdrop-filter:blur(6px);
+}
+.card h2{font-size:14px;text-transform:uppercase;letter-spacing:2px;opacity:.8;margin-bottom:12px;font-weight:700;}
+.seg{display:flex;gap:8px;flex-wrap:wrap;}
+.seg button{
+  flex:1;min-width:64px;padding:12px 8px;border-radius:12px;background:rgba(255,255,255,.08);
+  color:#fff;font-size:15px;font-weight:600;border:1.5px solid transparent;transition:.15s;
+}
+.seg button.on{background:var(--gold);color:#1a1a1a;border-color:#fff;}
+.seg button .sub{display:block;font-size:10px;opacity:.7;font-weight:500;margin-top:2px;}
+.seg button.on .sub{opacity:.7;}
+.names{display:flex;flex-direction:column;gap:8px;margin-top:12px;}
+.names input{
+  background:rgba(255,255,255,.1);border:1px solid rgba(255,255,255,.2);border-radius:10px;
+  padding:10px 12px;color:#fff;font-size:15px;
+}
+.names input::placeholder{color:rgba(255,255,255,.5);}
+.start-btn{
+  margin-top:20px;width:100%;max-width:460px;padding:16px;border-radius:14px;
+  background:linear-gradient(135deg,#f4d58d,#e0a93f);color:#3a2600;font-size:18px;font-weight:800;
+  letter-spacing:1px;box-shadow:0 6px 18px rgba(0,0,0,.35);
+}
+.start-btn:active{transform:scale(.98);}
+.setup-foot{margin-top:14px;display:flex;gap:14px;font-size:13px;opacity:.8;}
+.setup-foot a,.setup-foot button{color:var(--gold);background:none;text-decoration:underline;font-size:13px;}
+
+/* ============ GAME ============ */
+#game{position:absolute;inset:0;display:none;flex-direction:column;}
+.topbar{
+  display:flex;align-items:center;gap:10px;padding:6px 12px;
+  padding-top:calc(env(safe-area-inset-top) + 4px);
+  background:rgba(0,0,0,.25);font-size:13px;flex-shrink:0;
+}
+.topbar .title{font-weight:700;color:var(--gold);letter-spacing:1px;}
+.topbar .info{opacity:.85;}
+.topbar .spacer{flex:1;}
+.topbar button{background:rgba(255,255,255,.12);color:#fff;border-radius:8px;padding:6px 10px;font-size:13px;}
+
+.table{flex:1;position:relative;min-height:0;display:flex;flex-direction:column;padding:6px;gap:4px;}
+.seat{display:flex;flex-direction:column;align-items:center;gap:3px;}
+.seat-top{order:0;}
+.midrow{order:1;flex:1;display:flex;align-items:stretch;gap:4px;min-height:0;}
+.seat-left,.seat-right{justify-content:center;flex-shrink:0;width:74px;}
+.center{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;position:relative;min-width:0;}
+.seat-bottom{order:2;}
+
+.nameplate{
+  display:flex;align-items:center;gap:6px;font-size:12px;padding:3px 9px;border-radius:20px;
+  background:rgba(0,0,0,.3);border:1px solid rgba(255,255,255,.1);white-space:nowrap;
+}
+.nameplate.active{background:var(--gold);color:#1a1a1a;font-weight:700;box-shadow:0 0 12px rgba(244,213,141,.7);}
+.nameplate .dot{width:8px;height:8px;border-radius:50%;background:#888;}
+.nameplate.bot .dot{background:#5ac8fa;}
+.nameplate.human .dot{background:#30d158;}
+.nameplate .miss{font-weight:800;}
+.nameplate .sc{font-variant-numeric:tabular-nums;opacity:.9;}
+.nameplate .won{color:#ffd700;font-weight:800;}
+.thinking{font-size:11px;opacity:.7;font-style:italic;}
+
+/* tiles */
+.tile{
+  position:relative;background:linear-gradient(180deg,#fff,var(--tile-bg));
+  border:1px solid var(--tile-edge);border-bottom-width:3px;border-radius:6px;
+  display:flex;flex-direction:column;align-items:center;justify-content:center;
+  color:var(--ink);flex-shrink:0;box-shadow:0 1px 2px rgba(0,0,0,.25);overflow:hidden;
+}
+.tile .num{font-weight:800;line-height:1;}
+.tile .glyph{line-height:1;opacity:.95;}
+.tile.m .num,.tile.m .glyph{color:var(--man);}
+.tile.s .num,.tile.s .glyph{color:var(--sou);}
+.tile.p .num,.tile.p .glyph{color:var(--pin);}
+.tile.back{background:linear-gradient(135deg,#1f7a4d,#0c5635);border-color:#0a4329;}
+.tile.back::after{content:"";position:absolute;inset:3px;border:1px solid rgba(255,255,255,.25);border-radius:4px;}
+
+/* hand tiles (big, interactive) */
+.handarea{
+  flex-shrink:0;background:rgba(0,0,0,.32);border-top:1px solid rgba(255,255,255,.1);
+  padding:8px 8px calc(env(safe-area-inset-bottom) + 8px);
+}
+.hand-row{display:flex;justify-content:center;align-items:flex-end;gap:3px;flex-wrap:wrap;min-height:56px;}
+.hand-row .tile{
+  width:clamp(30px,8.4vw,46px);height:clamp(42px,11.6vw,64px);
+  transition:transform .12s;
+}
+.hand-row .tile .num{font-size:clamp(17px,4.6vw,24px);}
+.hand-row .tile .glyph{font-size:clamp(9px,2.4vw,13px);}
+.hand-row .tile.sel{transform:translateY(-12px);box-shadow:0 6px 14px rgba(0,0,0,.5);}
+.hand-row .tile.drawn{margin-left:12px;}
+.hand-row .tile.dim{opacity:.4;}
+.hand-row .tile.playable{cursor:pointer;}
+.hand-row .tile.playable:active{transform:translateY(-6px);}
+
+/* meld tiles (medium) */
+.melds{display:flex;gap:6px;flex-wrap:wrap;justify-content:center;}
+.meld{display:flex;gap:1px;}
+.meld .tile{width:20px;height:28px;border-bottom-width:2px;}
+.meld .tile .num{font-size:12px;}
+.meld .tile .glyph{font-size:7px;}
+.meld .tile.concealed{background:linear-gradient(135deg,#1f7a4d,#0c5635);}
+.meld .tile.concealed .num,.meld .tile.concealed .glyph{visibility:hidden;}
+
+/* opponent hand backs */
+.backs{display:flex;gap:1px;flex-wrap:wrap;justify-content:center;max-width:200px;}
+.backs .tile{width:13px;height:18px;border-bottom-width:2px;}
+.seat-left .backs,.seat-right .backs{max-width:20px;}
+.seat-left .backs .tile,.seat-right .backs .tile{width:18px;height:12px;}
+
+/* discard river */
+.river{display:flex;flex-wrap:wrap;gap:2px;justify-content:center;align-content:flex-start;}
+.river .tile{width:18px;height:25px;border-bottom-width:2px;}
+.river .tile .num{font-size:11px;}
+.river .tile .glyph{font-size:6px;}
+.river .tile.last{outline:2px solid var(--gold);outline-offset:1px;box-shadow:0 0 10px var(--gold);}
+.seat-top .river,.seat-bottom .river{max-width:min(94vw,620px);}
+.seat-left .river,.seat-right .river{max-width:72px;}
+
+.center .wall-info{font-size:12px;opacity:.7;margin-bottom:6px;text-align:center;}
+.center .last-played{display:flex;flex-direction:column;align-items:center;gap:4px;}
+.center .last-played .tile{width:34px;height:47px;}
+.center .last-played .tile .num{font-size:20px;}
+.center .last-played .tile .glyph{font-size:11px;}
+.center .last-played .lbl{font-size:10px;opacity:.7;}
+
+/* action buttons */
+.actions{display:flex;gap:8px;justify-content:center;flex-wrap:wrap;margin-top:8px;min-height:44px;}
+.actions button{
+  padding:11px 18px;border-radius:11px;font-size:16px;font-weight:800;letter-spacing:1px;
+  background:rgba(255,255,255,.14);color:#fff;border:1.5px solid rgba(255,255,255,.25);
+}
+.actions button:active{transform:scale(.96);}
+.actions .b-hu{background:linear-gradient(135deg,#ffcb52,#ff9d2e);color:#3a2600;border-color:#fff;}
+.actions .b-peng{background:linear-gradient(135deg,#5ac8fa,#2b6fb5);border-color:#fff;}
+.actions .b-gang{background:linear-gradient(135deg,#bd6cff,#7a3fd6);border-color:#fff;}
+.actions .b-pass{background:rgba(255,255,255,.1);}
+.actions .hint{align-self:center;font-size:13px;opacity:.8;font-weight:500;letter-spacing:0;}
+
+/* ding que */
+.dingque{display:flex;flex-direction:column;align-items:center;gap:14px;}
+.dingque .q{font-size:16px;text-align:center;}
+.dingque .opts{display:flex;gap:12px;}
+.dingque .opts button{
+  display:flex;flex-direction:column;align-items:center;gap:4px;padding:16px 18px;border-radius:14px;
+  background:rgba(255,255,255,.12);color:#fff;border:2px solid rgba(255,255,255,.2);min-width:84px;
+}
+.dingque .opts button .big{font-size:30px;font-weight:800;}
+.dingque .opts button .ct{font-size:12px;opacity:.85;}
+.dingque .opts button.rec{border-color:var(--gold);}
+.dingque .opts button.rec .tag{font-size:9px;color:var(--gold);}
+
+/* overlay (reveal gate, toasts, results) */
+#overlay{position:absolute;inset:0;display:none;align-items:center;justify-content:center;z-index:40;
+  background:rgba(0,0,0,.6);backdrop-filter:blur(4px);padding:24px;}
+.modal{background:#0d4d33;border:1px solid rgba(255,255,255,.18);border-radius:18px;padding:22px;
+  max-width:480px;width:100%;max-height:88vh;overflow-y:auto;box-shadow:0 12px 40px rgba(0,0,0,.5);}
+.modal h2{color:var(--gold);font-size:22px;margin-bottom:10px;text-align:center;}
+.modal p{font-size:14px;line-height:1.5;opacity:.92;margin-bottom:8px;}
+.modal .btn{margin-top:16px;width:100%;padding:14px;border-radius:12px;background:var(--gold);color:#2a1c00;font-weight:800;font-size:16px;}
+.modal .btn.alt{background:rgba(255,255,255,.14);color:#fff;margin-top:8px;}
+.reveal-gate{text-align:center;cursor:pointer;}
+.reveal-gate .big{font-size:48px;}
+.reveal-gate h2{margin-top:8px;}
+.scoreboard{width:100%;border-collapse:collapse;margin-top:8px;font-size:14px;}
+.scoreboard td,.scoreboard th{padding:7px 8px;text-align:left;border-bottom:1px solid rgba(255,255,255,.1);}
+.scoreboard th{opacity:.6;font-size:11px;text-transform:uppercase;}
+.scoreboard .pos{text-align:right;font-variant-numeric:tabular-nums;font-weight:700;}
+.scoreboard .gain-pos{color:#5ad17a;}
+.scoreboard .gain-neg{color:#ff7b7b;}
+.fan-list{display:flex;flex-wrap:wrap;gap:6px;justify-content:center;margin:6px 0;}
+.fan-list span{background:rgba(244,213,141,.18);border:1px solid var(--gold);color:var(--gold);
+  padding:2px 9px;border-radius:14px;font-size:12px;font-weight:600;}
+
+.toast{position:absolute;top:18%;left:50%;transform:translateX(-50%);z-index:50;
+  background:rgba(0,0,0,.82);border:2px solid var(--gold);color:var(--gold);
+  padding:14px 28px;border-radius:14px;font-size:26px;font-weight:800;letter-spacing:3px;
+  pointer-events:none;opacity:0;transition:opacity .2s;white-space:nowrap;}
+.toast.show{opacity:1;}
+
+.rules-content h3{color:var(--gold);font-size:15px;margin:12px 0 4px;}
+.rules-content ul{margin-left:18px;font-size:13px;line-height:1.5;opacity:.92;}
+.rules-content{text-align:left;}
+#testout{font-family:ui-monospace,Menlo,monospace;font-size:11px;white-space:pre-wrap;text-align:left;
+  background:rgba(0,0,0,.4);padding:10px;border-radius:8px;max-height:50vh;overflow:auto;}
+</style>
+</head>
+<body>
+
+<!-- ============ SETUP SCREEN ============ -->
+<div id="setup">
+  <div class="brand">
+    <div class="cn">四川麻將</div>
+    <div class="en">Sichuan Mahjong &middot; Bloody Rules</div>
+  </div>
+
+  <div class="card">
+    <h2>Players</h2>
+    <div class="seg" id="humans-seg">
+      <button data-h="1" class="on">1<span class="sub">+3 bots</span></button>
+      <button data-h="2">2<span class="sub">+2 bots</span></button>
+      <button data-h="3">3<span class="sub">+1 bot</span></button>
+      <button data-h="4">4<span class="sub">all human</span></button>
+    </div>
+    <div class="names" id="name-inputs"></div>
+  </div>
+
+  <div class="card">
+    <h2>Bot Difficulty</h2>
+    <div class="seg" id="diff-seg">
+      <button data-d="easy">Easy<span class="sub">loose play</span></button>
+      <button data-d="normal" class="on">Normal<span class="sub">solid</span></button>
+      <button data-d="hard">Hard<span class="sub">defends &amp; counts</span></button>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Mode</h2>
+    <div class="seg" id="mode-seg">
+      <button data-m="bloody" class="on">Bloody<span class="sub">play to 3 winners</span></button>
+      <button data-m="single">Single<span class="sub">first win ends hand</span></button>
+    </div>
+  </div>
+
+  <button class="start-btn" id="start-btn">Deal Tiles</button>
+  <div class="setup-foot">
+    <button id="rules-link">How to play</button>
+    <a href="../">&larr; All apps</a>
+  </div>
+</div>
+
+<!-- ============ GAME SCREEN ============ -->
+<div id="game">
+  <div class="topbar">
+    <span class="title">四川麻將</span>
+    <span class="info" id="round-info"></span>
+    <span class="spacer"></span>
+    <button id="rules-btn">Rules</button>
+    <button id="menu-btn">Menu</button>
+  </div>
+  <div class="table">
+    <div class="seat seat-top" id="seat-2"></div>
+    <div class="midrow">
+      <div class="seat seat-left" id="seat-3"></div>
+      <div class="center" id="center"></div>
+      <div class="seat seat-right" id="seat-1"></div>
+    </div>
+    <div class="seat seat-bottom" id="seat-0"></div>
+  </div>
+  <div class="handarea" id="handarea"></div>
+</div>
+
+<div id="overlay"></div>
+<div class="toast" id="toast"></div>
+
+<script>
+"use strict";
+/* ===================================================================
+   SICHUAN MAHJONG  (血战到底)
+   --------------------------------------------------------------------
+   Architecture (per spec):
+
+      Rules Engine   -> pure, no DOM, no hidden info
+         enumerateLegalActions(state, player, ctx)
+         evaluateHand(state, player)
+         simulate(state, action)
+         score(state, winner, info)
+      Legal Actions  -> the ONLY thing a bot may pick from
+      Bot Decision   -> chooses among legal actions; validated again before use
+
+   No chi/chow (Sichuan).  Mandatory missing-suit (定缺).  Peng / 3 kinds of
+   Gang / Hu (zimo, dianpao, rob-the-kong).  Fan-based scoring + 刮风下雨 gang
+   payments.  Bloody mode continues until 3 players have won.
+   =================================================================== */
+
+/* -------- tile helpers (kind = suit*9 + rank-1, suit 0=萬 1=条 2=筒) -------- */
+const SUIT_GLYPH = ['萬','条','筒'];
+const SUIT_CLASS = ['m','s','p'];
+const SUIT_EN    = ['Characters','Bamboo','Dots'];
+const ksuit = k => (k / 9) | 0;
+const krank = k => (k % 9) + 1;
+const mk = (suit, rank) => suit * 9 + rank - 1;
+const emptyCounts = () => new Array(27).fill(0);
+const handSize = c => { let s = 0; for (let i = 0; i < 27; i++) s += c[i]; return s; };
+const kindsOf = c => { const a = []; for (let k = 0; k < 27; k++) if (c[k] > 0) a.push(k); return a; };
+function listOf(c){ const a=[]; for(let k=0;k<27;k++) for(let i=0;i<c[k];i++) a.push(k); return a; }
+
+/* =====================================================================
+   RULES ENGINE — winning-hand detection
+   ===================================================================== */
+function formMelds(c, sets){
+  let i = 0; while (i < 27 && c[i] === 0) i++;
+  if (i === 27) return sets === 0;
+  if (sets === 0) return false;
+  if (c[i] >= 3){ c[i]-=3; if (formMelds(c, sets-1)){ c[i]+=3; return true; } c[i]+=3; }
+  const r = i % 9;
+  if (r <= 6 && c[i+1] > 0 && c[i+2] > 0){
+    c[i]--; c[i+1]--; c[i+2]--;
+    if (formMelds(c, sets-1)){ c[i]++; c[i+1]++; c[i+2]++; return true; }
+    c[i]++; c[i+1]++; c[i+2]++;
+  }
+  return false;
+}
+function isStandardWin(c, sets){
+  for (let p = 0; p < 27; p++){
+    if (c[p] >= 2){ c[p]-=2; const ok = formMelds(c.slice(), sets); c[p]+=2; if (ok) return true; }
+  }
+  return false;
+}
+function isSevenPairs(c){
+  if (handSize(c) !== 14) return false;
+  for (let k = 0; k < 27; k++) if (c[k] % 2 !== 0) return false;
+  return true;
+}
+function onlyTriplets(c, sets){
+  let i = 0; while (i < 27 && c[i] === 0) i++;
+  if (i === 27) return sets === 0;
+  if (sets > 0 && c[i] >= 3){ c[i]-=3; if (onlyTriplets(c, sets-1)){ c[i]+=3; return true; } c[i]+=3; }
+  return false;
+}
+function isAllPungs(c, sets){
+  for (let p = 0; p < 27; p++){
+    if (c[p] >= 2){ const cc = c.slice(); cc[p]-=2; if (onlyTriplets(cc, sets)) return true; }
+  }
+  return false;
+}
+const missingCount = p => { if (p.missing == null) return 0; let s = 0; for (let r = 0; r < 9; r++) s += p.hand[p.missing*9+r]; return s; };
+
+/* Does the player's CURRENT concealed hand (already winning size) form a win? */
+function winsNow(p){
+  const c = p.hand;
+  if (missingCount(p) > 0) return false;                 // 缺一门 not satisfied
+  const sets = 4 - p.melds.length;
+  if (handSize(c) !== sets * 3 + 2) return false;
+  if (p.melds.length === 0 && isSevenPairs(c)) return true;
+  return isStandardWin(c.slice(), sets);
+}
+/* Could the player win by adding `kind`?  (kind must not be their missing suit) */
+function canHu(p, kind){
+  if (ksuit(kind) === p.missing) return false;
+  p.hand[kind]++; const r = winsNow(p); p.hand[kind]--; return r;
+}
+/* Tenpai = one tile away from a legal win (used for draw-game settlement & AI). */
+function isTenpai(p){
+  if (missingCount(p) > 0) return false;
+  for (let k = 0; k < 27; k++){
+    if (ksuit(k) === p.missing) continue;
+    if (p.hand[k] >= 4) continue;
+    p.hand[k]++; const w = winsNow(p); p.hand[k]--;
+    if (w) return true;
+  }
+  return false;
+}
+
+/* =====================================================================
+   RULES ENGINE — shanten (distance to tenpai) for the AI
+   ===================================================================== */
+function sevenPairsShanten(c){
+  let pairs = 0, kinds = 0;
+  for (let k = 0; k < 27; k++){ if (c[k] > 0) kinds++; if (c[k] >= 2) pairs++; }
+  let sh = 6 - pairs;
+  if (kinds < 7) sh += 7 - kinds;
+  return sh;
+}
+function stdShanten(c0, openMelds){
+  let best = 8;
+  const c = c0.slice();
+  function rec(i, melds, partials, pairUsed){
+    while (i < 27 && c[i] === 0) i++;
+    if (i === 27){
+      let m = melds + openMelds;
+      let part = partials;
+      if (m + part > 4) part = 4 - m;
+      let sh = (4 - m) * 2 - part - (pairUsed ? 1 : 0);
+      if (sh < best) best = sh;
+      return;
+    }
+    if (c[i] >= 3){ c[i]-=3; rec(i, melds+1, partials, pairUsed); c[i]+=3; }
+    if (i%9 <= 6 && c[i+1] > 0 && c[i+2] > 0){ c[i]--;c[i+1]--;c[i+2]--; rec(i,melds+1,partials,pairUsed); c[i]++;c[i+1]++;c[i+2]++; }
+    if (!pairUsed && c[i] >= 2){ c[i]-=2; rec(i, melds, partials, true); c[i]+=2; }
+    if (c[i] >= 2){ c[i]-=2; rec(i, melds, partials+1, pairUsed); c[i]+=2; }
+    if (i%9 <= 7 && c[i+1] > 0){ c[i]--;c[i+1]--; rec(i, melds, partials+1, pairUsed); c[i]++;c[i+1]++; }
+    if (i%9 <= 6 && c[i+2] > 0){ c[i]--;c[i+2]--; rec(i, melds, partials+1, pairUsed); c[i]++;c[i+2]++; }
+    c[i]--; rec(i, melds, partials, pairUsed); c[i]++;
+  }
+  rec(0, 0, 0, false);
+  return best;
+}
+function shanten(p){
+  // tiles of the missing suit are dead weight: a hand still holding them can never win.
+  const c = p.hand.slice();
+  if (p.missing != null) for (let r = 0; r < 9; r++) c[p.missing*9+r] = 0;
+  let st = stdShanten(c, p.melds.length);
+  if (p.melds.length === 0) st = Math.min(st, sevenPairsShanten(c));
+  return st;
+}
+/* evaluateHand — engine-exposed scalar quality measure (lower shanten = better). */
+function evaluateHand(state, pi){
+  const p = state.players[pi];
+  const sh = shanten(p);
+  return { shanten: sh, tenpai: sh <= 0, missingTiles: missingCount(p), ukeire: sh <= 1 ? ukeire(state, p) : 0 };
+}
+/* ukeire — count of live tiles that lower shanten (tile-acceptance). */
+function ukeire(state, p){
+  const base = shanten(p);
+  let total = 0;
+  for (let k = 0; k < 27; k++){
+    if (ksuit(k) === p.missing) continue;
+    if (p.hand[k] >= 4) continue;
+    const remain = remainingCount(state, k, p);
+    if (remain <= 0) continue;
+    p.hand[k]++; const sh = shanten(p); p.hand[k]--;
+    if (sh < base) total += remain;
+  }
+  return total;
+}
+/* How many copies of `kind` are not visible to player p (engine: uses only public info). */
+function remainingCount(state, kind, p){
+  let seen = p.hand[kind];
+  for (const m of p.melds) if (m.kind === kind) seen += (m.type === 'peng' ? 3 : 4);
+  for (const q of state.players){
+    for (const d of q.discards) if (d === kind) seen++;
+    for (const m of q.melds) if (m.kind === kind && q !== p) seen += (m.type === 'peng' ? 3 : 4);
+  }
+  return 4 - seen;
+}
+
+/* =====================================================================
+   RULES ENGINE — legal action enumeration
+   ctx: {type:'turn'} | {type:'claim', discarder, kind} | {type:'rob', ganger, kind}
+   ===================================================================== */
+function enumerateLegalActions(state, pi, ctx){
+  const p = state.players[pi];
+  if (p.won) return [{ type:'pass' }];
+  const acts = [];
+  const hasMissing = missingCount(p) > 0;
+
+  if (ctx.type === 'turn'){
+    if (!hasMissing && winsNow(p)) acts.push({ type:'hu', self:true });
+    if (!hasMissing){
+      for (let k = 0; k < 27; k++) if (p.hand[k] === 4 && ksuit(k) !== p.missing) acts.push({ type:'angang', kind:k });
+      for (const m of p.melds) if (m.type === 'peng' && p.hand[m.kind] > 0) acts.push({ type:'bugang', kind:m.kind });
+    }
+    // Missing-suit tiles MUST be played out first.
+    const discardable = hasMissing
+      ? kindsOf(p.hand).filter(k => ksuit(k) === p.missing)
+      : kindsOf(p.hand);
+    for (const k of discardable) acts.push({ type:'discard', kind:k });
+  }
+  else if (ctx.type === 'claim'){
+    const k = ctx.kind;
+    if (!hasMissing && canHu(p, k)) acts.push({ type:'hu', self:false, kind:k });
+    if (!hasMissing && ksuit(k) !== p.missing){
+      if (p.hand[k] >= 2) acts.push({ type:'peng', kind:k });
+      if (p.hand[k] >= 3) acts.push({ type:'minggang', kind:k });
+    }
+    acts.push({ type:'pass' });
+  }
+  else if (ctx.type === 'rob'){
+    const k = ctx.kind;
+    if (!hasMissing && canHu(p, k)) acts.push({ type:'hu', self:false, kind:k, rob:true });
+    acts.push({ type:'pass' });
+  }
+  return acts;
+}
+const sameAction = (a, b) =>
+  a && b && a.type === b.type && (a.kind ?? -1) === (b.kind ?? -1) && !!a.self === !!b.self;
+
+/* =====================================================================
+   RULES ENGINE — simulate (clone + apply, for AI lookahead)
+   ===================================================================== */
+function cloneState(state){
+  return {
+    mode: state.mode,
+    wall: state.wall.slice(),
+    players: state.players.map(p => ({
+      id:p.id, name:p.name, isBot:p.isBot, diff:p.diff,
+      hand:p.hand.slice(), melds:p.melds.map(m => ({...m})),
+      discards:p.discards.slice(), missing:p.missing, won:p.won, score:p.score,
+    })),
+    turn: state.turn,
+  };
+}
+/* Applies a discard or claim to a cloned state; returns the new state. (AI only.) */
+function simulate(state, pi, action){
+  const s = cloneState(state);
+  const p = s.players[pi];
+  if (action.type === 'discard'){ p.hand[action.kind]--; p.discards.push(action.kind); }
+  else if (action.type === 'peng'){ p.hand[action.kind]-=2; p.melds.push({ type:'peng', kind:action.kind }); }
+  else if (action.type === 'minggang'){ p.hand[action.kind]-=3; p.melds.push({ type:'minggang', kind:action.kind }); }
+  else if (action.type === 'angang'){ p.hand[action.kind]-=4; p.melds.push({ type:'angang', kind:action.kind }); }
+  else if (action.type === 'bugang'){ p.hand[action.kind]--; const m = p.melds.find(x => x.type==='peng' && x.kind===action.kind); if (m) m.type='bugang'; }
+  return s;
+}
+
+/* =====================================================================
+   RULES ENGINE — scoring (fan / 番)
+   ===================================================================== */
+function score(state, winnerIdx, info){
+  const p = state.players[winnerIdx];
+  const full = p.hand.slice();
+  if (!info.self && info.kind != null) full[info.kind]++;
+
+  let fan = 1; const names = ['平胡'];
+  const suits = new Set();
+  for (let k = 0; k < 27; k++) if (full[k] > 0) suits.add(ksuit(k));
+  for (const m of p.melds) suits.add(ksuit(m.kind));
+
+  const setsNeeded = 4 - p.melds.length;
+  const sevenP = p.melds.length === 0 && isSevenPairs(full);
+
+  if (sevenP){
+    fan += 2; names.push('七对');
+    for (let k = 0; k < 27; k++) if (full[k] === 4){ fan += 2; names.push('龙七对'); break; }
+  } else if (isAllPungs(full, setsNeeded)){
+    fan += 1; names.push('碰碰胡');
+  }
+  if (suits.size === 1){ fan += 2; names.push('清一色'); }
+  if (p.melds.length === 4 && handSize(p.hand) <= 2){ fan += 1; names.push('金钩钓'); }
+  if (info.self){ fan += 1; names.push('自摸'); }
+  if (info.gangFlower){ fan += 1; names.push('杠上花'); }
+  if (info.gangCannon){ fan += 1; names.push('杠上炮'); }
+  if (info.rob){ fan += 1; names.push('抢杠胡'); }
+  if (info.haidi){ fan += 1; names.push(info.self ? '海底捞月' : '海底炮'); }
+
+  // 根 — every set of four identical tiles (a kong, or 4 concealed) adds a fan.
+  let gen = 0;
+  for (const m of p.melds) if (m.type !== 'peng') gen++;
+  if (!sevenP) for (let k = 0; k < 27; k++) if (full[k] === 4) gen++;
+  if (gen > 0){ fan += gen; for (let i=0;i<gen;i++) names.push('根'); }
+
+  const CAP = 8;
+  if (fan > CAP) fan = CAP;
+  return { fan, names, base: Math.pow(2, fan - 1) }; // 平胡 = 1 point
+}
+
+/* =====================================================================
+   GAME CONTROLLER (drives turns, talks to UI & bots)
+   ===================================================================== */
+let state = null;
+let cfg = { humans:1, diff:'normal', mode:'bloody', names:[] };
+let lastShownHuman = -1;
+
+function newDeck(){
+  const deck = [];
+  for (let k = 0; k < 27; k++) for (let i = 0; i < 4; i++) deck.push(k);
+  for (let i = deck.length - 1; i > 0; i--){ const j = (Math.random()*(i+1))|0; [deck[i],deck[j]] = [deck[j],deck[i]]; }
+  return deck;
+}
+function startGame(){
+  const deck = newDeck();
+  const players = [];
+  for (let i = 0; i < 4; i++){
+    const isBot = i >= cfg.humans;
+    players.push({
+      id:i, name: isBot ? `Bot ${i}` : (cfg.names[i] || `Player ${i+1}`),
+      isBot, diff: cfg.diff,
+      hand: emptyCounts(), melds:[], discards:[], missing:null, won:false,
+      score:0, winInfo:null, justGanged:false, drewFromGang:false,
+    });
+  }
+  for (let n = 0; n < 13; n++) for (let i = 0; i < 4; i++) players[i].hand[deck.pop()]++;
+  state = {
+    mode: cfg.mode, wall: deck, players,
+    dealer: 0, turn: 0, phase:'dingque',
+    lastDiscard:null, winners:[], handNo:1, lastTile:null,
+  };
+  lastShownHuman = -1;
+  showGame();
+  runDingQue();
+}
+
+/* ---- 定缺 missing-suit selection ---- */
+function botPickMissing(p){
+  const cnt = [0,0,0];
+  for (let k = 0; k < 27; k++) cnt[ksuit(k)] += p.hand[k];
+  // weakest suit = fewest tiles, tie-break by least connectivity (sum of adjacency)
+  let best = 0, bestScore = Infinity;
+  for (let s = 0; s < 3; s++){
+    let conn = 0;
+    for (let r = 0; r < 9; r++){
+      const k = s*9+r; const v = p.hand[k];
+      if (v && r < 8) conn += Math.min(v, p.hand[k+1]);
+      if (v >= 2) conn += 1;
+    }
+    const sc = cnt[s]*10 + conn;
+    if (sc < bestScore){ bestScore = sc; best = s; }
+  }
+  return best;
+}
+async function runDingQue(){
+  for (let i = 0; i < 4; i++){
+    const p = state.players[i];
+    if (p.isBot){ p.missing = botPickMissing(p); }
+    else {
+      p.missing = await askMissingSuit(i);
+    }
+  }
+  state.phase = 'play';
+  render();
+  toast('开始 GO', 900);
+  setTimeout(gameLoop, 700);
+}
+
+/* ---- main turn loop ---- */
+function activeCount(){ return state.players.filter(p => !p.won).length; }
+function nextActive(from){
+  for (let s = 1; s <= 4; s++){ const i = (from + s) % 4; if (!state.players[i].won) return i; }
+  return -1;
+}
+function gameEnds(){
+  if (state.mode === 'single' && state.winners.length >= 1) return true;
+  if (activeCount() <= 1) return true;
+  return false;
+}
+
+async function gameLoop(){
+  while (state.phase === 'play'){
+    if (gameEnds()){ endHand('done'); return; }
+    const pi = state.turn;
+    if (state.players[pi].won){ state.turn = nextActive(pi); continue; }
+    if (state.wall.length === 0){ endHand('draw'); return; }
+    const cont = await takeTurn(pi);
+    if (!cont) return;           // hand ended inside the turn
+  }
+}
+
+/* one player's turn: draw, (gang loop), discard, claim window. returns true to continue loop */
+async function takeTurn(pi){
+  const p = state.players[pi];
+  let drewFromGang = false;
+
+  while (true){
+    // ---- draw ----
+    const isLast = state.wall.length === 1;
+    const drawn = state.wall.pop();
+    p.hand[drawn]++;
+    p.drawn = drawn;
+    p.drewFromGang = drewFromGang;
+    render();
+    if (!p.isBot) await sleep(180);
+
+    // ---- decisions: hu / gang / discard ----
+    const ctx = { type:'turn' };
+    const options = enumerateLegalActions(state, pi, ctx);
+    const action = await getAction(pi, ctx, options);
+
+    if (action.type === 'hu'){
+      p.drawn = null;
+      const info = { self:true, haidi:isLast, gangFlower:drewFromGang };
+      await declareWin(pi, info, null);
+      return state.phase === 'play';
+    }
+    if (action.type === 'angang' || action.type === 'bugang'){
+      const robbed = await doGang(pi, action, /*fromDiscard*/false);
+      if (robbed) return state.phase === 'play';   // someone robbed the kong -> hand may end
+      drewFromGang = true;
+      continue;                                    // draw replacement, loop again
+    }
+    // ---- discard ----
+    p.hand[action.kind]--;
+    p.discards.push(action.kind);
+    p.drawn = null;
+    p.justGanged = drewFromGang;            // for 杠上炮 attribution
+    state.lastDiscard = { by:pi, kind:action.kind };
+    state.lastTile = action.kind;
+    render();
+    break;
+  }
+
+  // ---- claim window on the discard ----
+  const result = await resolveClaims(pi);
+  if (state.phase !== 'play') return false;
+  if (result.type === 'win') return true;       // loop will re-evaluate / continue
+  if (result.type === 'claim'){
+    state.turn = result.player;                 // claimer already acted/discarded inside
+    return true;
+  }
+  state.turn = nextActive(pi);
+  return true;
+}
+
+/* Resolve hu / peng / gang claims after player `discarder` discards lastDiscard. */
+async function resolveClaims(discarder){
+  const kind = state.lastDiscard.kind;
+  const isLast = state.wall.length === 0;
+  const dp = state.players[discarder];
+
+  // --- collect hu (ron) claimants, in turn order after discarder ---
+  const huWinners = [];
+  for (let s = 1; s <= 3; s++){
+    const pi = (discarder + s) % 4;
+    const p = state.players[pi];
+    if (p.won) continue;
+    const opts = enumerateLegalActions(state, pi, { type:'claim', discarder, kind });
+    if (!opts.some(o => o.type === 'hu')) continue;
+    const act = await getAction(pi, { type:'claim', discarder, kind }, opts);
+    if (act.type === 'hu'){
+      huWinners.push(pi);
+      if (state.mode === 'single') break;
+    }
+  }
+  if (huWinners.length){
+    for (const wi of huWinners){
+      const info = { self:false, kind, discarder, haidi:isLast, gangCannon:dp.justGanged };
+      await declareWin(wi, info, discarder);
+      if (state.phase !== 'play') break;
+    }
+    return { type:'win' };
+  }
+
+  // --- peng / gang (at most one possible holder) ---
+  for (let s = 1; s <= 3; s++){
+    const pi = (discarder + s) % 4;
+    const p = state.players[pi];
+    if (p.won) continue;
+    const opts = enumerateLegalActions(state, pi, { type:'claim', discarder, kind });
+    const claimable = opts.filter(o => o.type === 'peng' || o.type === 'minggang');
+    if (!claimable.length) continue;
+    const act = await getAction(pi, { type:'claim', discarder, kind }, opts);
+    if (act.type === 'peng' || act.type === 'minggang'){
+      await doClaim(pi, act, discarder);
+      return { type:'claim', player: pi };
+    }
+    if (act.type === 'pass') break;   // only one player can hold peng/gang material
+  }
+  return { type:'pass' };
+}
+
+/* perform a peng or ming-gang from the discard, then that player discards. */
+async function doClaim(pi, act, discarder){
+  const p = state.players[pi];
+  const k = act.kind;
+  dp_removeDiscard(discarder);                 // claimed tile leaves the river
+  toast(act.type === 'peng' ? '碰 PENG' : '杠 GANG', 750);
+  if (act.type === 'peng'){
+    p.hand[k] -= 2;
+    p.melds.push({ type:'peng', kind:k, from:discarder });
+    render(); await sleep(p.isBot ? 350 : 120);
+    await forceDiscard(pi);
+  } else { // minggang from discard (直杠)
+    p.hand[k] -= 3;
+    p.melds.push({ type:'minggang', kind:k, from:discarder });
+    payGang(pi, 'minggang', discarder);
+    render();
+    await drawReplacementAndContinue(pi);
+  }
+}
+function dp_removeDiscard(discarder){
+  const dp = state.players[discarder];
+  dp.discards.pop();
+  state.lastDiscard = null;
+}
+
+/* After a gang the player draws a replacement and may gang/hu again, then discards. */
+async function drawReplacementAndContinue(pi){
+  // mimic takeTurn's draw+decision loop but starting already-melded
+  state.turn = pi;
+  const p = state.players[pi];
+  let drewFromGang = true;
+  while (true){
+    if (state.wall.length === 0){ endHand('draw'); return; }
+    const drawn = state.wall.pop();
+    p.hand[drawn]++; p.drawn = drawn; p.drewFromGang = true;
+    render();
+    const opts = enumerateLegalActions(state, pi, { type:'turn' });
+    const act = await getAction(pi, { type:'turn' }, opts);
+    if (act.type === 'hu'){
+      p.drawn = null;
+      await declareWin(pi, { self:true, gangFlower:true, haidi:state.wall.length===0 }, null);
+      return;
+    }
+    if (act.type === 'angang' || act.type === 'bugang'){
+      const robbed = await doGang(pi, act, false);
+      if (robbed) return;
+      continue;
+    }
+    p.hand[act.kind]--; p.discards.push(act.kind); p.drawn = null;
+    p.justGanged = true;
+    state.lastDiscard = { by:pi, kind:act.kind }; state.lastTile = act.kind;
+    render();
+    const result = await resolveClaims(pi);
+    if (state.phase !== 'play') return;
+    if (result.type === 'claim'){ state.turn = result.player; return; }
+    if (result.type === 'win'){ return; }
+    state.turn = nextActive(pi);
+    return;
+  }
+}
+
+/* perform an gang or bugang on the player's own turn. returns true if robbed (hand control changes). */
+async function doGang(pi, act, fromDiscard){
+  const p = state.players[pi];
+  const k = act.kind;
+  if (act.type === 'bugang'){
+    // rob-the-kong window first
+    for (let s = 1; s <= 3; s++){
+      const ri = (pi + s) % 4;
+      const rp = state.players[ri];
+      if (rp.won) continue;
+      const opts = enumerateLegalActions(state, ri, { type:'rob', ganger:pi, kind:k });
+      if (!opts.some(o => o.type === 'hu')) continue;
+      const a = await getAction(ri, { type:'rob', ganger:pi, kind:k }, opts);
+      if (a.type === 'hu'){
+        toast('抢杠 ROB!', 1000);
+        const info = { self:false, kind:k, discarder:pi, rob:true };
+        await declareWin(ri, info, pi);
+        return true;
+      }
+    }
+    const m = p.melds.find(x => x.type === 'peng' && x.kind === k);
+    m.type = 'bugang';
+    p.hand[k]--;
+    payGang(pi, 'bugang', null);
+    toast('补杠', 700);
+  } else { // angang
+    p.hand[k] -= 4;
+    p.melds.push({ type:'angang', kind:k });
+    payGang(pi, 'angang', null);
+    toast('暗杠', 700);
+  }
+  p.drawn = null;
+  render();
+  await sleep(p.isBot ? 250 : 60);
+  return false;
+}
+
+/* 刮风下雨 gang payments, applied immediately. */
+function payGang(ganger, type, discarder){
+  const g = state.players[ganger];
+  const per = (type === 'angang') ? 2 : (type === 'minggang') ? 2 : 1;
+  if (type === 'minggang'){
+    const d = state.players[discarder];
+    if (!d.won){ d.score -= per; g.score += per; }
+  } else {
+    for (let i = 0; i < 4; i++){
+      if (i === ganger) continue;
+      const o = state.players[i];
+      if (o.won) continue;
+      o.score -= per; g.score += per;
+    }
+  }
+}
+
+/* finalize a win (zimo or dianpao). updates scores; bloody mode keeps the hand going. */
+async function declareWin(pi, info, payerIdx){
+  const p = state.players[pi];
+  if (info.kind != null && !info.self) p.hand[info.kind]++;  // commit the winning tile
+  const sc = score(state, pi, info);
+  p.won = true; p.winInfo = { ...info, ...sc };
+  state.winners.push(pi);
+
+  // payments
+  if (info.self){
+    for (let i = 0; i < 4; i++){
+      if (i === pi) continue;
+      const o = state.players[i];
+      if (o.won) continue;
+      o.score -= sc.base; p.score += sc.base;
+    }
+  } else {
+    const payer = state.players[payerIdx];
+    payer.score -= sc.base; p.score += sc.base;
+  }
+  render();
+  toast((info.self ? '自摸 ZIMO' : info.rob ? '胡 HU' : '胡 HU') + ' +' + sc.base, 1100);
+  await sleep(1000);
+
+  if (state.mode === 'single'){ endHand('done'); return; }
+  if (gameEnds()){ endHand('done'); return; }
+}
+
+/* settle the hand and show the scoreboard. reason: 'done' | 'draw' */
+function endHand(reason){
+  if (state.phase === 'over') return;
+  state.phase = 'over';
+  // draw-game settlement: 查大叫 / 查花猪 (light version)
+  if (reason === 'draw'){
+    const remaining = state.players.filter(p => !p.won);
+    const tenpai = remaining.filter(p => isTenpai(p));
+    const huazhu = remaining.filter(p => missingCount(p) > 0);
+    // 花猪 pays everyone else a flat penalty
+    for (const hz of huazhu){
+      for (let i = 0; i < 4; i++){
+        if (state.players[i] === hz) continue;
+        hz.score -= 4; state.players[i].score += 4;
+      }
+    }
+    // 查大叫: not-tenpai (and not huazhu) pay each tenpai player
+    const notReady = remaining.filter(p => !isTenpai(p) && missingCount(p) === 0);
+    for (const nr of notReady){
+      for (const t of tenpai){ nr.score -= 2; t.score += 2; }
+    }
+  }
+  render();
+  showResults(reason);
+}
+
+/* =====================================================================
+   ACTION ROUTING — human vs bot, with mandatory legality validation
+   ===================================================================== */
+async function getAction(pi, ctx, options){
+  const p = state.players[pi];
+  let act;
+  if (p.isBot){
+    await botThink(p);
+    act = botDecide(state, pi, ctx, options);
+  } else {
+    act = await askHuman(pi, ctx, options);
+  }
+  // SPEC: every action must be validated through the rules engine before execution.
+  const legal = enumerateLegalActions(state, pi, ctx);
+  if (!legal.some(o => sameAction(o, act))){
+    console.warn('Illegal action rejected', act, 'legal:', legal);
+    act = legal.find(o => o.type === 'pass')
+       || legal.find(o => o.type === 'discard')
+       || legal[0];
+  }
+  return act;
+}
+async function forceDiscard(pi){
+  const ctx = { type:'turn-discard-only' };
+  const all = enumerateLegalActions(state, pi, { type:'turn' });
+  const opts = all.filter(o => o.type === 'discard');   // after peng you just discard
+  const act = await getAction2(pi, opts);
+  state.players[pi].hand[act.kind]--;
+  state.players[pi].discards.push(act.kind);
+  state.players[pi].drawn = null;
+  state.players[pi].justGanged = false;
+  state.lastDiscard = { by:pi, kind:act.kind }; state.lastTile = act.kind;
+  render();
+  const result = await resolveClaims(pi);
+  if (state.phase !== 'play') return;
+  if (result.type === 'claim'){ state.turn = result.player; }
+  else if (result.type === 'pass'){ state.turn = nextActive(pi); }
+}
+async function getAction2(pi, options){
+  const p = state.players[pi];
+  let act;
+  if (p.isBot){ await botThink(p); act = botDiscardOnly(state, pi, options); }
+  else { act = await askHuman(pi, { type:'discard-only' }, options); }
+  if (!options.some(o => sameAction(o, act))) act = options[0];
+  return act;
+}
+
+/* =====================================================================
+   BOT DECISION LOGIC (separate from the rules engine)
+   ===================================================================== */
+function botThink(p){
+  const base = p.diff === 'hard' ? 650 : p.diff === 'normal' ? 520 : 380;
+  const jitter = Math.random() * 500;
+  return sleep(base + jitter);
+}
+/* Decide among legal options following the spec priority order. */
+function botDecide(state, pi, ctx, options){
+  const p = state.players[pi];
+
+  // 1. Winning move (always take it)
+  const hu = options.find(o => o.type === 'hu');
+  if (hu){
+    // Hard occasionally passes a tiny dianpao to chase bigger hands — but default: win.
+    return hu;
+  }
+  if (ctx.type === 'rob') return options.find(o => o.type === 'pass');
+
+  if (ctx.type === 'turn' || ctx.type === 'turn-discard-only'){
+    // 3. Kong decisions
+    const gangs = options.filter(o => o.type === 'angang' || o.type === 'bugang');
+    if (gangs.length){
+      const g = chooseGang(state, pi, gangs);
+      if (g) return g;
+    }
+    // 5. Best discard
+    const discards = options.filter(o => o.type === 'discard');
+    return { type:'discard', kind: chooseDiscard(state, pi, discards.map(d => d.kind)) };
+  }
+
+  if (ctx.type === 'claim'){
+    // 4. Meld opportunities (peng / gang from discard)
+    const peng = options.find(o => o.type === 'peng');
+    const gang = options.find(o => o.type === 'minggang');
+    const choice = chooseMeld(state, pi, peng, gang);
+    if (choice) return choice;
+    return options.find(o => o.type === 'pass');
+  }
+  return options.find(o => o.type === 'pass') || options[0];
+}
+function botDiscardOnly(state, pi, options){
+  return { type:'discard', kind: chooseDiscard(state, pi, options.map(o => o.kind)) };
+}
+
+/* Should the bot declare this kong?  Avoid kongs that wreck a near hand. */
+function chooseGang(state, pi, gangs){
+  const p = state.players[pi];
+  if (p.diff === 'easy') return Math.random() < 0.7 ? gangs[0] : null;
+  const before = shanten(p);
+  for (const g of gangs){
+    const snap = p.hand.slice(), msnap = p.melds.map(m => ({...m}));
+    if (g.type === 'angang') p.hand[g.kind] -= 4;
+    else p.hand[g.kind]--;
+    const after = shanten(p);
+    p.hand = snap; p.melds = msnap;
+    // gang is good if it doesn't increase shanten (kong tiles weren't forming a run anyway)
+    if (after <= before) return g;
+  }
+  // Hard: also weigh extra fan (根) — take an gang if not clearly hand-wrecking
+  if (p.diff === 'hard') return gangs.find(g => g.type === 'angang') || null;
+  return null;
+}
+
+/* Should the bot peng/gang a discard?  Maintain suit strategy & shanten progress. */
+function chooseMeld(state, pi, peng, gang){
+  const p = state.players[pi];
+  if (!peng && !gang) return null;
+  const k = (peng || gang).kind;
+  if (ksuit(k) === p.missing) return null;
+
+  if (p.diff === 'easy'){
+    // claims impulsively, sometimes wrongly skips
+    if (Math.random() < 0.45) return null;
+    return peng || gang;
+  }
+
+  // Evaluate: does claiming reduce shanten and keep us toward a real hand?
+  const before = shanten(p);
+  const snap = p.hand.slice(), msnap = p.melds.map(m => ({...m}));
+  p.hand[k] -= (gang && !peng ? 3 : 2);
+  p.melds.push({ type: gang && !peng ? 'minggang' : 'peng', kind:k });
+  const after = shanten(p);
+  const tenpaiAfter = isTenpai(p);
+  p.hand = snap; p.melds = msnap;
+
+  // gang from discard: only if it helps and we're committed to pungs
+  if (gang && !peng){
+    if (after < before || tenpaiAfter) return gang;
+    if (p.diff === 'hard') return after <= before ? gang : null;
+    return after < before ? gang : null;
+  }
+  // peng: claim if it lowers shanten, or reaches tenpai, or strongly supports a pung hand
+  if (after < before || tenpaiAfter){
+    // Hard defends: don't open up if an opponent looks dangerously close
+    if (p.diff === 'hard' && after >= before && opponentDanger(state, pi) > 0.6) return null;
+    return peng;
+  }
+  // Normal/Hard generally avoid pengs that don't progress the hand.
+  if (p.diff === 'hard') return null;
+  return after <= before && Math.random() < 0.25 ? peng : null;
+}
+
+/* Choose the best discard from candidate kinds (spec discard heuristics + defense). */
+function chooseDiscard(state, pi, candidates){
+  const p = state.players[pi];
+  if (!candidates.length) candidates = kindsOf(p.hand);
+
+  // Forced: missing-suit tiles must go first (engine already restricts, but be safe).
+  const miss = candidates.filter(k => ksuit(k) === p.missing);
+  if (miss.length) candidates = miss;
+
+  if (p.diff === 'easy' && Math.random() < 0.35){
+    return candidates[(Math.random()*candidates.length)|0];   // optional mistakes
+  }
+
+  const base = shanten(p);
+  let best = candidates[0], bestScore = -Infinity;
+  for (const k of candidates){
+    p.hand[k]--;
+    const sh = shanten(p);
+    const accept = (p.diff !== 'easy') ? ukeire(state, p) : 0;
+    p.hand[k]++;
+
+    let s = -sh * 1000 + accept * 4;
+    s += discardPreference(p, k);                 // isolated/terminal bias
+    if (p.diff === 'hard') s -= tileDanger(state, pi, k) * 60 * opponentDanger(state, pi);
+    if (s > bestScore){ bestScore = s; best = k; }
+  }
+  return best;
+}
+/* Prefer isolated honors-equivalent (terminals) & dead-ends; keep pairs/run material. */
+function discardPreference(p, k){
+  const suit = ksuit(k), r = krank(k);
+  const c = p.hand;
+  let s = 0;
+  const left2 = r>2 ? c[k-2]:0, left1 = r>1 ? c[k-1]:0, right1 = r<9 ? c[k+1]:0, right2 = r<8 ? c[k+2]:0;
+  const neighbours = left2+left1+right1+right2;
+  if (neighbours === 0 && c[k] === 1) s += 30;          // fully isolated -> dump
+  if ((r === 1 || r === 9) && c[k] === 1) s += 10;       // lone terminal
+  if (c[k] >= 2) s -= 25;                                // protect pair candidates
+  if (left1 && right1) s -= 18;                          // protect run middles
+  if (left1 || right1) s -= 6;                           // some connection
+  s -= Math.abs(r - 5);                                  // mild: terminals less flexible
+  return s;
+}
+/* Danger of discarding kind k: how likely it feeds an opponent. (Hard only.) */
+function tileDanger(state, pi, k){
+  let danger = 0;
+  for (let i = 0; i < 4; i++){
+    if (i === pi) continue;
+    const o = state.players[i];
+    if (o.won) continue;
+    // a tile not yet discarded anywhere that pairs with opponent melds is risky
+    const live = remainingCount(state, k, state.players[pi]);
+    let seenInRivers = 0;
+    for (const q of state.players) for (const d of q.discards) if (d === k) seenInRivers++;
+    danger += (seenInRivers === 0 ? 0.5 : 0.1);
+    // suit they are clearly collecting (their missing suit is safe to them? no — they can't use it)
+    if (o.missing != null && ksuit(k) === o.missing) danger -= 0.4;  // safe vs that opponent
+  }
+  return Math.max(0, danger);
+}
+/* Rough estimate that SOME opponent is close to winning (0..1). */
+function opponentDanger(state, pi){
+  let worst = 0;
+  for (let i = 0; i < 4; i++){
+    if (i === pi) continue;
+    const o = state.players[i];
+    if (o.won) continue;
+    const melds = o.melds.length;
+    const discs = o.discards.length;
+    // heuristic: many melds + has voided + few recent off-suit discards => close
+    let d = melds * 0.18 + (missingCount(o) === 0 ? 0.15 : 0) + Math.min(discs, 12) * 0.02;
+    worst = Math.max(worst, Math.min(1, d));
+  }
+  return worst;
+}
+
+/* =====================================================================
+   UI
+   ===================================================================== */
+const $ = id => document.getElementById(id);
+const overlay = $('overlay');
+
+function tileHTML(kind, cls=''){
+  const s = ksuit(kind), r = krank(kind);
+  return `<div class="tile ${SUIT_CLASS[s]} ${cls}">
+    <span class="num">${r}</span><span class="glyph">${SUIT_GLYPH[s]}</span></div>`;
+}
+function backHTML(cls=''){ return `<div class="tile back ${cls}"></div>`; }
+function meldHTML(m){
+  let tiles = '';
+  const n = m.type === 'peng' ? 3 : 4;
+  for (let i = 0; i < n; i++){
+    const concealed = (m.type === 'angang' && (i === 0 || i === 3));
+    tiles += concealed ? `<div class="tile back concealed"></div>` : tileHTML(m.kind);
+  }
+  return `<div class="meld">${tiles}</div>`;
+}
+
+let humanResolver = null;
+let uiState = null;   // {pi, ctx, options}
+
+function render(){
+  if (!state) return;
+  $('round-info').textContent =
+    `Wall ${state.wall.length} · ${state.mode === 'bloody' ? '血战' : 'Single'} · Won ${state.winners.length}/3`;
+
+  const view = (uiState && !state.players[uiState.pi].isBot) ? uiState.pi
+             : (state.phase === 'over' ? 0 : 0);
+  // seats are positioned relative to the bottom view player
+  for (let rel = 0; rel < 4; rel++){
+    const pi = (view + rel) % 4;
+    renderSeat(pi, rel);
+  }
+  renderCenter();
+  renderHandArea(view);
+}
+
+function renderSeat(pi, rel){
+  const p = state.players[pi];
+  const el = $('seat-' + rel);
+  if (!el) return;
+  const activeTurn = (state.phase === 'play' && state.turn === pi && !p.won);
+  const missLbl = p.missing != null ? `<span class="miss ${SUIT_CLASS[p.missing]}" style="color:${['#ff8a8a','#7be39a','#8ec5ff'][p.missing]}">缺${SUIT_GLYPH[p.missing]}</span>` : '';
+  const plate = `<div class="nameplate ${activeTurn?'active':''} ${p.isBot?'bot':'human'}">
+      <span class="dot"></span>
+      <span>${escapeHtml(p.name)}</span>
+      ${missLbl}
+      ${p.won ? `<span class="won">胡 #${state.winners.indexOf(pi)+1}</span>` : ''}
+      <span class="sc">${p.score>=0?'+':''}${p.score}</span>
+      ${p.isBot && activeTurn ? '<span class="thinking">…</span>' : ''}
+    </div>`;
+
+  if (rel === 0){
+    // bottom — interactive player: plate + melds + river (hand is in handarea)
+    el.innerHTML = plate + meldsRow(p) + riverRow(pi);
+  } else {
+    const backs = backsRow(p, rel);
+    el.innerHTML = (rel === 2)
+      ? plate + meldsRow(p) + backs + riverRow(pi)
+      : plate + backs + meldsRow(p) + riverRow(pi);
+  }
+}
+function meldsRow(p){
+  if (!p.melds.length) return '';
+  return `<div class="melds">${p.melds.map(meldHTML).join('')}</div>`;
+}
+function backsRow(p, rel){
+  const n = handSize(p.hand);
+  let t = ''; for (let i = 0; i < n; i++) t += backHTML();
+  return `<div class="backs">${t}</div>`;
+}
+function riverRow(pi){
+  const p = state.players[pi];
+  const last = state.lastDiscard;
+  return `<div class="river">${p.discards.map((k,i) => {
+    const isLast = last && last.by === pi && i === p.discards.length-1;
+    return tileHTML(k, isLast ? 'last' : '');
+  }).join('')}</div>`;
+}
+function renderCenter(){
+  const c = $('center');
+  if (state.phase === 'over'){ c.innerHTML = ''; return; }
+  let inner = `<div class="wall-info">剩 ${state.wall.length} tiles</div>`;
+  if (state.lastDiscard){
+    inner += `<div class="last-played"><span class="lbl">${escapeHtml(state.players[state.lastDiscard.by].name)} discarded</span>${tileHTML(state.lastDiscard.kind)}</div>`;
+  }
+  c.innerHTML = inner;
+}
+
+function renderHandArea(view){
+  const area = $('handarea');
+  const p = state.players[view];
+
+  // ding-que prompt handled separately by askMissingSuit (overlay-ish inline)
+  if (state.phase === 'dingque' && uiState && uiState.ctx && uiState.ctx.type === 'dingque'){
+    area.innerHTML = dingQueHTML(view);
+    return;
+  }
+
+  // hand tiles
+  const kinds = [];
+  for (let k = 0; k < 27; k++) for (let i = 0; i < p.hand[k]; i++) kinds.push(k);
+  // place the freshly drawn tile at the end, separated
+  let drawnIdx = -1;
+  if (p.drawn != null){
+    const di = kinds.lastIndexOf(p.drawn);
+    if (di >= 0){ kinds.splice(di, 1); drawnIdx = p.drawn; }
+  }
+
+  const canDiscard = uiState && uiState.pi === view &&
+      (uiState.options || []).some(o => o.type === 'discard');
+  const discardKinds = canDiscard ? new Set(uiState.options.filter(o=>o.type==='discard').map(o=>o.kind)) : null;
+
+  let html = '<div class="hand-row">';
+  for (const k of kinds){
+    const playable = discardKinds && discardKinds.has(k);
+    const dim = discardKinds && !discardKinds.has(k);
+    html += `<div class="tile ${SUIT_CLASS[ksuit(k)]} ${playable?'playable':''} ${dim?'dim':''}" data-k="${k}">
+      <span class="num">${krank(k)}</span><span class="glyph">${SUIT_GLYPH[ksuit(k)]}</span></div>`;
+  }
+  if (drawnIdx >= 0){
+    const playable = discardKinds && discardKinds.has(drawnIdx);
+    const dim = discardKinds && !discardKinds.has(drawnIdx);
+    html += `<div class="tile ${SUIT_CLASS[ksuit(drawnIdx)]} drawn ${playable?'playable':''} ${dim?'dim':''}" data-k="${drawnIdx}">
+      <span class="num">${krank(drawnIdx)}</span><span class="glyph">${SUIT_GLYPH[ksuit(drawnIdx)]}</span></div>`;
+  }
+  html += '</div>';
+  html += `<div class="actions" id="actions"></div>`;
+  area.innerHTML = html;
+
+  // wire discard taps
+  if (discardKinds){
+    area.querySelectorAll('.tile.playable').forEach(t => {
+      t.addEventListener('click', () => {
+        const k = +t.dataset.k;
+        resolveHuman({ type:'discard', kind:k });
+      });
+    });
+  }
+  renderActions(view);
+}
+function renderActions(view){
+  const ab = $('actions');
+  if (!ab) return;
+  if (!uiState || uiState.pi !== view){ ab.innerHTML = ''; return; }
+  const opts = uiState.options || [];
+  let html = '';
+  const hu = opts.find(o => o.type === 'hu');
+  if (hu) html += `<button class="b-hu" data-act="hu">胡 HU</button>`;
+  // gang buttons (turn): angang/bugang
+  for (const o of opts.filter(o => o.type === 'angang')) html += `<button class="b-gang" data-act="angang" data-k="${o.kind}">暗杠 ${krank(o.kind)}${SUIT_GLYPH[ksuit(o.kind)]}</button>`;
+  for (const o of opts.filter(o => o.type === 'bugang')) html += `<button class="b-gang" data-act="bugang" data-k="${o.kind}">补杠 ${krank(o.kind)}${SUIT_GLYPH[ksuit(o.kind)]}</button>`;
+  // claim window
+  const peng = opts.find(o => o.type === 'peng');
+  const mgang = opts.find(o => o.type === 'minggang');
+  if (peng) html += `<button class="b-peng" data-act="peng" data-k="${peng.kind}">碰 PENG</button>`;
+  if (mgang) html += `<button class="b-gang" data-act="minggang" data-k="${mgang.kind}">杠 GANG</button>`;
+  const pass = opts.find(o => o.type === 'pass');
+  if (pass) html += `<button class="b-pass" data-act="pass">Pass</button>`;
+  if (opts.some(o => o.type === 'discard') && !hu && !peng && !mgang){
+    html += `<span class="hint">Tap a tile to discard${missingCount(state.players[view])>0?' (clear 缺 suit)':''}</span>`;
+  }
+  ab.innerHTML = html;
+  ab.querySelectorAll('button').forEach(b => {
+    b.addEventListener('click', () => {
+      const a = b.dataset.act;
+      const k = b.dataset.k != null ? +b.dataset.k : undefined;
+      if (a === 'hu') resolveHuman(uiState.options.find(o => o.type === 'hu'));
+      else if (a === 'pass') resolveHuman({ type:'pass' });
+      else resolveHuman({ type:a, kind:k });
+    });
+  });
+}
+
+/* ---- human input plumbing ---- */
+function askHuman(pi, ctx, options){
+  return new Promise(async resolve => {
+    // reveal gate for hot-seat (multiple humans)
+    if (cfg.humans > 1 && pi !== lastShownHuman){
+      await revealGate(pi);
+    }
+    lastShownHuman = pi;
+    uiState = { pi, ctx, options };
+    humanResolver = (action) => {
+      humanResolver = null;
+      uiState = null;
+      resolve(action);
+    };
+    render();
+  });
+}
+function resolveHuman(action){ if (humanResolver) humanResolver(action); }
+function revealGate(pi){
+  return new Promise(resolve => {
+    overlay.style.display = 'flex';
+    overlay.innerHTML = `<div class="modal reveal-gate" id="rg">
+      <div class="big">🀄️</div>
+      <h2>${escapeHtml(state.players[pi].name)}</h2>
+      <p>Pass the device. Tap when ready — keep your tiles hidden from the others.</p>
+      <button class="btn">I'm ready</button></div>`;
+    const go = () => { overlay.style.display = 'none'; overlay.innerHTML = ''; resolve(); };
+    $('rg').querySelector('.btn').addEventListener('click', go);
+  });
+}
+
+/* ---- ding que selection ---- */
+function askMissingSuit(pi){
+  return new Promise(async resolve => {
+    if (cfg.humans > 1 && pi !== lastShownHuman) await revealGate(pi);
+    lastShownHuman = pi;
+    uiState = { pi, ctx:{ type:'dingque' }, options:[] };
+    state._dingResolve = resolve;
+    render();
+  });
+}
+function dingQueHTML(pi){
+  const p = state.players[pi];
+  const cnt = [0,0,0];
+  for (let k = 0; k < 27; k++) cnt[ksuit(k)] += p.hand[k];
+  const rec = botPickMissing(p);
+  // show the hand above the chooser
+  const kinds = listOf(p.hand);
+  let hand = '<div class="hand-row" style="margin-bottom:6px">';
+  for (const k of kinds) hand += tileHTML(k);
+  hand += '</div>';
+  let opts = '<div class="opts">';
+  for (let s = 0; s < 3; s++){
+    opts += `<button class="${s===rec?'rec':''}" data-suit="${s}">
+      <span class="big ${SUIT_CLASS[s]}" style="color:${['#ff8a8a','#7be39a','#8ec5ff'][s]}">${SUIT_GLYPH[s]}</span>
+      <span class="ct">${cnt[s]} tiles</span>
+      ${s===rec?'<span class="tag">suggested</span>':''}</button>`;
+  }
+  opts += '</div>';
+  return hand + `<div class="dingque"><div class="q">定缺 — choose the suit you will <b>not</b> use</div>${opts}</div>`;
+}
+document.addEventListener('click', e => {
+  const b = e.target.closest('.dingque .opts button');
+  if (b && state && state._dingResolve){
+    const s = +b.dataset.suit;
+    const r = state._dingResolve; state._dingResolve = null; uiState = null;
+    r(s);
+  }
+});
+
+/* ---- toasts ---- */
+let toastTimer = null;
+function toast(msg, ms=900){
+  const t = $('toast');
+  t.textContent = msg; t.classList.add('show');
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => t.classList.remove('show'), ms);
+}
+
+/* ---- results ---- */
+function showResults(reason){
+  const ranked = state.players.map((p,i) => ({ p, i })).sort((a,b) => b.p.score - a.p.score);
+  let rows = '';
+  for (const { p, i } of ranked){
+    const wi = p.winInfo;
+    rows += `<tr>
+      <td>${escapeHtml(p.name)} ${p.isBot?'<small style="opacity:.5">bot</small>':''}</td>
+      <td>${wi ? `<small>${wi.names.join(' ')} (${wi.fan}番)</small>` : (state.winners.includes(i)?'':'<small style="opacity:.5">—</small>')}</td>
+      <td class="pos ${p.score>0?'gain-pos':p.score<0?'gain-neg':''}">${p.score>=0?'+':''}${p.score}</td>
+    </tr>`;
+  }
+  const title = reason === 'draw'
+      ? (state.winners.length ? '血战结束 Hand Over' : '荒庄 Draw')
+    : state.mode === 'single' ? '胡牌 Winner!' : '血战结束 Hand Over';
+  overlay.style.display = 'flex';
+  overlay.innerHTML = `<div class="modal">
+    <h2>${title}</h2>
+    <table class="scoreboard"><tr><th>Player</th><th>Hand</th><th class="pos">Score</th></tr>${rows}</table>
+    <button class="btn" id="again">New Hand</button>
+    <button class="btn alt" id="tomenu">Main Menu</button>
+  </div>`;
+  $('again').addEventListener('click', () => { overlay.style.display='none'; overlay.innerHTML=''; startGame(); });
+  $('tomenu').addEventListener('click', () => { overlay.style.display='none'; overlay.innerHTML=''; showSetup(); });
+}
+
+/* ---- menu / rules ---- */
+function showMenu(){
+  overlay.style.display = 'flex';
+  overlay.innerHTML = `<div class="modal">
+    <h2>Menu</h2>
+    <button class="btn" id="m-resume">Resume</button>
+    <button class="btn alt" id="m-new">New Hand</button>
+    <button class="btn alt" id="m-rules">Rules</button>
+    <button class="btn alt" id="m-menu">Main Menu</button>
+  </div>`;
+  $('m-resume').onclick = () => { overlay.style.display='none'; overlay.innerHTML=''; };
+  $('m-new').onclick = () => { overlay.style.display='none'; overlay.innerHTML=''; startGame(); };
+  $('m-rules').onclick = showRules;
+  $('m-menu').onclick = () => { overlay.style.display='none'; overlay.innerHTML=''; showSetup(); };
+}
+function showRules(){
+  overlay.style.display = 'flex';
+  overlay.innerHTML = `<div class="modal"><div class="rules-content">
+    <h2>四川麻將 — How to Play</h2>
+    <h3>Tiles</h3>
+    <ul><li>108 tiles: three suits only — 萬 Characters, 条 Bamboo, 筒 Dots, 1–9 ×4. No winds or dragons.</li></ul>
+    <h3>定缺 Missing Suit</h3>
+    <ul><li>After the deal, each player picks one suit they will <b>not</b> use.</li>
+    <li>You must discard all tiles of that suit before doing anything else, and you cannot win while holding any.</li></ul>
+    <h3>Melds</h3>
+    <ul><li><b>碰 Peng</b> — claim a discard to make a triplet.</li>
+    <li><b>杠 Gang</b> — a kong of four: from a discard (直杠), added to a peng (补杠, can be robbed), or concealed (暗杠). Draw a replacement after.</li>
+    <li>No chow — you cannot claim a discard to make a run.</li></ul>
+    <h3>胡 Winning</h3>
+    <ul><li>Four melds + a pair (or seven pairs), using only your two chosen suits.</li>
+    <li>自摸 self-draw: everyone pays. 点炮 on a discard: only the discarder pays.</li></ul>
+    <h3>Scoring (番)</h3>
+    <ul><li>Points double per 番: 平胡, 碰碰胡, 清一色, 七对, 金钩钓, 自摸, 杠上花/炮, 抢杠, 海底, 根…</li>
+    <li>刮风下雨: kongs pay out immediately (暗杠 2 each, 直杠 2 from the discarder, 补杠 1 each).</li></ul>
+    <h3>血战到底 Bloody</h3>
+    <ul><li>Winning doesn't end the hand — play continues until three players have won.</li></ul>
+    </div>
+    <button class="btn" id="r-close">Got it</button></div>`;
+  $('r-close').onclick = () => {
+    if (state && state.phase !== 'over') { overlay.style.display='none'; overlay.innerHTML=''; }
+    else { overlay.style.display='none'; overlay.innerHTML=''; }
+  };
+}
+
+/* =====================================================================
+   SCREEN SWITCHING + SETUP WIRING
+   ===================================================================== */
+function showSetup(){ $('setup').style.display='flex'; $('game').style.display='none'; }
+function showGame(){ $('setup').style.display='none'; $('game').style.display='flex'; }
+
+function buildNameInputs(){
+  const box = $('name-inputs');
+  box.innerHTML = '';
+  for (let i = 0; i < cfg.humans; i++){
+    const inp = document.createElement('input');
+    inp.placeholder = `Player ${i+1} name`;
+    inp.value = cfg.names[i] || '';
+    inp.maxLength = 12;
+    inp.addEventListener('input', () => { cfg.names[i] = inp.value; });
+    box.appendChild(inp);
+  }
+}
+function wireSetup(){
+  $('humans-seg').addEventListener('click', e => {
+    const b = e.target.closest('button'); if (!b) return;
+    [...$('humans-seg').children].forEach(x => x.classList.remove('on'));
+    b.classList.add('on'); cfg.humans = +b.dataset.h; buildNameInputs();
+  });
+  $('diff-seg').addEventListener('click', e => {
+    const b = e.target.closest('button'); if (!b) return;
+    [...$('diff-seg').children].forEach(x => x.classList.remove('on'));
+    b.classList.add('on'); cfg.diff = b.dataset.d;
+  });
+  $('mode-seg').addEventListener('click', e => {
+    const b = e.target.closest('button'); if (!b) return;
+    [...$('mode-seg').children].forEach(x => x.classList.remove('on'));
+    b.classList.add('on'); cfg.mode = b.dataset.m;
+  });
+  $('start-btn').addEventListener('click', startGame);
+  $('rules-link').addEventListener('click', showRules);
+  $('rules-btn').addEventListener('click', showRules);
+  $('menu-btn').addEventListener('click', showMenu);
+  buildNameInputs();
+}
+
+/* utils */
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+function escapeHtml(s){ return String(s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
+
+wireSetup();
+
+/* =====================================================================
+   TEST SUITE  (legality + rules engine).  Run with ?test or window.runTests()
+   ===================================================================== */
+function runTests(){
+  let pass = 0, fail = 0; const log = [];
+  const ok = (cond, msg) => { if (cond){ pass++; } else { fail++; log.push('FAIL: ' + msg); } };
+
+  // deck composition
+  const d = newDeck();
+  ok(d.length === 108, '108 tiles');
+  const cc = emptyCounts(); d.forEach(k => cc[k]++);
+  ok(cc.every(x => x === 4), 'exactly 4 of each kind');
+
+  // winning hands
+  const P = (hand, melds=[], missing=2) => ({ hand: listToCounts(hand), melds, missing });
+  function listToCounts(a){ const c = emptyCounts(); a.forEach(k => c[k]++); return c; }
+  // 123 456 789 m  + 11 s  + 11 s pair? need 4 sets + pair. Build: 123m 456m 789m 123s 99s
+  let h = [mk(0,1),mk(0,2),mk(0,3), mk(0,4),mk(0,5),mk(0,6), mk(0,7),mk(0,8),mk(0,9), mk(1,1),mk(1,2),mk(1,3), mk(1,9),mk(1,9)];
+  ok(winsNow(P(h, [], 2)), 'standard 4 sets + pair wins');
+  // missing-suit violation: same hand but missing = bamboo(1)
+  ok(!winsNow(P(h, [], 1)), 'cannot win holding missing suit');
+  // seven pairs
+  let sp = [mk(0,1),mk(0,1),mk(0,3),mk(0,3),mk(0,5),mk(0,5),mk(1,2),mk(1,2),mk(1,4),mk(1,4),mk(1,6),mk(1,6),mk(1,8),mk(1,8)];
+  ok(winsNow(P(sp, [], 2)), 'seven pairs wins');
+  // not a win
+  let no = [mk(0,1),mk(0,2),mk(0,4), mk(0,4),mk(0,5),mk(0,6), mk(0,7),mk(0,8),mk(0,9), mk(1,1),mk(1,2),mk(1,3), mk(1,9),mk(1,8)];
+  ok(!winsNow(P(no, [], 2)), 'non-winning hand rejected');
+  // with a peng meld: 3 sets + pair concealed
+  let hm = [mk(0,1),mk(0,2),mk(0,3), mk(0,4),mk(0,5),mk(0,6), mk(1,1),mk(1,2),mk(1,3), mk(1,9),mk(1,9)];
+  ok(winsNow(P(hm, [{type:'peng',kind:mk(0,7)}], 2)), 'win with one peng meld');
+  // canHu adds a tile
+  let wait = [mk(0,1),mk(0,2),mk(0,3), mk(0,4),mk(0,5),mk(0,6), mk(0,7),mk(0,8),mk(0,9), mk(1,1),mk(1,2),mk(1,3), mk(1,9)];
+  ok(canHu(P(wait, [], 2), mk(1,9)), 'canHu completes the pair');
+  ok(!canHu(P(wait, [], 2), mk(2,5)), 'canHu rejects non-winning tile');
+  // canHu must respect missing suit
+  ok(!canHu(P(wait, [], 1), mk(1,9)), 'canHu rejects tile from forbidden suit / holding missing');
+
+  // shanten sanity
+  ok(stdShanten(listToCounts(h), 0) === -1, 'complete hand shanten = -1');
+  ok(stdShanten(listToCounts(wait), 0) === 0, 'tenpai shanten = 0');
+
+  // enumerateLegalActions — turn context restricts to missing suit when holding it
+  const ts = makeTestState();
+  ts.players[0].missing = 2; // dots
+  ts.players[0].hand = listToCounts([mk(2,1),mk(2,2), mk(0,1),mk(0,2),mk(0,3), mk(0,4),mk(0,5),mk(0,6), mk(1,1),mk(1,2),mk(1,3), mk(1,7),mk(1,8),mk(1,9)]);
+  const turnActs = enumerateLegalActions(ts, 0, { type:'turn' });
+  const discardKinds = turnActs.filter(a => a.type === 'discard').map(a => a.kind);
+  ok(discardKinds.every(k => ksuit(k) === 2), 'must discard missing suit first');
+  ok(discardKinds.length === 2, 'only the two dot tiles are discardable');
+
+  // claim legality: peng requires two in hand
+  ts.players[1].missing = 0; ts.players[1].hand = listToCounts([mk(1,5),mk(1,5), mk(2,1),mk(2,2),mk(2,3), mk(1,1),mk(1,2),mk(1,3),mk(2,7),mk(2,8),mk(2,9),mk(2,4),mk(2,5)]);
+  const claimActs = enumerateLegalActions(ts, 1, { type:'claim', discarder:0, kind:mk(1,5) });
+  ok(claimActs.some(a => a.type === 'peng'), 'peng offered with a pair in hand');
+  ok(!claimActs.some(a => a.type === 'minggang'), 'no gang offered with only a pair');
+  // peng of the missing suit not allowed
+  ts.players[1].missing = 1;
+  const claimActs2 = enumerateLegalActions(ts, 1, { type:'claim', discarder:0, kind:mk(1,5) });
+  ok(!claimActs2.some(a => a.type === 'peng'), 'cannot peng your missing suit');
+
+  // FULL BOT-LEGALITY FUZZ: play many bot-only games, validate EVERY chosen action.
+  let illegal = 0, games = 0, errors = 0;
+  for (let g = 0; g < 60; g++){
+    try { illegal += simulateBotGame(); games++; }
+    catch (e){ errors++; log.push('ERR: ' + (e && e.message)); }
+  }
+  ok(illegal === 0, `bots only chose legal actions (illegal=${illegal} over ${games} games)`);
+  ok(errors === 0, `no engine errors during fuzz (${errors})`);
+
+  const summary = `Mahjong tests: ${pass} passed, ${fail} failed.`;
+  const out = summary + (log.length ? '\n' + log.join('\n') : '');
+  console.log(out);
+  return { pass, fail, log, summary };
+}
+function makeTestState(){
+  return {
+    mode:'bloody', wall:[], winners:[], turn:0,
+    players: [0,1,2,3].map(i => ({ id:i, name:'P'+i, isBot:true, diff:'normal',
+      hand:emptyCounts(), melds:[], discards:[], missing:null, won:false, score:0 })),
+  };
+}
+/* Headless bot-only game using ONLY the engine + bot logic (no DOM, no await). */
+function simulateBotGame(){
+  let illegal = 0;
+  const deck = newDeck();
+  const players = [0,1,2,3].map(i => ({ id:i, name:'Bot'+i, isBot:true, diff:['easy','normal','hard'][i%3],
+    hand:emptyCounts(), melds:[], discards:[], missing:null, won:false, score:0, justGanged:false }));
+  for (let n = 0; n < 13; n++) for (let i = 0; i < 4; i++) players[i].hand[deck.pop()]++;
+  const S = { mode:'bloody', wall:deck, players, winners:[], turn:0 };
+  for (const p of players) p.missing = botPickMissing(p);
+
+  const validate = (pi, ctx, act) => {
+    const legal = enumerateLegalActions(S, pi, ctx);
+    if (!legal.some(o => sameAction(o, act))) illegal++;
+    return legal.some(o => sameAction(o, act)) ? act : (legal.find(o=>o.type==='pass') || legal.find(o=>o.type==='discard') || legal[0]);
+  };
+
+  let turn = 0, guard = 0;
+  const active = () => players.filter(p => !p.won).length;
+  while (S.wall.length > 0 && active() > 1 && guard++ < 400){
+    let pi = turn;
+    if (players[pi].won){ turn = (turn+1)%4; continue; }
+    const p = players[pi];
+    // draw
+    const drawn = S.wall.pop(); p.hand[drawn]++; p.drawn = drawn;
+    // turn decision loop (handle gangs)
+    let acted = false;
+    while (true){
+      const ctx = { type:'turn' };
+      let act = botDecide(S, pi, ctx, enumerateLegalActions(S, pi, ctx));
+      act = validate(pi, ctx, act);
+      if (act.type === 'hu'){ p.won = true; S.winners.push(pi); acted = true; break; }
+      if (act.type === 'angang'){ p.hand[act.kind] -= 4; p.melds.push({type:'angang',kind:act.kind});
+        if (S.wall.length === 0) { acted = true; break; } const r = S.wall.pop(); p.hand[r]++; p.drawn = r; continue; }
+      if (act.type === 'bugang'){ const m = p.melds.find(x => x.type==='peng' && x.kind===act.kind); m.type='bugang'; p.hand[act.kind]--;
+        if (S.wall.length === 0) { acted = true; break; } const r = S.wall.pop(); p.hand[r]++; p.drawn = r; continue; }
+      // discard
+      p.hand[act.kind]--; p.discards.push(act.kind); p.drawn = null;
+      S.lastDiscard = { by:pi, kind:act.kind };
+      // claim window
+      let claimed = -1;
+      // hu
+      for (let s = 1; s <= 3; s++){
+        const qi = (pi+s)%4; const q = players[qi]; if (q.won) continue;
+        const cctx = { type:'claim', discarder:pi, kind:act.kind };
+        const opts = enumerateLegalActions(S, qi, cctx);
+        if (!opts.some(o => o.type==='hu')) continue;
+        let ca = validate(qi, cctx, botDecide(S, qi, cctx, opts));
+        if (ca.type === 'hu'){ q.won = true; S.winners.push(qi); }
+      }
+      if (active() <= 1) { acted = true; break; }
+      // peng/gang
+      for (let s = 1; s <= 3; s++){
+        const qi = (pi+s)%4; const q = players[qi]; if (q.won) continue;
+        const cctx = { type:'claim', discarder:pi, kind:act.kind };
+        const opts = enumerateLegalActions(S, qi, cctx);
+        if (!opts.some(o => o.type==='peng' || o.type==='minggang')) continue;
+        let ca = validate(qi, cctx, botDecide(S, qi, cctx, opts));
+        if (ca.type === 'peng'){ q.hand[act.kind]-=2; q.melds.push({type:'peng',kind:act.kind});
+          // q now discards
+          claimed = qi; break; }
+        if (ca.type === 'minggang'){ q.hand[act.kind]-=3; q.melds.push({type:'minggang',kind:act.kind});
+          if (S.wall.length>0){ const r = S.wall.pop(); q.hand[r]++; q.drawn=r; } claimed = qi; break; }
+        if (ca.type === 'pass') break;
+      }
+      if (claimed >= 0){
+        const q = players[claimed];
+        // q makes a discard (validate)
+        const dctx = { type:'turn' };
+        const dopts = enumerateLegalActions(S, claimed, dctx).filter(o => o.type==='discard');
+        if (dopts.length){
+          let da = validate(claimed, dctx, { type:'discard', kind: chooseDiscard(S, claimed, dopts.map(o=>o.kind)) });
+          q.hand[da.kind]--; q.discards.push(da.kind); q.drawn = null;
+        }
+        turn = claimed; acted = true; break;
+      }
+      acted = true; break;
+    }
+    if (active() <= 1) break;
+    // advance turn if not claimed
+    if (turn === pi) turn = (turn+1)%4;
+    else { /* turn already set to claimer */ }
+  }
+  return illegal;
+}
+
+// Spec-named Rules Engine surface (the only interface the bot is allowed to use).
+const RulesEngine = {
+  enumerate_legal_actions: (state, player, ctx) => enumerateLegalActions(state, player, ctx),
+  evaluate_hand:           (state, player)      => evaluateHand(state, player),
+  simulate:                (state, player, action) => simulate(state, player, action),
+  score:                   (state, winner, info) => score(state, winner, info),
+};
+
+// expose for headless / console
+window.RulesEngine = RulesEngine;
+window.runTests = runTests;
+window.__mahjong = { enumerateLegalActions, winsNow, canHu, score, shanten, newDeck };
+if (location.search.includes('test')){
+  window.addEventListener('load', () => {
+    const r = runTests();
+    document.body.innerHTML = `<div style="padding:24px;font-family:monospace;white-space:pre-wrap;color:#fff">${escapeHtml(r.summary + '\n\n' + r.log.join('\n'))}</div>`;
+    document.title = (r.fail === 0 ? 'PASS ' : 'FAIL ') + r.summary;
+  });
+}
+</script>
+</body>
+</html>

--- a/apps/mahjong/index.html
+++ b/apps/mahjong/index.html
@@ -532,10 +532,13 @@ const winsNow = (player, config) => isWinningHand(player, config, null);
 function getWinningTiles(player, config, state = null) {
   const tiles = [];
   if (hasMissingSuitInCounts(player.concealed, player.missingSuit)) return tiles;
+  const pending = state && state.pendingDiscard ? state.pendingDiscard.tile : -1;
   for (let t = 0; t < NUM_TYPES; t++) {
     if (tileSuit(t) === player.missingSuit) continue;
     if (player.concealed[t] >= 4) continue;
-    if (state && remainingOf(state, t, player.seat) <= 0) continue;
+    // a tile with 0 unseen copies is unreachable — UNLESS it's the tile sitting on the
+    // table right now (the player can win on it this instant), so never filter that one out
+    if (state && t !== pending && remainingOf(state, t, player.seat) <= 0) continue;
     if (isWinningHand(player, config, t)) tiles.push(t);
   }
   return tiles;
@@ -1651,6 +1654,7 @@ function showRules() {
 }
 
 function leaveGame() {
+  try { if (conn && conn.code) localStorage.removeItem('mjrt:' + conn.code); } catch {}  // drop our reconnect token
   if (conn && conn.dispose) conn.dispose();
   conn = null; curView = null; online = false; pendingReveal = null;
   overlay.style.display = 'none'; overlay.innerHTML = ''; overlay.style.background = '';
@@ -1711,6 +1715,7 @@ class LocalConnection {
         if (!live()) return;
         const a = botChooseAction(this.state, botSeat);
         const res = applyAction(this.state, botSeat, a);
+        if (!res.ok) { this.emit({ toasts: [{ msg: (res.error && res.error.message) || 'Bot error', ms: 1600 }] }); return; }  // never spin
         this.emit({ toasts: this.eventToasts(res.events || []) });
         continue;
       }
@@ -1747,11 +1752,11 @@ function buildNameInputs() {
     box.appendChild(inp);
   }
 }
-function segWire(id, key, cfg, cast = (x) => x) {
+function segWire(id, key, cfg, dataKey, cast = (x) => x) {
   $(id).addEventListener('click', (e) => {
     const b = e.target.closest('button'); if (!b) return;
     [...$(id).children].forEach((x) => x.classList.remove('on')); b.classList.add('on');
-    cfg[key] = cast(b.dataset[Object.keys(b.dataset)[0]]);
+    cfg[key] = cast(b.dataset[dataKey]);
     if (id === 'humans-seg') buildNameInputs();
   });
 }
@@ -1777,10 +1782,10 @@ function wireSetup() {
     $('local-setup').style.display = isOnlineTab ? 'none' : 'block';
     $('online-setup').style.display = isOnlineTab ? 'block' : 'none';
   });
-  segWire('humans-seg', 'humans', localCfg, (x) => +x);
-  segWire('diff-seg', 'diff', localCfg);
-  segWire('mode-seg', 'mode', localCfg);
-  segWire('odiff-seg', 'diff', onlineCfg);
+  segWire('humans-seg', 'humans', localCfg, 'h', (x) => +x);
+  segWire('diff-seg', 'diff', localCfg, 'd');
+  segWire('mode-seg', 'mode', localCfg, 'm');
+  segWire('odiff-seg', 'diff', onlineCfg, 'd');
   $('sw-sevenpairs').addEventListener('click', (e) => { e.currentTarget.classList.toggle('on'); localCfg.sevenPairs = e.currentTarget.classList.contains('on'); });
   $('start-local').addEventListener('click', startLocal);
   $('online-name').addEventListener('input', (e) => { onlineCfg.name = e.target.value; });

--- a/apps/mahjong/index.html
+++ b/apps/mahjong/index.html
@@ -1011,23 +1011,23 @@ function score(state, seat, ctx) {
   if (ctx.winType === 'SELF_DRAW') add('Self-Draw', cfg.selfDrawBonusFan);
   if (sevenP) {
     add('Seven Pairs', cfg.sevenPairsFan);
+    // a quad in a seven-pairs hand is credited here as Luxury Seven Pairs (龙七对);
+    // it is NOT also counted as a Root below, which would double-credit the same tiles.
     let quads = 0; for (let t = 0; t < NUM_TYPES; t++) if (concealed[t] === 4) quads++;
     if (quads >= 1) add('Luxury Seven Pairs', cfg.luxurySevenPairsExtraFanPerQuad * quads);
   } else {
-    // all pungs: every meld is a pung/kong (Sichuan melds always are) AND concealed = triplets + pair
-    const meldsAllPung = p.melds.every((m) => true);
-    if (meldsAllPung && decomposeAllPungs(concealed, groupsNeeded)) add('All Pungs', cfg.allPungsFan);
+    // Sichuan has no chow melds, so every meld is already a pung/kong by construction
+    if (decomposeAllPungs(concealed, groupsNeeded)) add('All Pungs', cfg.allPungsFan);
+    // Root (根): four identical tiles in the hand (a kong, or 4 concealed) — standard hands only
+    let roots = 0;
+    for (let t = 0; t < NUM_TYPES; t++) {
+      let phys = concealed[t];
+      for (const m of p.melds) if (m.tile === t) phys += meldPhysical(m);
+      if (phys === 4) roots++;
+    }
+    if (roots > 0) add('Root', cfg.rootFan * roots);
   }
   if (suitsUsed.size === 1) add('Pure One Suit', cfg.pureOneSuitFan);
-
-  // root (gen): 4 physical copies of a type in the full hand
-  let roots = 0;
-  for (let t = 0; t < NUM_TYPES; t++) {
-    let phys = concealed[t];
-    for (const m of p.melds) if (m.tile === t) phys += meldPhysical(m);
-    if (phys === 4) roots++;
-  }
-  if (roots > 0) add('Root', cfg.rootFan * roots);
 
   if (ctx.afterKong && ctx.winType === 'SELF_DRAW') add('Kong Bloom', cfg.kongBloomBonusFan);
   if (ctx.winType === 'ROB_KONG') add('Robbing a Kong', cfg.robKongBonusFan);
@@ -1293,15 +1293,15 @@ function botChooseDiscard(state, seat, candidates, difficulty) {
   return best;
 }
 function tileDanger(state, seat, t) {
-  let danger = 0;
+  // a tile never seen in any river is more likely to be a live wait — count it ONCE
+  let seenRivers = 0;
+  for (const q of state.players) for (const d of q.discards) if (d === t) seenRivers++;
+  let danger = (seenRivers === 0 ? 0.5 : 0.1);
   for (let s = 0; s < 4; s++) {
     if (s === seat) continue;
     const o = state.players[s];
     if (o.hasWon) continue;
-    let seenRivers = 0;
-    for (const q of state.players) for (const d of q.discards) if (d === t) seenRivers++;
-    danger += (seenRivers === 0 ? 0.5 : 0.1);
-    if (o.missingSuit != null && tileSuit(t) === o.missingSuit) danger -= 0.4;
+    if (o.missingSuit != null && tileSuit(t) === o.missingSuit) danger -= 0.4;  // safe vs that opponent
   }
   return Math.max(0, danger);
 }
@@ -1450,7 +1450,7 @@ function renderSeat(view, seat, rel) {
       <span class="dot"></span>${dealer}<span>${escapeHtml(p.name)}</span>${tint}${won}
       <span class="sc">${p.score >= 0 ? '+' : ''}${p.score}</span>${thinking}</div>`;
   const melds = p.melds.length ? `<div class="melds">${p.melds.map(meldHTML).join('')}</div>` : '';
-  const river = `<div class="river">${p.discards.map((t) => tileHTML(t, '')).join('')}</div>`;
+  const river = `<div class="river">${p.discards.map((t, i) => tileHTML(t, i === p.discards.length - 1 ? 'last' : '')).join('')}</div>`;
 
   if (rel === 0) { el.innerHTML = plate + melds + river; return; }
   let backs = '';
@@ -1596,7 +1596,7 @@ const FAN_CN = { 'Base Win': '平胡', 'Self-Draw': '自摸', 'All Pungs': '碰�
   'Heavenly Hand': '天胡', 'Earthly Hand': '地胡' };
 function showResults(view) {
   const res = view.results;
-  const ranked = view.players.map((p) => p).slice().sort((a, b) => b.score - a.score);
+  const ranked = view.players.slice().sort((a, b) => b.score - a.score);
   let rows = '';
   for (const p of ranked) {
     const rec = res.records.find((r) => r.winner === p.seat);
@@ -1764,9 +1764,9 @@ function wireSetup() {
   document.querySelector('.mode-tabs').addEventListener('click', (e) => {
     const b = e.target.closest('button'); if (!b) return;
     document.querySelectorAll('.mode-tabs button').forEach((x) => x.classList.remove('on')); b.classList.add('on');
-    const online = b.dataset.tab === 'online';
-    $('local-setup').style.display = online ? 'none' : 'block';
-    $('online-setup').style.display = online ? 'block' : 'none';
+    const isOnlineTab = b.dataset.tab === 'online';
+    $('local-setup').style.display = isOnlineTab ? 'none' : 'block';
+    $('online-setup').style.display = isOnlineTab ? 'block' : 'none';
   });
   segWire('humans-seg', 'humans', localCfg, (x) => +x);
   segWire('diff-seg', 'diff', localCfg);

--- a/tests/core-sync.mjs
+++ b/tests/core-sync.mjs
@@ -1,0 +1,23 @@
+/* Guard: the engine region inlined into apps/mahjong/index.html must stay
+ * byte-identical to the canonical worker/src/mahjongCore.js. If this fails,
+ * run `node apps/mahjong/build-core.mjs`. Run from repo root. */
+import fs from 'node:fs';
+
+const re = /\/\/ ==CORE-START==[\s\S]*?\/\/ ==CORE-END==/;
+const core = fs.readFileSync('worker/src/mahjongCore.js', 'utf8').match(re);
+const html = fs.readFileSync('apps/mahjong/index.html', 'utf8').match(re);
+
+if (!core) { console.error('FAIL: CORE markers missing in worker/src/mahjongCore.js'); process.exit(1); }
+if (!html) { console.error('FAIL: CORE-INLINE region missing in apps/mahjong/index.html'); process.exit(1); }
+
+if (core[0] !== html[0]) {
+  const a = core[0], b = html[0];
+  let i = 0; while (i < a.length && i < b.length && a[i] === b[i]) i++;
+  console.error('FAIL: inlined core has drifted from the canonical engine.');
+  console.error(`First difference at offset ${i}:`);
+  console.error('  canonical: …' + JSON.stringify(a.slice(i, i + 60)));
+  console.error('  inlined:   …' + JSON.stringify(b.slice(i, i + 60)));
+  console.error('Fix: node apps/mahjong/build-core.mjs');
+  process.exit(1);
+}
+console.log(`core-sync OK — ${core[0].length} bytes identical in both files.`);

--- a/worker/CLAUDE.md
+++ b/worker/CLAUDE.md
@@ -44,6 +44,32 @@ can rejoin by name and reclaim their kart. Protocol lives in
 `apps/fablekart/index.html` (`netHandle`) and `apps/fablekart/VISION.md`.
 Rooms self-destruct via alarm after 45 min or when the last socket leaves.
 
+### Sichuan Mahjong rooms (`/mahjong/*` — NO Google auth, origin-gated like kart3)
+
+Unlike `Kart3Room` (an opaque relay), `MahjongRoom` (`src/mahjongroom.ts`) is
+**server-authoritative**: the DO runs the shared rules engine
+(`src/mahjongCore.js` — the *same* file the browser inlines for local play) and
+is the sole holder of hidden state. Each client is sent only its own redacted
+`viewFor()` snapshot, so no client ever sees another player's concealed tiles
+(the anti-cheat property a host-authoritative model can't give a hidden-info
+game). Hibernation-safe: the whole engine state lives in DO storage as plain
+JSON; every message loads → mutates → saves → broadcasts. Bots run server-side,
+paced by the alarm. Disconnect → that seat is taken over by a bot so the hand
+continues; the human can rejoin by name. 45-min idle TTL.
+
+- `POST /mahjong/rooms` → `{code}` — create a room
+- `GET /mahjong/rooms/:code` → `{exists, phase, players}` — status
+- `GET /mahjong/rooms/:code/ws` — WebSocket (registered BEFORE cors, same as kart3)
+
+Client protocol (`apps/mahjong/index.html`, `OnlineConnection`): `hello` →
+`welcome`; lobby `ready`/`config`/`start`/`rematch`; in-game `action` → server
+validates via the engine and replies `view` (redacted) or `reject`.
+
+**Engine sync:** `src/mahjongCore.js` is the canonical engine. The identical
+region (between `==CORE-START==`/`==CORE-END==`) is inlined into the app by
+`node apps/mahjong/build-core.mjs`; `node tests/core-sync.mjs` asserts no drift.
+Engine tests: `node worker/test/core.test.mjs`.
+
 ## Auth
 
 Google ID tokens are verified using Google's public JWKS keys via the Web Crypto API. The middleware checks:

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -199,7 +199,8 @@ app.post("/mahjong/rooms", async (c) => {
     for (const b of bytes) code += ROOM_ALPHABET[b % ROOM_ALPHABET.length];
     const stub = c.env.MAHJONG_ROOM.get(c.env.MAHJONG_ROOM.idFromName(code));
     const res = await stub.fetch("https://do/init", { method: "POST", body: code });
-    if (res.status !== 409) return c.json({ code });   // 409 = code already in use; try another
+    if (res.ok) return c.json({ code });   // only a confirmed init returns the code
+    // 409 = code already in use; any other non-ok = transient DO error → try a fresh code
   }
   return c.json({ error: "could not allocate a room, please try again" }, 503);
 });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { Kart3Room } from "./kart3room";
+import { MahjongRoom } from "./mahjongroom";
 
-export { Kart3Room };
+export { Kart3Room, MahjongRoom };
 
 const SESSION_TTL = 365 * 24 * 60 * 60; // 1 year in seconds
 const SESSION_PREFIX = "__session:";
@@ -12,6 +13,7 @@ type Bindings = {
   PHOTOS: R2Bucket;
   DB: D1Database;
   KART3_ROOM: DurableObjectNamespace;
+  MAHJONG_ROOM: DurableObjectNamespace;
   GOOGLE_CLIENT_ID: string;
   ALLOWED_EMAILS: string;
 };
@@ -132,6 +134,18 @@ app.get("/kart3/rooms/:code/ws", async (c) => {
   return stub.fetch("https://do/ws", c.req.raw);
 });
 
+// --- Sichuan Mahjong online rooms: WebSocket upgrade (server-authoritative) ---
+// Same origin-gated, code-as-credential model as kart3. Registered before cors
+// for the same reason (immutable 101 headers).
+app.get("/mahjong/rooms/:code/ws", async (c) => {
+  if (c.req.header("Upgrade") !== "websocket") return c.json({ error: "expected websocket" }, 426);
+  if (!kart3OriginOk(c.req.header("Origin"))) return c.json({ error: "forbidden" }, 403);
+  const code = c.req.param("code").toUpperCase();
+  if (!ROOM_CODE_RE.test(code)) return c.json({ error: "bad room code" }, 400);
+  const stub = c.env.MAHJONG_ROOM.get(c.env.MAHJONG_ROOM.idFromName(code));
+  return stub.fetch("https://do/ws", c.req.raw);
+});
+
 app.use("*", cors({
   // function form so any localhost port works for local development
   origin: (origin) => {
@@ -171,6 +185,26 @@ app.get("/kart3/rooms/:code", async (c) => {
     return c.json({ error: "bad room code" }, 400);
   }
   const stub = c.env.KART3_ROOM.get(c.env.KART3_ROOM.idFromName(code));
+  const res = await stub.fetch("https://do/status");
+  return c.json(await res.json());
+});
+
+// --- Sichuan Mahjong online rooms: create + status (CORS applies) ---
+app.post("/mahjong/rooms", async (c) => {
+  if (!kart3OriginOk(c.req.header("Origin"))) return c.json({ error: "forbidden" }, 403);
+  const bytes = new Uint8Array(5);
+  crypto.getRandomValues(bytes);
+  let code = "";
+  for (const b of bytes) code += ROOM_ALPHABET[b % ROOM_ALPHABET.length];
+  const stub = c.env.MAHJONG_ROOM.get(c.env.MAHJONG_ROOM.idFromName(code));
+  await stub.fetch("https://do/init", { method: "POST", body: code });
+  return c.json({ code });
+});
+
+app.get("/mahjong/rooms/:code", async (c) => {
+  const code = c.req.param("code").toUpperCase();
+  if (!ROOM_CODE_RE.test(code)) return c.json({ error: "bad room code" }, 400);
+  const stub = c.env.MAHJONG_ROOM.get(c.env.MAHJONG_ROOM.idFromName(code));
   const res = await stub.fetch("https://do/status");
   return c.json(await res.json());
 });

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -192,13 +192,16 @@ app.get("/kart3/rooms/:code", async (c) => {
 // --- Sichuan Mahjong online rooms: create + status (CORS applies) ---
 app.post("/mahjong/rooms", async (c) => {
   if (!kart3OriginOk(c.req.header("Origin"))) return c.json({ error: "forbidden" }, 403);
-  const bytes = new Uint8Array(5);
-  crypto.getRandomValues(bytes);
-  let code = "";
-  for (const b of bytes) code += ROOM_ALPHABET[b % ROOM_ALPHABET.length];
-  const stub = c.env.MAHJONG_ROOM.get(c.env.MAHJONG_ROOM.idFromName(code));
-  await stub.fetch("https://do/init", { method: "POST", body: code });
-  return c.json({ code });
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const bytes = new Uint8Array(5);
+    crypto.getRandomValues(bytes);
+    let code = "";
+    for (const b of bytes) code += ROOM_ALPHABET[b % ROOM_ALPHABET.length];
+    const stub = c.env.MAHJONG_ROOM.get(c.env.MAHJONG_ROOM.idFromName(code));
+    const res = await stub.fetch("https://do/init", { method: "POST", body: code });
+    if (res.status !== 409) return c.json({ code });   // 409 = code already in use; try another
+  }
+  return c.json({ error: "could not allocate a room, please try again" }, 503);
 });
 
 app.get("/mahjong/rooms/:code", async (c) => {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -202,6 +202,7 @@ app.post("/mahjong/rooms", async (c) => {
 });
 
 app.get("/mahjong/rooms/:code", async (c) => {
+  if (!kart3OriginOk(c.req.header("Origin"))) return c.json({ error: "forbidden" }, 403);
   const code = c.req.param("code").toUpperCase();
   if (!ROOM_CODE_RE.test(code)) return c.json({ error: "bad room code" }, 400);
   const stub = c.env.MAHJONG_ROOM.get(c.env.MAHJONG_ROOM.idFromName(code));

--- a/worker/src/mahjongCore.d.ts
+++ b/worker/src/mahjongCore.d.ts
@@ -1,0 +1,10 @@
+/* Type stubs for the pure JS engine core. The engine is exercised by
+ * worker/test/core.test.mjs at runtime; the DO treats it as `any`. */
+export const createGame: (opts?: any) => any;
+export const getLegalActions: (state: any, seat: number) => any[];
+export const pendingDeciders: (state: any) => number[];
+export const applyAction: (state: any, seat: number, action: any) => { ok: boolean; events?: any[]; error?: any };
+export const botChooseAction: (state: any, seat: number, difficulty?: string) => any;
+export const viewFor: (state: any, seat: number, opts?: any) => any;
+export const makeConfig: (overrides?: any) => any;
+export const DEFAULT_CONFIG: any;

--- a/worker/src/mahjongCore.js
+++ b/worker/src/mahjongCore.js
@@ -255,10 +255,13 @@ const winsNow = (player, config) => isWinningHand(player, config, null);
 function getWinningTiles(player, config, state = null) {
   const tiles = [];
   if (hasMissingSuitInCounts(player.concealed, player.missingSuit)) return tiles;
+  const pending = state && state.pendingDiscard ? state.pendingDiscard.tile : -1;
   for (let t = 0; t < NUM_TYPES; t++) {
     if (tileSuit(t) === player.missingSuit) continue;
     if (player.concealed[t] >= 4) continue;
-    if (state && remainingOf(state, t, player.seat) <= 0) continue;
+    // a tile with 0 unseen copies is unreachable — UNLESS it's the tile sitting on the
+    // table right now (the player can win on it this instant), so never filter that one out
+    if (state && t !== pending && remainingOf(state, t, player.seat) <= 0) continue;
     if (isWinningHand(player, config, t)) tiles.push(t);
   }
   return tiles;

--- a/worker/src/mahjongCore.js
+++ b/worker/src/mahjongCore.js
@@ -734,23 +734,23 @@ function score(state, seat, ctx) {
   if (ctx.winType === 'SELF_DRAW') add('Self-Draw', cfg.selfDrawBonusFan);
   if (sevenP) {
     add('Seven Pairs', cfg.sevenPairsFan);
+    // a quad in a seven-pairs hand is credited here as Luxury Seven Pairs (龙七对);
+    // it is NOT also counted as a Root below, which would double-credit the same tiles.
     let quads = 0; for (let t = 0; t < NUM_TYPES; t++) if (concealed[t] === 4) quads++;
     if (quads >= 1) add('Luxury Seven Pairs', cfg.luxurySevenPairsExtraFanPerQuad * quads);
   } else {
-    // all pungs: every meld is a pung/kong (Sichuan melds always are) AND concealed = triplets + pair
-    const meldsAllPung = p.melds.every((m) => true);
-    if (meldsAllPung && decomposeAllPungs(concealed, groupsNeeded)) add('All Pungs', cfg.allPungsFan);
+    // Sichuan has no chow melds, so every meld is already a pung/kong by construction
+    if (decomposeAllPungs(concealed, groupsNeeded)) add('All Pungs', cfg.allPungsFan);
+    // Root (根): four identical tiles in the hand (a kong, or 4 concealed) — standard hands only
+    let roots = 0;
+    for (let t = 0; t < NUM_TYPES; t++) {
+      let phys = concealed[t];
+      for (const m of p.melds) if (m.tile === t) phys += meldPhysical(m);
+      if (phys === 4) roots++;
+    }
+    if (roots > 0) add('Root', cfg.rootFan * roots);
   }
   if (suitsUsed.size === 1) add('Pure One Suit', cfg.pureOneSuitFan);
-
-  // root (gen): 4 physical copies of a type in the full hand
-  let roots = 0;
-  for (let t = 0; t < NUM_TYPES; t++) {
-    let phys = concealed[t];
-    for (const m of p.melds) if (m.tile === t) phys += meldPhysical(m);
-    if (phys === 4) roots++;
-  }
-  if (roots > 0) add('Root', cfg.rootFan * roots);
 
   if (ctx.afterKong && ctx.winType === 'SELF_DRAW') add('Kong Bloom', cfg.kongBloomBonusFan);
   if (ctx.winType === 'ROB_KONG') add('Robbing a Kong', cfg.robKongBonusFan);
@@ -1016,15 +1016,15 @@ function botChooseDiscard(state, seat, candidates, difficulty) {
   return best;
 }
 function tileDanger(state, seat, t) {
-  let danger = 0;
+  // a tile never seen in any river is more likely to be a live wait — count it ONCE
+  let seenRivers = 0;
+  for (const q of state.players) for (const d of q.discards) if (d === t) seenRivers++;
+  let danger = (seenRivers === 0 ? 0.5 : 0.1);
   for (let s = 0; s < 4; s++) {
     if (s === seat) continue;
     const o = state.players[s];
     if (o.hasWon) continue;
-    let seenRivers = 0;
-    for (const q of state.players) for (const d of q.discards) if (d === t) seenRivers++;
-    danger += (seenRivers === 0 ? 0.5 : 0.1);
-    if (o.missingSuit != null && tileSuit(t) === o.missingSuit) danger -= 0.4;
+    if (o.missingSuit != null && tileSuit(t) === o.missingSuit) danger -= 0.4;  // safe vs that opponent
   }
   return Math.max(0, danger);
 }

--- a/worker/src/mahjongCore.js
+++ b/worker/src/mahjongCore.js
@@ -718,7 +718,7 @@ function score(state, seat, ctx) {
 
   const sevenP = p.melds.length === 0 && cfg.allowSevenPairs && isSevenPairs(concealed, cfg);
 
-  add('Base Win', 0);
+  fanAwards.push({ name: 'Base Win', fan: 0 });   // 平胡 — always shown, contributes 0
   if (ctx.winType === 'SELF_DRAW') add('Self-Draw', cfg.selfDrawBonusFan);
   if (sevenP) {
     add('Seven Pairs', cfg.sevenPairsFan);

--- a/worker/src/mahjongCore.js
+++ b/worker/src/mahjongCore.js
@@ -395,6 +395,8 @@ function invalid(code, message, details, suggested) {
   return { ok: false, error: { code, message, details: details || '', suggestedActions: suggested || [] } };
 }
 function applyAction(state, seat, action) {
+  // reject malformed input cleanly (untrusted over the wire) — never throw
+  if (!action || typeof action.type !== 'string') return invalid('BAD_ACTION', 'Malformed action.');
   const legal = getLegalActions(state, seat);
   if (!legal.some((o) => actionsEqual(o, action))) {
     return invalid(...explainIllegal(state, seat, action));

--- a/worker/src/mahjongCore.js
+++ b/worker/src/mahjongCore.js
@@ -208,7 +208,7 @@ function isStandardShape(counts, groupsNeeded) {
   for (let p = 0; p < NUM_TYPES; p++) {
     if (counts[p] >= 2) {
       counts[p] -= 2;
-      const ok = canPartition(counts.slice(), groupsNeeded);
+      const ok = canPartition(counts, groupsNeeded);   // canPartition fully backtracks, so no copy needed
       counts[p] += 2;
       if (ok) return true;
     }
@@ -855,7 +855,12 @@ function viewFor(state, seat, opts = {}) {
       isBot: p.isBot,
       connected: p.connected,
       missingSuit: p.missingSuit,             // public after selection (default)
-      melds: p.melds.map((m) => ({ ...m, concealed: m.type === KONG_CONCEALED })),
+      // an opponent's concealed kong (暗杠) stays hidden until the hand ends — never
+      // leak its tile to other seats (this is a hidden-info game)
+      melds: p.melds.map((m) =>
+        (m.type === KONG_CONCEALED && p.seat !== seat && state.phase !== PHASE.HAND_ENDED)
+          ? { type: m.type, tile: -1, hidden: true }
+          : { ...m }),
       discards: p.discards.slice(),
       handCount: countTotal(p.concealed),
       hasWon: p.hasWon,
@@ -870,7 +875,7 @@ function viewFor(state, seat, opts = {}) {
     view.results = {
       reason: state.endReason,
       winners: state.winnersThisHand.slice(),
-      records: [].concat(...state.players.map((p) => p.winRecords)),
+      records: state.players.flatMap((p) => p.winRecords),
       scores: state.players.map((p) => p.score),
       nextDealer: state.nextDealer,
     };
@@ -1089,7 +1094,7 @@ function botChooseMeld(state, seat, pung, kong, difficulty) {
   // simulate removing `remove` copies into a meld; return resulting shanten + tenpai
   const evalClaim = (remove) => {
     const snap = p.concealed.slice(), msnap = p.melds.map((m) => ({ ...m }));
-    p.concealed[tile] -= remove; p.melds.push({ type: PUNG, tile });
+    p.concealed[tile] -= remove; p.melds.push({ type: remove === 2 ? PUNG : KONG_EXPOSED_FROM_DISCARD, tile });
     const after = shantenOf(p), ready = isReady(p, state.config);
     p.concealed = snap; p.melds = msnap;
     return { after, ready };

--- a/worker/src/mahjongCore.js
+++ b/worker/src/mahjongCore.js
@@ -33,7 +33,6 @@ const NUM_TYPES = 27;
 
 const emptyCounts = () => new Array(NUM_TYPES).fill(0);
 const countTotal = (c) => { let s = 0; for (let i = 0; i < NUM_TYPES; i++) s += c[i]; return s; };
-const countsToList = (c) => { const a = []; for (let t = 0; t < NUM_TYPES; t++) for (let i = 0; i < c[t]; i++) a.push(t); return a; };
 
 /* ---- deterministic RNG (mulberry32). state.rng is a serializable integer ---- */
 function rngNext(state) {
@@ -1003,6 +1002,7 @@ function botChooseDiscard(state, seat, candidates, difficulty) {
   const miss = candidates.filter((t) => tileSuit(t) === p.missingSuit);
   if (miss.length) candidates = miss;                       // forced clear first
   if (difficulty === 'easy' && rngNext(state) < 0.35) return candidates[rngInt(state, candidates.length)];
+  const danger = difficulty === 'hard' ? opponentDanger(state, seat) : 0;   // constant across candidates — hoisted
   let best = candidates[0], bestScore = -Infinity;
   for (const t of candidates) {
     p.concealed[t]--;
@@ -1010,7 +1010,7 @@ function botChooseDiscard(state, seat, candidates, difficulty) {
     const accept = (difficulty !== 'easy') ? ukeireOf(state, p) : 0;
     p.concealed[t]++;
     let sc = -sh * 1000 + accept * 4 + discardPreference(p, t);
-    if (difficulty === 'hard') sc -= tileDanger(state, seat, t) * 60 * opponentDanger(state, seat);
+    if (difficulty === 'hard') sc -= tileDanger(state, seat, t) * 60 * danger;
     if (sc > bestScore) { bestScore = sc; best = t; }
   }
   return best;
@@ -1083,29 +1083,33 @@ function botChooseMeld(state, seat, pung, kong, difficulty) {
   if (tileSuit(tile) === p.missingSuit) return null;
   if (difficulty === 'easy') { if (rngNext(state) < 0.45) return null; return pung || kong; }
   const before = shantenOf(p);
-  const snap = p.concealed.slice(), msnap = p.melds.map((m) => ({ ...m }));
-  if (kong && !pung) { p.concealed[tile] -= 3; p.melds.push({ type: PUNG, tile }); }
-  else { p.concealed[tile] -= 2; p.melds.push({ type: PUNG, tile }); }
-  const after = shantenOf(p);
-  const ready = isReady(p, state.config);
-  p.concealed = snap; p.melds = msnap;
-  if (kong && !pung) {
-    if (after < before || ready) return kong;
-    return difficulty === 'hard' ? (after <= before ? kong : null) : (after < before ? kong : null);
+  // simulate removing `remove` copies into a meld; return resulting shanten + tenpai
+  const evalClaim = (remove) => {
+    const snap = p.concealed.slice(), msnap = p.melds.map((m) => ({ ...m }));
+    p.concealed[tile] -= remove; p.melds.push({ type: PUNG, tile });
+    const after = shantenOf(p), ready = isReady(p, state.config);
+    p.concealed = snap; p.melds = msnap;
+    return { after, ready };
+  };
+  // primary claim decision uses the pung (keeps a spare); fall back to kong if no pung
+  const primary = pung ? evalClaim(2) : evalClaim(3);
+  const claimGood = primary.after < before || primary.ready;
+  if (!claimGood) {
+    if (difficulty === 'hard') return null;
+    return primary.after <= before && rngNext(state) < 0.25 ? (pung || kong) : null;
   }
-  if (after < before || ready) {
-    if (difficulty === 'hard' && after >= before && opponentDanger(state, seat) > 0.6) return null;
-    return pung;
-  }
-  if (difficulty === 'hard') return null;
-  return after <= before && rngNext(state) < 0.25 ? pung : null;
+  if (difficulty === 'hard' && primary.after >= before && opponentDanger(state, seat) > 0.6) return null;
+  // both offered (3 in hand): take the kong for its replacement draw when the spare
+  // tile the pung would keep isn't improving the hand anyway.
+  if (pung && kong && evalClaim(3).after <= primary.after) return kong;
+  return pung || kong;
 }
 
 // ==CORE-END== (synced region)
 
 export {
   DOT, BAMBOO, CHARACTER, SUIT_GLYPH, SUIT_NAME, NUM_TYPES,
-  tileIndex, tileSuit, tileRank, emptyCounts, countTotal, countsToList,
+  tileIndex, tileSuit, tileRank, emptyCounts, countTotal,
   DEFAULT_CONFIG, makeConfig, createGame,
   getLegalActions, pendingDeciders, applyAction, actionsEqual,
   isWinningHand, winsNow, getWinningTiles, isReady, isSevenPairs,

--- a/worker/src/mahjongCore.js
+++ b/worker/src/mahjongCore.js
@@ -1010,7 +1010,17 @@ function discardPreference(player, t) {
 function botChooseDiscard(state, seat, candidates, difficulty) {
   const p = state.players[seat];
   const miss = candidates.filter((t) => tileSuit(t) === p.missingSuit);
-  if (miss.length) candidates = miss;                       // forced clear first
+  if (miss.length) {
+    // forced clear: these tiles are all leaving regardless, and their within-suit
+    // connectivity (which shanten zeroes out anyway) is a meaningless tiebreaker.
+    // Hard bots dump the safest one; others just take the lowest deterministically.
+    if (difficulty === 'hard') {
+      let best = miss[0], bd = Infinity;
+      for (const t of miss) { const d = tileDanger(state, seat, t); if (d < bd) { bd = d; best = t; } }
+      return best;
+    }
+    return miss[0];
+  }
   if (difficulty === 'easy' && rngNext(state) < 0.35) return candidates[rngInt(state, candidates.length)];
   const danger = difficulty === 'hard' ? opponentDanger(state, seat) : 0;   // constant across candidates — hoisted
   let best = candidates[0], bestScore = -Infinity;

--- a/worker/src/mahjongCore.js
+++ b/worker/src/mahjongCore.js
@@ -1,0 +1,1096 @@
+/* =====================================================================
+ * Sichuan Mahjong — Bloody Battle (血战到底) Rules Engine Core
+ * =====================================================================
+ * Pure, deterministic, config-driven state machine. NO DOM, NO I/O.
+ * Implements mahjong.txt (the formal spec) §1–27.
+ *
+ * This exact file is the single source of truth. The identical region
+ * between CORE-START and CORE-END is inlined into apps/mahjong/index.html;
+ * tests/core-sync.mjs asserts the two never drift. Only the `export`
+ * block at the very bottom is worker-only.
+ *
+ * Design contract (so the same core backs LOCAL hot-seat AND online):
+ *   - createGame(config, seed) -> state          (JSON-serializable)
+ *   - getLegalActions(state, seat) -> Action[]    (the ONLY things allowed)
+ *   - applyAction(state, seat, action) -> {ok, events, error}
+ *   - The core AUTO-ADVANCES through draws and empty reaction windows;
+ *     it stops only when a human/bot decision is actually required, i.e.
+ *     whenever some seat has a non-empty getLegalActions(). Bots are a
+ *     DRIVER concern (botChooseAction), never called by the core.
+ *   - viewFor(state, seat) -> redacted view (hides other hands) for render.
+ * ===================================================================== */
+
+// ==CORE-START== (synced region — keep identical with index.html)
+
+/* ---- tile model: suit 0=DOT(筒) 1=BAMBOO(条) 2=CHARACTER(萬), rank 1..9 ---- */
+const DOT = 0, BAMBOO = 1, CHARACTER = 2;
+const SUIT_GLYPH = ['筒', '条', '萬'];
+const SUIT_NAME = ['Dots', 'Bamboo', 'Characters'];
+const tileIndex = (suit, rank) => suit * 9 + (rank - 1);
+const tileSuit = (t) => (t / 9) | 0;
+const tileRank = (t) => (t % 9) + 1;
+const NUM_TYPES = 27;
+
+const emptyCounts = () => new Array(NUM_TYPES).fill(0);
+const countTotal = (c) => { let s = 0; for (let i = 0; i < NUM_TYPES; i++) s += c[i]; return s; };
+const countsToList = (c) => { const a = []; for (let t = 0; t < NUM_TYPES; t++) for (let i = 0; i < c[t]; i++) a.push(t); return a; };
+
+/* ---- deterministic RNG (mulberry32). state.rng is a serializable integer ---- */
+function rngNext(state) {
+  let x = (state.rng + 0x6D2B79F5) | 0;
+  state.rng = x;
+  x = Math.imul(x ^ (x >>> 15), 1 | x);
+  x = (x + Math.imul(x ^ (x >>> 7), 61 | x)) ^ x;
+  return ((x ^ (x >>> 14)) >>> 0) / 4294967296;
+}
+function rngInt(state, n) { return (rngNext(state) * n) | 0; }
+
+/* ---- default table rules (spec §21.4 / §26 "common digital rules") ---- */
+const DEFAULT_CONFIG = {
+  allowSevenPairs: true,
+  fourOfKindCountsAsTwoPairs: true,
+  mustDiscardMissingSuitFirst: true,
+  allowMeldsInMissingSuit: false,
+  allowKongInMissingSuit: false,
+  allowMultipleWinnersOnDiscard: true,
+  allowRobKong: true,
+  allowMultipleRobKongWinners: true,
+  wonPlayersExcludedFromFuturePayments: true,
+  fanLimit: 3,
+  baseWinPoints: 1,
+  selfDrawBonusFan: 1,
+  robKongBonusFan: 1,
+  kongBloomBonusFan: 1,
+  rootFan: 1,
+  allPungsFan: 1,
+  pureOneSuitFan: 2,
+  sevenPairsFan: 2,
+  luxurySevenPairsExtraFanPerQuad: 1,
+  lastTileFan: 1,
+  heavenlyEarthlyFan: 3,       // table-limit
+  enableMissingSuitPenaltyAtExhaustion: true,
+  missingSuitPenalty: 2,
+  kongExposedFromDiscard: 2,   // discarder pays
+  kongAdded: 1,                // each non-won opponent pays
+  kongConcealed: 2,            // each non-won opponent pays
+  mode: 'bloody',              // 'bloody' | 'single'
+};
+
+/* ---- meld types ---- */
+const PUNG = 'PUNG';
+const KONG_EXPOSED_FROM_DISCARD = 'KONG_EXPOSED_FROM_DISCARD';
+const KONG_ADDED = 'KONG_ADDED';
+const KONG_CONCEALED = 'KONG_CONCEALED';
+const isKong = (m) => m.type !== PUNG;
+const meldPhysical = (m) => (m.type === PUNG ? 3 : 4);
+
+/* ---- phases (spec §18) ---- */
+const PHASE = {
+  MISSING_SUIT: 'MISSING_SUIT_SELECTION',
+  ACTIVE_TURN: 'ACTIVE_TURN',
+  DISCARD_REACT: 'AWAITING_DISCARD_REACTIONS',
+  ROB_REACT: 'AWAITING_ROB_KONG_REACTIONS',
+  HAND_ENDED: 'HAND_ENDED',
+};
+
+/* =====================================================================
+ * Game creation & dealing
+ * ===================================================================== */
+function makeConfig(overrides) { return Object.assign({}, DEFAULT_CONFIG, overrides || {}); }
+
+function createGame(opts = {}) {
+  const config = makeConfig(opts.config);
+  const seed = (opts.seed != null ? opts.seed : 0x1a2b3c4d) | 0;
+  const dealer = (opts.dealer || 0) % 4;
+  const names = opts.names || ['East', 'South', 'West', 'North'];
+  const seats = opts.seats || [
+    { isBot: false, difficulty: 'normal' },
+    { isBot: true, difficulty: 'normal' },
+    { isBot: true, difficulty: 'normal' },
+    { isBot: true, difficulty: 'normal' },
+  ];
+
+  const state = {
+    config, seed, rng: seed, handNo: opts.handNo || 1,
+    phase: PHASE.MISSING_SUIT, dealer, active: dealer,
+    wall: [], wallHead: 0, wallTail: 0,
+    players: [],
+    pendingDiscard: null, reactions: null, robReactions: null,
+    turnFlags: { needsDraw: false, drewFromKong: false, lastDrawn: null, firstTurn: false, lastTileExhausted: false },
+    firstDiscardDone: false,
+    winnersThisHand: [],
+    log: [],
+    ended: false, endReason: null,
+    seatScores: opts.seatScores || [0, 0, 0, 0],   // carry running scores across hands
+  };
+
+  for (let i = 0; i < 4; i++) {
+    state.players.push({
+      seat: i,
+      name: names[i] || ('P' + (i + 1)),
+      isBot: seats[i] ? !!seats[i].isBot : true,
+      difficulty: seats[i] ? (seats[i].difficulty || 'normal') : 'normal',
+      connected: true,
+      concealed: emptyCounts(),
+      melds: [],
+      discards: [],
+      missingSuit: null,
+      hasWon: false,
+      winOrder: null,
+      winRecords: [],
+      score: state.seatScores[i] || 0,
+      isDealer: i === dealer,
+    });
+  }
+
+  // build & shuffle the 108-tile wall (spec §3.1)
+  const wall = [];
+  for (let suit = 0; suit < 3; suit++)
+    for (let rank = 1; rank <= 9; rank++)
+      for (let k = 0; k < 4; k++) wall.push(tileIndex(suit, rank));
+  for (let i = wall.length - 1; i > 0; i--) {
+    const j = rngInt(state, i + 1);
+    const tmp = wall[i]; wall[i] = wall[j]; wall[j] = tmp;
+  }
+  state.wall = wall;
+  state.wallHead = 0;
+  state.wallTail = wall.length;
+  logEvent(state, { type: 'WallShuffled', seed });
+
+  // deal: dealer 14, others 13 (spec §3.2)
+  for (let i = 0; i < 4; i++) {
+    const p = state.players[(dealer + i) % 4];
+    const n = p.isDealer ? 14 : 13;
+    for (let k = 0; k < n; k++) p.concealed[drawFront(state)]++;
+  }
+  logEvent(state, { type: 'TilesDealt' });
+
+  // dealer keeps the 14th and acts first WITHOUT drawing (enables Heavenly Hand)
+  state.turnFlags.needsDraw = false;
+  state.turnFlags.firstTurn = true;
+  return state;
+}
+
+function drawFront(state) {
+  if (state.wallHead >= state.wallTail) return -1;
+  return state.wall[state.wallHead++];
+}
+function drawBack(state) {
+  if (state.wallTail <= state.wallHead) return -1;
+  return state.wall[--state.wallTail];
+}
+const wallRemaining = (state) => state.wallTail - state.wallHead;
+
+function logEvent(state, ev) { state.log.push(ev); return ev; }
+
+/* =====================================================================
+ * Winning-hand validation (spec §7)
+ * ===================================================================== */
+function canPartition(counts, groupsNeeded) {
+  let i = 0; while (i < NUM_TYPES && counts[i] === 0) i++;
+  if (i === NUM_TYPES) return groupsNeeded === 0;
+  if (groupsNeeded === 0) return false;
+  // pung
+  if (counts[i] >= 3) {
+    counts[i] -= 3;
+    if (canPartition(counts, groupsNeeded - 1)) { counts[i] += 3; return true; }
+    counts[i] += 3;
+  }
+  // chow (same suit, consecutive) — allowed in concealed shape only
+  const r = i % 9;
+  if (r <= 6 && counts[i + 1] > 0 && counts[i + 2] > 0) {
+    counts[i]--; counts[i + 1]--; counts[i + 2]--;
+    if (canPartition(counts, groupsNeeded - 1)) { counts[i]++; counts[i + 1]++; counts[i + 2]++; return true; }
+    counts[i]++; counts[i + 1]++; counts[i + 2]++;
+  }
+  return false;
+}
+function isStandardShape(counts, groupsNeeded) {
+  for (let p = 0; p < NUM_TYPES; p++) {
+    if (counts[p] >= 2) {
+      counts[p] -= 2;
+      const ok = canPartition(counts.slice(), groupsNeeded);
+      counts[p] += 2;
+      if (ok) return true;
+    }
+  }
+  return false;
+}
+function isSevenPairs(counts, config) {
+  if (countTotal(counts) !== 14) return false;
+  let pairs = 0;
+  for (let t = 0; t < NUM_TYPES; t++) {
+    const c = counts[t];
+    if (c === 1 || c === 3) return false;
+    if (c === 2) pairs += 1;
+    if (c === 4) pairs += (config.fourOfKindCountsAsTwoPairs ? 2 : -100);
+  }
+  return pairs === 7;
+}
+function hasMissingSuitInCounts(counts, missingSuit) {
+  if (missingSuit == null) return false;
+  for (let r = 0; r < 9; r++) if (counts[missingSuit * 9 + r] > 0) return true;
+  return false;
+}
+/* Does player p's concealed counts (already at winning size) form a legal win? */
+function isWinningCounts(counts, melds, missingSuit, config) {
+  if (hasMissingSuitInCounts(counts, missingSuit)) return false;
+  const groupsNeeded = 4 - melds.length;
+  const total = countTotal(counts);
+  if (total !== groupsNeeded * 3 + 2) return false;
+  if (melds.length === 0 && config.allowSevenPairs && isSevenPairs(counts, config)) return true;
+  return isStandardShape(counts.slice(), groupsNeeded);
+}
+/* Player-level helper: would adding `tile` (or nothing) make a win? */
+function isWinningHand(player, config, addTile = null) {
+  const c = player.concealed.slice();
+  if (addTile != null) {
+    if (tileSuit(addTile) === player.missingSuit) return false;
+    c[addTile]++;
+  }
+  return isWinningCounts(c, player.melds, player.missingSuit, config);
+}
+const winsNow = (player, config) => isWinningHand(player, config, null);
+
+/* ---- ready / ting detection (spec §16) ---- */
+function getWinningTiles(player, config, state = null) {
+  const tiles = [];
+  if (hasMissingSuitInCounts(player.concealed, player.missingSuit)) return tiles;
+  for (let t = 0; t < NUM_TYPES; t++) {
+    if (tileSuit(t) === player.missingSuit) continue;
+    if (player.concealed[t] >= 4) continue;
+    if (state && remainingOf(state, t, player.seat) <= 0) continue;
+    if (isWinningHand(player, config, t)) tiles.push(t);
+  }
+  return tiles;
+}
+const isReady = (player, config, state = null) => getWinningTiles(player, config, state).length > 0;
+
+/* count of tile-type t not visible to seat `me` (public info + own hand) */
+function remainingOf(state, t, me) {
+  let seen = 0;
+  for (let s = 0; s < 4; s++) {
+    const p = state.players[s];
+    if (s === me) seen += p.concealed[t];
+    for (const m of p.melds) if (m.tile === t) seen += meldPhysical(m);
+    for (const d of p.discards) if (d === t) seen++;
+  }
+  if (state.pendingDiscard && state.pendingDiscard.tile === t) seen++;
+  return 4 - seen;
+}
+
+/* =====================================================================
+ * Legal-action generation (spec §17)
+ * Action shapes:
+ *   {type:'ChooseMissingSuit', suit}
+ *   {type:'Discard', tile}      {type:'Pass'}
+ *   {type:'ClaimPung', tile}    {type:'ClaimKongFromDiscard', tile}
+ *   {type:'DeclareConcealedKong', tile}  {type:'DeclareAddedKong', tile}
+ *   {type:'DeclareWinFromDiscard', tile} {type:'DeclareSelfDrawWin'}
+ *   {type:'RobKong', tile}
+ * ===================================================================== */
+const missingCount = (p) => {
+  if (p.missingSuit == null) return 0;
+  let s = 0; for (let r = 0; r < 9; r++) s += p.concealed[p.missingSuit * 9 + r]; return s;
+};
+function legalDiscards(player, config) {
+  const out = [];
+  const holdsMissing = missingCount(player) > 0;
+  for (let t = 0; t < NUM_TYPES; t++) {
+    if (player.concealed[t] === 0) continue;
+    if (config.mustDiscardMissingSuitFirst && holdsMissing && tileSuit(t) !== player.missingSuit) continue;
+    out.push(t);
+  }
+  return out;
+}
+
+function getLegalActions(state, seat) {
+  const p = state.players[seat];
+  if (state.phase === PHASE.HAND_ENDED) return [];
+  if (p.hasWon) return [];
+
+  if (state.phase === PHASE.MISSING_SUIT) {
+    if (p.missingSuit != null) return [];
+    return [
+      { type: 'ChooseMissingSuit', suit: DOT },
+      { type: 'ChooseMissingSuit', suit: BAMBOO },
+      { type: 'ChooseMissingSuit', suit: CHARACTER },
+    ];
+  }
+
+  if (state.phase === PHASE.ACTIVE_TURN) {
+    if (seat !== state.active) return [];
+    const acts = [];
+    const holdsMissing = missingCount(p) > 0;
+    const justDrew = state.turnFlags.lastDrawn != null || state.turnFlags.firstTurn;
+    // self-draw win
+    if (!holdsMissing && justDrew && winsNow(p, state.config)) acts.push({ type: 'DeclareSelfDrawWin' });
+    if (!holdsMissing && !state.turnFlags.afterPung) {
+      // concealed kong
+      for (let t = 0; t < NUM_TYPES; t++) {
+        if (p.concealed[t] === 4 && (state.config.allowKongInMissingSuit || tileSuit(t) !== p.missingSuit))
+          acts.push({ type: 'DeclareConcealedKong', tile: t });
+      }
+      // added kong (upgrade an exposed pung)
+      for (const m of p.melds) {
+        if (m.type === PUNG && p.concealed[m.tile] >= 1 &&
+            (state.config.allowKongInMissingSuit || tileSuit(m.tile) !== p.missingSuit))
+          acts.push({ type: 'DeclareAddedKong', tile: m.tile });
+      }
+    }
+    for (const t of legalDiscards(p, state.config)) acts.push({ type: 'Discard', tile: t });
+    return acts;
+  }
+
+  if (state.phase === PHASE.DISCARD_REACT) {
+    const r = state.reactions;
+    if (!r || r.discarder === seat || r.responses[seat] != null || !r.eligible.includes(seat)) return [];
+    const tile = r.tile;
+    const acts = [];
+    const holdsMissing = missingCount(p) > 0;
+    if (!holdsMissing && tileSuit(tile) !== p.missingSuit && isWinningHand(p, state.config, tile))
+      acts.push({ type: 'DeclareWinFromDiscard', tile });
+    const meldOk = !holdsMissing && (state.config.allowMeldsInMissingSuit || tileSuit(tile) !== p.missingSuit);
+    if (meldOk && p.concealed[tile] >= 3) acts.push({ type: 'ClaimKongFromDiscard', tile });
+    if (meldOk && p.concealed[tile] >= 2) acts.push({ type: 'ClaimPung', tile });
+    acts.push({ type: 'Pass' });
+    return acts;
+  }
+
+  if (state.phase === PHASE.ROB_REACT) {
+    const r = state.robReactions;
+    if (!r || r.declarer === seat || r.responses[seat] != null || !r.eligible.includes(seat)) return [];
+    const tile = r.tile;
+    const acts = [];
+    if (state.config.allowRobKong && tileSuit(tile) !== p.missingSuit && isWinningHand(p, state.config, tile))
+      acts.push({ type: 'RobKong', tile });
+    acts.push({ type: 'Pass' });
+    return acts;
+  }
+
+  return [];
+}
+
+/* Seats that currently owe a decision (driver: prompt humans, run bots). */
+function pendingDeciders(state) {
+  const out = [];
+  if (state.phase === PHASE.HAND_ENDED) return out;
+  for (let s = 0; s < 4; s++) if (getLegalActions(state, s).length > 0) out.push(s);
+  return out;
+}
+
+const actionsEqual = (a, b) =>
+  a && b && a.type === b.type && (a.tile ?? -1) === (b.tile ?? -1) && (a.suit ?? -1) === (b.suit ?? -1);
+
+/* =====================================================================
+ * applyAction — validates via getLegalActions, mutates state, cascades
+ * through auto-advances, returns {ok, events, error}.
+ * ===================================================================== */
+function invalid(code, message, details, suggested) {
+  return { ok: false, error: { code, message, details: details || '', suggestedActions: suggested || [] } };
+}
+function applyAction(state, seat, action) {
+  const legal = getLegalActions(state, seat);
+  if (!legal.some((o) => actionsEqual(o, action))) {
+    return invalid(...explainIllegal(state, seat, action));
+  }
+  const before = state.log.length;
+  switch (action.type) {
+    case 'ChooseMissingSuit': doChooseMissing(state, seat, action.suit); break;
+    case 'Discard': doDiscard(state, seat, action.tile); break;
+    case 'Pass': doReactionResponse(state, seat, action); break;
+    case 'ClaimPung': doReactionResponse(state, seat, action); break;
+    case 'ClaimKongFromDiscard': doReactionResponse(state, seat, action); break;
+    case 'DeclareWinFromDiscard': doReactionResponse(state, seat, action); break;
+    case 'RobKong': doRobResponse(state, seat, action); break;
+    case 'DeclareConcealedKong': doConcealedKong(state, seat, action.tile); break;
+    case 'DeclareAddedKong': doAddedKong(state, seat, action.tile); break;
+    case 'DeclareSelfDrawWin': doSelfDrawWin(state, seat); break;
+    default: return invalid('UNKNOWN_ACTION', 'Unknown action.');
+  }
+  return { ok: true, events: state.log.slice(before) };
+}
+
+/* ---- missing-suit selection (spec §3.3) ---- */
+function doChooseMissing(state, seat, suit) {
+  const p = state.players[seat];
+  p.missingSuit = suit;
+  logEvent(state, { type: 'MissingSuitChosen', seat, suit });
+  if (state.players.every((q) => q.missingSuit != null)) {
+    // begin play: dealer acts first with 14 tiles, no draw
+    state.phase = PHASE.ACTIVE_TURN;
+    state.active = state.dealer;
+    state.turnFlags = { needsDraw: false, drewFromKong: false, lastDrawn: null, firstTurn: true, afterPung: false, lastTileExhausted: false };
+  }
+}
+
+/* ---- begin a fresh turn for `seat`: draw (unless suppressed), maybe end ---- */
+function beginTurn(state, seat, { draw = true, fromKong = false, afterPung = false } = {}) {
+  // skip won players
+  let guard = 0;
+  while (state.players[seat].hasWon) {
+    seat = (seat + 1) % 4;
+    if (++guard > 4) { endHand(state, 'exhaustion'); return; }
+  }
+  state.active = seat;
+  state.turnFlags = { needsDraw: false, drewFromKong: fromKong, lastDrawn: null, firstTurn: false, afterPung, lastTileExhausted: false };
+  if (draw) {
+    if (wallRemaining(state) <= 0) { endHand(state, 'exhaustion'); return; }
+    const t = fromKong ? drawBack(state) : drawFront(state);
+    state.players[seat].concealed[t]++;
+    state.turnFlags.lastDrawn = t;
+    state.turnFlags.lastTileExhausted = wallRemaining(state) <= 0;
+    logEvent(state, { type: fromKong ? 'ReplacementTileDrawn' : 'TileDrawn', seat, tile: t });
+  }
+  state.phase = PHASE.ACTIVE_TURN;
+}
+
+/* next non-won seat after `from` (exclusive). returns -1 if none. */
+function nextActiveSeat(state, from) {
+  for (let k = 1; k <= 4; k++) {
+    const s = (from + k) % 4;
+    if (!state.players[s].hasWon) return s;
+  }
+  return -1;
+}
+const nonWonCount = (state) => state.players.filter((p) => !p.hasWon).length;
+
+/* ---- discard (spec §6.3) ---- */
+function commitDiscardToPile(state) {
+  // move the pending discard into the discarder's river (unclaimed); §19 keeps the
+  // pending slot and the pile as distinct terms, so the tile lives in exactly one.
+  const pd = state.pendingDiscard;
+  if (!pd) return;
+  state.players[pd.discarder].discards.push(pd.tile);
+  state.pendingDiscard = null;
+}
+function doDiscard(state, seat, tile) {
+  const p = state.players[seat];
+  p.concealed[tile]--;
+  const wasFirstDiscard = !state.firstDiscardDone;
+  const dealerFirstDiscard = wasFirstDiscard && seat === state.dealer;
+  state.firstDiscardDone = true;
+  state.turnFlags.afterPung = false;
+  const cameFromKongDiscard = state.turnFlags.drewFromKong; // 杠上炮 attribution
+  state.pendingDiscard = { tile, discarder: seat, dealerFirstDiscard, afterKong: cameFromKongDiscard, lastTile: wallRemaining(state) <= 0 };
+  logEvent(state, { type: 'TileDiscarded', seat, tile });
+
+  // who can react? (non-won, non-discarder with a real option)
+  const eligible = [];
+  for (let k = 1; k <= 3; k++) {
+    const s = (seat + k) % 4;
+    const q = state.players[s];
+    if (q.hasWon) continue;
+    const opts = reactionOptions(state, s, tile);
+    if (opts.win || opts.kong || opts.pung) eligible.push(s);
+  }
+  if (eligible.length === 0) { commitDiscardToPile(state); beginTurn(state, nextActiveSeat(state, seat)); return; }
+  state.phase = PHASE.DISCARD_REACT;
+  state.reactions = { tile, discarder: seat, eligible, responses: {} };
+}
+function reactionOptions(state, seat, tile) {
+  const p = state.players[seat];
+  const holdsMissing = missingCount(p) > 0;
+  const meldOk = !holdsMissing && (state.config.allowMeldsInMissingSuit || tileSuit(tile) !== p.missingSuit);
+  return {
+    win: !holdsMissing && tileSuit(tile) !== p.missingSuit && isWinningHand(p, state.config, tile),
+    kong: meldOk && p.concealed[tile] >= 3,
+    pung: meldOk && p.concealed[tile] >= 2,
+  };
+}
+
+/* ---- record a discard-reaction response; resolve when all responded ---- */
+function doReactionResponse(state, seat, action) {
+  state.reactions.responses[seat] = action;
+  if (action.type !== 'Pass') logEvent(state, { type: 'Reaction', seat, action: action.type });
+  const r = state.reactions;
+  if (r.eligible.every((s) => r.responses[s] != null)) resolveDiscardReactions(state);
+}
+function resolveDiscardReactions(state) {
+  const r = state.reactions;
+  const tile = r.tile, discarder = r.discarder;
+  const pd = state.pendingDiscard;
+  // 1) wins (possibly multiple) — highest priority
+  const winners = r.eligible.filter((s) => r.responses[s] && r.responses[s].type === 'DeclareWinFromDiscard');
+  if (winners.length) {
+    const ordered = state.config.allowMultipleWinnersOnDiscard ? winners : [nearestInOrder(discarder, winners)];
+    state.reactions = null;
+    commitDiscardToPile(state);   // the won tile stays visible in the river, counted once
+    for (const w of ordered) {
+      // The winning tile is scored VIRTUALLY (not added to concealed) so one physical
+      // tile can feed multiple winners without breaking conservation (spec §19, §10.1).
+      const ctx = { winType: 'DISCARD', winningTile: tile, source: discarder, lastTile: pd.lastTile, afterKong: pd.afterKong, isEarthly: pd.dealerFirstDiscard && w !== state.dealer };
+      resolveWin(state, w, ctx);
+    }
+    if (!checkHandEnd(state)) beginTurn(state, nextActiveSeat(state, discarder));
+    return;
+  }
+  // 2) kong (only one possible holder) — tile is consumed into the meld
+  const konger = r.eligible.find((s) => r.responses[s] && r.responses[s].type === 'ClaimKongFromDiscard');
+  if (konger != null) { state.reactions = null; state.pendingDiscard = null; claimKongFromDiscard(state, konger, tile, discarder); return; }
+  // 3) pung (only one possible holder) — tile is consumed into the meld
+  const punger = r.eligible.find((s) => r.responses[s] && r.responses[s].type === 'ClaimPung');
+  if (punger != null) { state.reactions = null; state.pendingDiscard = null; claimPung(state, punger, tile, discarder); return; }
+  // 4) all pass — tile joins the river
+  state.reactions = null;
+  commitDiscardToPile(state);
+  beginTurn(state, nextActiveSeat(state, discarder));
+}
+function nearestInOrder(from, list) {
+  for (let k = 1; k <= 3; k++) { const s = (from + k) % 4; if (list.includes(s)) return s; }
+  return list[0];
+}
+
+/* ---- claim pung (spec §6.5): take discard, expose, must discard ---- */
+function claimPung(state, seat, tile, discarder) {
+  const p = state.players[seat];
+  p.concealed[tile] -= 2;
+  p.melds.push({ type: PUNG, tile, source: discarder, concealed: false });
+  logEvent(state, { type: 'PungClaimed', seat, tile, source: discarder });
+  state.active = seat;
+  state.phase = PHASE.ACTIVE_TURN;
+  state.turnFlags = { needsDraw: false, drewFromKong: false, lastDrawn: null, firstTurn: false, afterPung: true, lastTileExhausted: false };
+}
+
+/* ---- exposed kong from discard (spec §6.6) ---- */
+function claimKongFromDiscard(state, seat, tile, discarder) {
+  const p = state.players[seat];
+  p.concealed[tile] -= 3;
+  p.melds.push({ type: KONG_EXPOSED_FROM_DISCARD, tile, source: discarder, concealed: false });
+  logEvent(state, { type: 'KongClaimedFromDiscard', seat, tile, source: discarder });
+  payKong(state, seat, KONG_EXPOSED_FROM_DISCARD, discarder);
+  beginTurn(state, seat, { draw: true, fromKong: true });   // replacement draw, may win/kong/discard
+}
+
+/* ---- concealed kong (spec §6.7) ---- */
+function doConcealedKong(state, seat, tile) {
+  const p = state.players[seat];
+  p.concealed[tile] -= 4;
+  p.melds.push({ type: KONG_CONCEALED, tile, source: null, concealed: true });
+  logEvent(state, { type: 'ConcealedKongDeclared', seat, tile });
+  payKong(state, seat, KONG_CONCEALED, null);
+  beginTurn(state, seat, { draw: true, fromKong: true });
+}
+
+/* ---- added kong (spec §6.8) with rob window (spec §6.9) ---- */
+function doAddedKong(state, seat, tile) {
+  // open rob-the-kong window
+  const eligible = [];
+  for (let k = 1; k <= 3; k++) {
+    const s = (seat + k) % 4;
+    const q = state.players[s];
+    if (q.hasWon) continue;
+    if (state.config.allowRobKong && tileSuit(tile) !== q.missingSuit && isWinningHand(q, state.config, tile)) eligible.push(s);
+  }
+  logEvent(state, { type: 'AddedKongDeclared', seat, tile });
+  if (eligible.length === 0) { finalizeAddedKong(state, seat, tile); return; }
+  state.phase = PHASE.ROB_REACT;
+  state.robReactions = { tile, declarer: seat, eligible, responses: {} };
+}
+function doRobResponse(state, seat, action) {
+  state.robReactions.responses[seat] = action;
+  const r = state.robReactions;
+  if (r.eligible.every((s) => r.responses[s] != null)) resolveRobReactions(state);
+}
+function resolveRobReactions(state) {
+  const r = state.robReactions;
+  const tile = r.tile, declarer = r.declarer;
+  const robbers = r.eligible.filter((s) => r.responses[s] && r.responses[s].type === 'RobKong');
+  if (robbers.length) {
+    const ordered = state.config.allowMultipleRobKongWinners ? robbers : [nearestInOrder(declarer, robbers)];
+    state.robReactions = null;
+    logEvent(state, { type: 'KongRobbed', declarer, tile });
+    for (const w of ordered) {
+      // winning tile scored virtually (the declarer keeps the physical tile)
+      resolveWin(state, w, { winType: 'ROB_KONG', winningTile: tile, source: declarer, lastTile: false, afterKong: false });
+    }
+    if (!checkHandEnd(state)) beginTurn(state, nextActiveSeat(state, declarer));
+    return;
+  }
+  state.robReactions = null;
+  finalizeAddedKong(state, declarer, tile);
+}
+function finalizeAddedKong(state, seat, tile) {
+  const p = state.players[seat];
+  const m = p.melds.find((x) => x.type === PUNG && x.tile === tile);
+  m.type = KONG_ADDED;
+  p.concealed[tile] -= 1;
+  payKong(state, seat, KONG_ADDED, null);
+  beginTurn(state, seat, { draw: true, fromKong: true });
+}
+
+/* ---- self-draw win (spec §6.11) ---- */
+function doSelfDrawWin(state, seat) {
+  const pd = state.turnFlags;
+  const isHeavenly = state.turnFlags.firstTurn && seat === state.dealer && !state.firstDiscardDone;
+  const ctx = { winType: 'SELF_DRAW', winningTile: state.turnFlags.lastDrawn, source: null,
+    lastTile: state.turnFlags.lastTileExhausted, afterKong: pd.drewFromKong, isHeavenly };
+  resolveWin(state, seat, ctx);
+  if (!checkHandEnd(state)) beginTurn(state, nextActiveSeat(state, seat));
+}
+
+/* =====================================================================
+ * Win resolution & payments (spec §13)
+ * ===================================================================== */
+function resolveWin(state, seat, ctx) {
+  const p = state.players[seat];
+  const sc = score(state, seat, ctx);
+  p.hasWon = true;
+  p.winOrder = state.winnersThisHand.length;
+  const rec = { winner: seat, winType: ctx.winType, winningTile: ctx.winningTile, source: ctx.source,
+    fanAwards: sc.fanAwards, finalFan: sc.finalFan, points: sc.points, deltas: [0, 0, 0, 0] };
+  // payments
+  if (ctx.winType === 'SELF_DRAW') {
+    for (let s = 0; s < 4; s++) {
+      if (s === seat) continue;
+      const o = state.players[s];
+      if (state.config.wonPlayersExcludedFromFuturePayments && o.hasWon) continue;
+      o.score -= sc.points; p.score += sc.points;
+      rec.deltas[s] -= sc.points; rec.deltas[seat] += sc.points;
+    }
+  } else { // DISCARD or ROB_KONG — single payer
+    const payer = state.players[ctx.source];
+    payer.score -= sc.points; p.score += sc.points;
+    rec.deltas[ctx.source] -= sc.points; rec.deltas[seat] += sc.points;
+  }
+  p.winRecords.push(rec);
+  state.winnersThisHand.push(seat);
+  logEvent(state, { type: 'WinResolved', seat, winType: ctx.winType, points: sc.points, fan: sc.finalFan, fanAwards: sc.fanAwards.map((f) => f.name) });
+}
+
+/* immediate kong payments (spec §11.3) */
+function payKong(state, seat, kongType, discarder) {
+  const g = state.players[seat];
+  const cfg = state.config;
+  let amount, log;
+  if (kongType === KONG_EXPOSED_FROM_DISCARD) {
+    amount = cfg.kongExposedFromDiscard;
+    const d = state.players[discarder];
+    if (!(cfg.wonPlayersExcludedFromFuturePayments && d.hasWon)) { d.score -= amount; g.score += amount; }
+    log = 'exposed';
+  } else {
+    amount = (kongType === KONG_ADDED) ? cfg.kongAdded : cfg.kongConcealed;
+    for (let s = 0; s < 4; s++) {
+      if (s === seat) continue;
+      const o = state.players[s];
+      if (cfg.wonPlayersExcludedFromFuturePayments && o.hasWon) continue;
+      o.score -= amount; g.score += amount;
+    }
+    log = (kongType === KONG_ADDED) ? 'added' : 'concealed';
+  }
+  logEvent(state, { type: 'KongScored', seat, kongType: log, amount });
+}
+
+/* =====================================================================
+ * Scoring / fan detection (spec §14)
+ * ===================================================================== */
+function decomposeAllPungs(counts, groupsNeeded) {
+  // pair + only triplets (no chow). counts = concealed (winning size minus melds)
+  for (let p = 0; p < NUM_TYPES; p++) {
+    if (counts[p] >= 2) {
+      const cc = counts.slice(); cc[p] -= 2;
+      if (onlyTriplets(cc, groupsNeeded)) return true;
+    }
+  }
+  return false;
+}
+function onlyTriplets(c, groups) {
+  let i = 0; while (i < NUM_TYPES && c[i] === 0) i++;
+  if (i === NUM_TYPES) return groups === 0;
+  if (groups > 0 && c[i] >= 3) { c[i] -= 3; if (onlyTriplets(c, groups - 1)) { c[i] += 3; return true; } c[i] += 3; }
+  return false;
+}
+function score(state, seat, ctx) {
+  const cfg = state.config;
+  const p = state.players[seat];
+  // For SELF_DRAW the winning tile is already in concealed (drawn); for DISCARD /
+  // ROB_KONG it is added virtually here only (never persisted) — see §10.1.
+  const concealed = p.concealed.slice();
+  if (ctx.winType !== 'SELF_DRAW' && ctx.winningTile != null) concealed[ctx.winningTile]++;
+  const groupsNeeded = 4 - p.melds.length;
+  const fanAwards = [];
+  const add = (name, fan) => { if (fan > 0) fanAwards.push({ name, fan }); };
+
+  // suits across full hand
+  const suitsUsed = new Set();
+  for (let t = 0; t < NUM_TYPES; t++) if (concealed[t] > 0) suitsUsed.add(tileSuit(t));
+  for (const m of p.melds) suitsUsed.add(tileSuit(m.tile));
+
+  const sevenP = p.melds.length === 0 && cfg.allowSevenPairs && isSevenPairs(concealed, cfg);
+
+  add('Base Win', 0);
+  if (ctx.winType === 'SELF_DRAW') add('Self-Draw', cfg.selfDrawBonusFan);
+  if (sevenP) {
+    add('Seven Pairs', cfg.sevenPairsFan);
+    let quads = 0; for (let t = 0; t < NUM_TYPES; t++) if (concealed[t] === 4) quads++;
+    if (quads >= 1) add('Luxury Seven Pairs', cfg.luxurySevenPairsExtraFanPerQuad * quads);
+  } else {
+    // all pungs: every meld is a pung/kong (Sichuan melds always are) AND concealed = triplets + pair
+    const meldsAllPung = p.melds.every((m) => true);
+    if (meldsAllPung && decomposeAllPungs(concealed, groupsNeeded)) add('All Pungs', cfg.allPungsFan);
+  }
+  if (suitsUsed.size === 1) add('Pure One Suit', cfg.pureOneSuitFan);
+
+  // root (gen): 4 physical copies of a type in the full hand
+  let roots = 0;
+  for (let t = 0; t < NUM_TYPES; t++) {
+    let phys = concealed[t];
+    for (const m of p.melds) if (m.tile === t) phys += meldPhysical(m);
+    if (phys === 4) roots++;
+  }
+  if (roots > 0) add('Root', cfg.rootFan * roots);
+
+  if (ctx.afterKong && ctx.winType === 'SELF_DRAW') add('Kong Bloom', cfg.kongBloomBonusFan);
+  if (ctx.winType === 'ROB_KONG') add('Robbing a Kong', cfg.robKongBonusFan);
+  if (ctx.lastTile) add(ctx.winType === 'SELF_DRAW' ? 'Last Tile Draw' : 'Last Discard Win', cfg.lastTileFan);
+  if (ctx.isHeavenly) add('Heavenly Hand', cfg.heavenlyEarthlyFan);
+  if (ctx.isEarthly) add('Earthly Hand', cfg.heavenlyEarthlyFan);
+
+  let fan = fanAwards.reduce((s, f) => s + f.fan, 0);
+  if (cfg.fanLimit != null) fan = Math.min(fan, cfg.fanLimit);
+  const points = cfg.baseWinPoints * Math.pow(2, fan);
+  return { fanAwards, finalFan: fan, points };
+}
+
+/* =====================================================================
+ * End of hand (spec §9, §12)
+ * ===================================================================== */
+function checkHandEnd(state) {
+  if (state.config.mode === 'single' && state.winnersThisHand.length >= 1) { endHand(state, 'win'); return true; }
+  if (nonWonCount(state) <= 1) { endHand(state, 'win'); return true; }
+  return false;
+}
+function endHand(state, reason) {
+  if (state.phase === PHASE.HAND_ENDED) return;
+  state.phase = PHASE.HAND_ENDED;
+  state.ended = true; state.endReason = reason;
+  state.pendingDiscard = null; state.reactions = null; state.robReactions = null;
+
+  if (reason === 'exhaustion' && state.config.enableMissingSuitPenaltyAtExhaustion) {
+    // 查花猪: players still holding missing suit pay each cleared / won player (spec §8.3)
+    const pen = state.config.missingSuitPenalty;
+    const holders = state.players.filter((p) => !p.hasWon && missingCount(p) > 0);
+    for (const h of holders) {
+      for (let s = 0; s < 4; s++) {
+        const o = state.players[s];
+        if (o === h) continue;
+        if (!h.hasWon && (o.hasWon || missingCount(o) === 0)) { h.score -= pen; o.score += pen; }
+      }
+      logEvent(state, { type: 'EndPenaltyApplied', seat: h.seat, kind: 'missingSuit' });
+    }
+  }
+  // next dealer: first winner, else dealer repeats (spec §12.1)
+  state.nextDealer = (state.winnersThisHand.length > 0) ? state.winnersThisHand[0] : state.dealer;
+  state.seatScores = state.players.map((p) => p.score);
+  logEvent(state, { type: 'HandEnded', reason, winners: state.winnersThisHand.slice() });
+}
+
+/* =====================================================================
+ * Tile conservation invariant (spec §19)
+ * ===================================================================== */
+function validateConservation(state) {
+  const total = emptyCounts();
+  for (let i = state.wallHead; i < state.wallTail; i++) total[state.wall[i]]++;
+  for (const p of state.players) {
+    for (let t = 0; t < NUM_TYPES; t++) total[t] += p.concealed[t];
+    for (const m of p.melds) total[m.tile] += meldPhysical(m);
+    for (const d of p.discards) total[d]++;
+  }
+  if (state.pendingDiscard) total[state.pendingDiscard.tile]++;
+  let sum = 0;
+  for (let t = 0; t < NUM_TYPES; t++) { sum += total[t]; if (total[t] !== 4) return { ok: false, tile: t, count: total[t] }; }
+  return { ok: sum === 108, sum };
+}
+
+/* =====================================================================
+ * Redaction — per-seat view for rendering (hides others' concealed tiles)
+ * ===================================================================== */
+function viewFor(state, seat, opts = {}) {
+  const me = state.players[seat];
+  const myActions = getLegalActions(state, seat);
+  const ready = (state.phase !== PHASE.HAND_ENDED) ? getWinningTiles(me, state.config, state) : [];
+  const deciders = pendingDeciders(state);
+  const view = {
+    phase: state.phase,
+    handNo: state.handNo,
+    mode: state.config.mode,
+    wallRemaining: wallRemaining(state),
+    dealer: state.dealer,
+    active: state.active,
+    mySeat: seat,
+    deciders,
+    pendingDiscard: state.pendingDiscard ? { tile: state.pendingDiscard.tile, by: state.pendingDiscard.discarder } : null,
+    lastDrawn: (seat === state.active && state.phase === PHASE.ACTIVE_TURN) ? state.turnFlags.lastDrawn : null,
+    winnersThisHand: state.winnersThisHand.slice(),
+    me: {
+      seat,
+      concealed: me.concealed.slice(),
+      melds: me.melds.map((m) => ({ ...m })),
+      missingSuit: me.missingSuit,
+      discards: me.discards.slice(),
+      hasWon: me.hasWon,
+      winOrder: me.winOrder,
+      score: me.score,
+      legalActions: myActions,
+      ready,
+    },
+    players: state.players.map((p) => ({
+      seat: p.seat,
+      name: p.name,
+      isBot: p.isBot,
+      connected: p.connected,
+      missingSuit: p.missingSuit,             // public after selection (default)
+      melds: p.melds.map((m) => ({ ...m, concealed: m.type === KONG_CONCEALED })),
+      discards: p.discards.slice(),
+      handCount: countTotal(p.concealed),
+      hasWon: p.hasWon,
+      winOrder: p.winOrder,
+      score: p.score,
+      isDealer: p.isDealer,
+      isActive: p.seat === state.active && state.phase === PHASE.ACTIVE_TURN,
+      mustDecide: deciders.includes(p.seat),
+    })),
+  };
+  if (state.phase === PHASE.HAND_ENDED) {
+    view.results = {
+      reason: state.endReason,
+      winners: state.winnersThisHand.slice(),
+      records: [].concat(...state.players.map((p) => p.winRecords)),
+      scores: state.players.map((p) => p.score),
+      nextDealer: state.nextDealer,
+    };
+  }
+  return view;
+}
+
+/* =====================================================================
+ * Invalid-move explanations (spec §20)
+ * ===================================================================== */
+function explainIllegal(state, seat, action) {
+  const p = state.players[seat];
+  if (p.hasWon) return ['PLAYER_ALREADY_WON', 'You have already won this hand. In Bloody Battle, the remaining players continue without you.'];
+  if (state.phase === PHASE.ACTIVE_TURN && seat !== state.active)
+    return ['NOT_YOUR_TURN', 'You cannot do that because it is not your turn.'];
+  if (action.type === 'ClaimPung')
+    return ['PUNG_REQUIRES_TWO_IN_HAND', 'You need two matching tiles in your hand to claim a pung.'];
+  if (action.type === 'ClaimKongFromDiscard')
+    return ['KONG_REQUIRES_THREE_IN_HAND', 'You need three matching tiles in your hand to claim a kong from a discard.'];
+  if (action.type === 'DeclareWinFromDiscard' || action.type === 'DeclareSelfDrawWin' || action.type === 'RobKong') {
+    if (missingCount(p) > 0) {
+      const ms = SUIT_NAME[p.missingSuit];
+      return ['WIN_CONTAINS_MISSING_SUIT', 'You cannot win while holding tiles from your missing suit.', `Your missing suit is ${ms}.`, ['Discard your missing-suit tiles first.']];
+    }
+    return ['HAND_NOT_COMPLETE', 'This is not a legal winning hand.', 'A winning hand needs four groups and one pair (or seven pairs).'];
+  }
+  if (action.type === 'Discard' && state.config.mustDiscardMissingSuitFirst && missingCount(p) > 0)
+    return ['MUST_DISCARD_MISSING_SUIT', 'You still have tiles from your missing suit. You must discard those before discarding other suits.'];
+  return ['ILLEGAL_ACTION', 'That move is not available right now.'];
+}
+
+/* =====================================================================
+ * BOT decision logic (driver-side; reads only public info + own hand)
+ * Follows the addendum priority: win > mandatory > kong > meld > discard.
+ * ===================================================================== */
+function botChooseMissingSuit(player) {
+  const cnt = [0, 0, 0];
+  for (let t = 0; t < NUM_TYPES; t++) cnt[tileSuit(t)] += player.concealed[t];
+  let best = 0, bestScore = Infinity;
+  for (let s = 0; s < 3; s++) {
+    let conn = 0;
+    for (let r = 0; r < 9; r++) {
+      const t = s * 9 + r, v = player.concealed[t];
+      if (v && r < 8) conn += Math.min(v, player.concealed[t + 1]);
+      if (v >= 2) conn += 1;
+    }
+    const sc = cnt[s] * 10 + conn;
+    if (sc < bestScore) { bestScore = sc; best = s; }
+  }
+  return best;
+}
+
+/* shanten estimate (standard + seven pairs), ignoring missing-suit dead tiles */
+function shantenOf(player) {
+  const c = player.concealed.slice();
+  if (player.missingSuit != null) for (let r = 0; r < 9; r++) c[player.missingSuit * 9 + r] = 0;
+  let st = stdShanten(c, player.melds.length);
+  if (player.melds.length === 0) st = Math.min(st, sevenPairsShanten(c));
+  return st;
+}
+function sevenPairsShanten(c) {
+  let pairs = 0, kinds = 0;
+  for (let t = 0; t < NUM_TYPES; t++) { if (c[t] > 0) kinds++; if (c[t] >= 2) pairs++; }
+  let sh = 6 - pairs; if (kinds < 7) sh += 7 - kinds; return sh;
+}
+function stdShanten(c0, openMelds) {
+  let best = 8; const c = c0.slice();
+  function rec(i, melds, partials, pairUsed) {
+    while (i < NUM_TYPES && c[i] === 0) i++;
+    if (i === NUM_TYPES) {
+      let m = melds + openMelds, part = partials;
+      if (m + part > 4) part = 4 - m;
+      const sh = (4 - m) * 2 - part - (pairUsed ? 1 : 0);
+      if (sh < best) best = sh; return;
+    }
+    if (c[i] >= 3) { c[i] -= 3; rec(i, melds + 1, partials, pairUsed); c[i] += 3; }
+    if (i % 9 <= 6 && c[i + 1] > 0 && c[i + 2] > 0) { c[i]--; c[i + 1]--; c[i + 2]--; rec(i, melds + 1, partials, pairUsed); c[i]++; c[i + 1]++; c[i + 2]++; }
+    if (!pairUsed && c[i] >= 2) { c[i] -= 2; rec(i, melds, partials, true); c[i] += 2; }
+    if (c[i] >= 2) { c[i] -= 2; rec(i, melds, partials + 1, pairUsed); c[i] += 2; }
+    if (i % 9 <= 7 && c[i + 1] > 0) { c[i]--; c[i + 1]--; rec(i, melds, partials + 1, pairUsed); c[i]++; c[i + 1]++; }
+    if (i % 9 <= 6 && c[i + 2] > 0) { c[i]--; c[i + 2]--; rec(i, melds, partials + 1, pairUsed); c[i]++; c[i + 2]++; }
+    c[i]--; rec(i, melds, partials, pairUsed); c[i]++;
+  }
+  rec(0, 0, 0, false);
+  return best;
+}
+function ukeireOf(state, player) {
+  const base = shantenOf(player);
+  let total = 0;
+  for (let t = 0; t < NUM_TYPES; t++) {
+    if (tileSuit(t) === player.missingSuit) continue;
+    if (player.concealed[t] >= 4) continue;
+    const rem = remainingOf(state, t, player.seat);
+    if (rem <= 0) continue;
+    player.concealed[t]++; const sh = shantenOf(player); player.concealed[t]--;
+    if (sh < base) total += rem;
+  }
+  return total;
+}
+function opponentDanger(state, seat) {
+  let worst = 0;
+  for (let s = 0; s < 4; s++) {
+    if (s === seat) continue;
+    const o = state.players[s];
+    if (o.hasWon) continue;
+    const d = o.melds.length * 0.18 + (missingCount(o) === 0 ? 0.15 : 0) + Math.min(o.discards.length, 12) * 0.02;
+    worst = Math.max(worst, Math.min(1, d));
+  }
+  return worst;
+}
+function discardPreference(player, t) {
+  const r = tileRank(t), c = player.concealed;
+  let s = 0;
+  const l2 = r > 2 ? c[t - 2] : 0, l1 = r > 1 ? c[t - 1] : 0, r1 = r < 9 ? c[t + 1] : 0, r2 = r < 8 ? c[t + 2] : 0;
+  const nb = l2 + l1 + r1 + r2;
+  if (nb === 0 && c[t] === 1) s += 30;
+  if ((r === 1 || r === 9) && c[t] === 1) s += 10;
+  if (c[t] >= 2) s -= 25;
+  if (l1 && r1) s -= 18;
+  if (l1 || r1) s -= 6;
+  s -= Math.abs(r - 5);
+  return s;
+}
+function botChooseDiscard(state, seat, candidates, difficulty) {
+  const p = state.players[seat];
+  const miss = candidates.filter((t) => tileSuit(t) === p.missingSuit);
+  if (miss.length) candidates = miss;                       // forced clear first
+  if (difficulty === 'easy' && rngNext(state) < 0.35) return candidates[rngInt(state, candidates.length)];
+  let best = candidates[0], bestScore = -Infinity;
+  for (const t of candidates) {
+    p.concealed[t]--;
+    const sh = shantenOf(p);
+    const accept = (difficulty !== 'easy') ? ukeireOf(state, p) : 0;
+    p.concealed[t]++;
+    let sc = -sh * 1000 + accept * 4 + discardPreference(p, t);
+    if (difficulty === 'hard') sc -= tileDanger(state, seat, t) * 60 * opponentDanger(state, seat);
+    if (sc > bestScore) { bestScore = sc; best = t; }
+  }
+  return best;
+}
+function tileDanger(state, seat, t) {
+  let danger = 0;
+  for (let s = 0; s < 4; s++) {
+    if (s === seat) continue;
+    const o = state.players[s];
+    if (o.hasWon) continue;
+    let seenRivers = 0;
+    for (const q of state.players) for (const d of q.discards) if (d === t) seenRivers++;
+    danger += (seenRivers === 0 ? 0.5 : 0.1);
+    if (o.missingSuit != null && tileSuit(t) === o.missingSuit) danger -= 0.4;
+  }
+  return Math.max(0, danger);
+}
+function botChooseAction(state, seat, difficulty) {
+  difficulty = difficulty || state.players[seat].difficulty || 'normal';
+  const acts = getLegalActions(state, seat);
+  if (!acts.length) return null;
+  const p = state.players[seat];
+
+  // missing-suit selection
+  const choose = acts.filter((a) => a.type === 'ChooseMissingSuit');
+  if (choose.length) return { type: 'ChooseMissingSuit', suit: botChooseMissingSuit(p) };
+
+  // 1. winning move
+  const win = acts.find((a) => a.type === 'DeclareSelfDrawWin' || a.type === 'DeclareWinFromDiscard' || a.type === 'RobKong');
+  if (win) return win;
+
+  // reaction window (no win): consider pung/kong, else pass
+  if (state.phase === PHASE.DISCARD_REACT) {
+    const pung = acts.find((a) => a.type === 'ClaimPung');
+    const kong = acts.find((a) => a.type === 'ClaimKongFromDiscard');
+    const m = botChooseMeld(state, seat, pung, kong, difficulty);
+    return m || acts.find((a) => a.type === 'Pass');
+  }
+  if (state.phase === PHASE.ROB_REACT) return acts.find((a) => a.type === 'Pass');
+
+  // 3. kong decisions on own turn
+  const kongs = acts.filter((a) => a.type === 'DeclareConcealedKong' || a.type === 'DeclareAddedKong');
+  if (kongs.length) {
+    const g = botChooseKong(state, seat, kongs, difficulty);
+    if (g) return g;
+  }
+  // 5. best discard
+  const discards = acts.filter((a) => a.type === 'Discard').map((a) => a.tile);
+  if (discards.length) return { type: 'Discard', tile: botChooseDiscard(state, seat, discards, difficulty) };
+  return acts[0];
+}
+function botChooseKong(state, seat, kongs, difficulty) {
+  const p = state.players[seat];
+  if (difficulty === 'easy') return rngNext(state) < 0.7 ? kongs[0] : null;
+  const before = shantenOf(p);
+  for (const g of kongs) {
+    const snap = p.concealed.slice();
+    if (g.type === 'DeclareConcealedKong') p.concealed[g.tile] -= 4; else p.concealed[g.tile] -= 1;
+    const after = shantenOf(p);
+    p.concealed = snap;
+    if (after <= before) return g;
+  }
+  if (difficulty === 'hard') return kongs.find((g) => g.type === 'DeclareConcealedKong') || null;
+  return null;
+}
+function botChooseMeld(state, seat, pung, kong, difficulty) {
+  const p = state.players[seat];
+  if (!pung && !kong) return null;
+  const tile = (pung || kong).tile;
+  if (tileSuit(tile) === p.missingSuit) return null;
+  if (difficulty === 'easy') { if (rngNext(state) < 0.45) return null; return pung || kong; }
+  const before = shantenOf(p);
+  const snap = p.concealed.slice(), msnap = p.melds.map((m) => ({ ...m }));
+  if (kong && !pung) { p.concealed[tile] -= 3; p.melds.push({ type: PUNG, tile }); }
+  else { p.concealed[tile] -= 2; p.melds.push({ type: PUNG, tile }); }
+  const after = shantenOf(p);
+  const ready = isReady(p, state.config);
+  p.concealed = snap; p.melds = msnap;
+  if (kong && !pung) {
+    if (after < before || ready) return kong;
+    return difficulty === 'hard' ? (after <= before ? kong : null) : (after < before ? kong : null);
+  }
+  if (after < before || ready) {
+    if (difficulty === 'hard' && after >= before && opponentDanger(state, seat) > 0.6) return null;
+    return pung;
+  }
+  if (difficulty === 'hard') return null;
+  return after <= before && rngNext(state) < 0.25 ? pung : null;
+}
+
+// ==CORE-END== (synced region)
+
+export {
+  DOT, BAMBOO, CHARACTER, SUIT_GLYPH, SUIT_NAME, NUM_TYPES,
+  tileIndex, tileSuit, tileRank, emptyCounts, countTotal, countsToList,
+  DEFAULT_CONFIG, makeConfig, createGame,
+  getLegalActions, pendingDeciders, applyAction, actionsEqual,
+  isWinningHand, winsNow, getWinningTiles, isReady, isSevenPairs,
+  score, viewFor, validateConservation, remainingOf, missingCount,
+  botChooseAction, botChooseMissingSuit, shantenOf,
+  PHASE, PUNG, KONG_CONCEALED, KONG_ADDED, KONG_EXPOSED_FROM_DISCARD,
+};

--- a/worker/src/mahjongCore.js
+++ b/worker/src/mahjongCore.js
@@ -118,7 +118,7 @@ function createGame(opts = {}) {
     pendingDiscard: null, reactions: null, robReactions: null,
     turnFlags: { needsDraw: false, drewFromKong: false, lastDrawn: null, firstTurn: false, lastTileExhausted: false },
     firstDiscardDone: false,
-    winnersThisHand: [],
+    winnersThisHand: [], firstDealerSeat: null,
     log: [],
     ended: false, endReason: null,
     seatScores: opts.seatScores || [0, 0, 0, 0],   // carry running scores across hands
@@ -325,7 +325,9 @@ function getLegalActions(state, seat) {
     const justDrew = state.turnFlags.lastDrawn != null || state.turnFlags.firstTurn;
     // self-draw win
     if (!holdsMissing && justDrew && winsNow(p, state.config)) acts.push({ type: 'DeclareSelfDrawWin' });
-    if (!holdsMissing && !state.turnFlags.afterPung) {
+    // kongs only gate on the kong tile's suit (spec §6.7/§6.8), not on whether the
+    // player has cleared their own missing suit (that rule restricts discards only, §8.2)
+    if (!state.turnFlags.afterPung) {
       // concealed kong
       for (let t = 0; t < NUM_TYPES; t++) {
         if (p.concealed[t] === 4 && (state.config.allowKongInMissingSuit || tileSuit(t) !== p.missingSuit))
@@ -350,7 +352,8 @@ function getLegalActions(state, seat) {
     const holdsMissing = missingCount(p) > 0;
     if (!holdsMissing && tileSuit(tile) !== p.missingSuit && isWinningHand(p, state.config, tile))
       acts.push({ type: 'DeclareWinFromDiscard', tile });
-    const meldOk = !holdsMissing && (state.config.allowMeldsInMissingSuit || tileSuit(tile) !== p.missingSuit);
+    // peng/kong-from-discard gate on the claimed tile's suit only (spec §6.5/§6.6)
+    const meldOk = (state.config.allowMeldsInMissingSuit || tileSuit(tile) !== p.missingSuit);
     if (meldOk && p.concealed[tile] >= 3) acts.push({ type: 'ClaimKongFromDiscard', tile });
     if (meldOk && p.concealed[tile] >= 2) acts.push({ type: 'ClaimPung', tile });
     acts.push({ type: 'Pass' });
@@ -491,7 +494,7 @@ function doDiscard(state, seat, tile) {
 function reactionOptions(state, seat, tile) {
   const p = state.players[seat];
   const holdsMissing = missingCount(p) > 0;
-  const meldOk = !holdsMissing && (state.config.allowMeldsInMissingSuit || tileSuit(tile) !== p.missingSuit);
+  const meldOk = (state.config.allowMeldsInMissingSuit || tileSuit(tile) !== p.missingSuit);
   return {
     win: !holdsMissing && tileSuit(tile) !== p.missingSuit && isWinningHand(p, state.config, tile),
     kong: meldOk && p.concealed[tile] >= 3,
@@ -516,6 +519,8 @@ function resolveDiscardReactions(state) {
     const ordered = state.config.allowMultipleWinnersOnDiscard ? winners : [nearestInOrder(discarder, winners)];
     state.reactions = null;
     commitDiscardToPile(state);   // the won tile stays visible in the river, counted once
+    // §12.1: first winner becomes next dealer; if multiple win the same discard, the discarder does
+    if (state.winnersThisHand.length === 0) state.firstDealerSeat = (ordered.length >= 2 ? discarder : ordered[0]);
     for (const w of ordered) {
       // The winning tile is scored VIRTUALLY (not added to concealed) so one physical
       // tile can feed multiple winners without breaking conservation (spec §19, §10.1).
@@ -600,8 +605,14 @@ function resolveRobReactions(state) {
     const ordered = state.config.allowMultipleRobKongWinners ? robbers : [nearestInOrder(declarer, robbers)];
     state.robReactions = null;
     logEvent(state, { type: 'KongRobbed', declarer, tile });
+    // The kong tile is consumed by the rob (like a discard handed to the winner):
+    // remove it from the declarer's hand into their river so the declarer returns to
+    // 13 effective tiles and conservation holds. The pung is NOT upgraded (kong cancelled).
+    state.players[declarer].concealed[tile] -= 1;
+    state.players[declarer].discards.push(tile);
+    if (state.winnersThisHand.length === 0) state.firstDealerSeat = (ordered.length >= 2 ? declarer : ordered[0]);
     for (const w of ordered) {
-      // winning tile scored virtually (the declarer keeps the physical tile)
+      // winning tile scored virtually (it now lives in the declarer's river, counted once)
       resolveWin(state, w, { winType: 'ROB_KONG', winningTile: tile, source: declarer, lastTile: false, afterKong: false });
     }
     if (!checkHandEnd(state)) beginTurn(state, nextActiveSeat(state, declarer));
@@ -625,6 +636,7 @@ function doSelfDrawWin(state, seat) {
   const isHeavenly = state.turnFlags.firstTurn && seat === state.dealer && !state.firstDiscardDone;
   const ctx = { winType: 'SELF_DRAW', winningTile: state.turnFlags.lastDrawn, source: null,
     lastTile: state.turnFlags.lastTileExhausted, afterKong: pd.drewFromKong, isHeavenly };
+  if (state.winnersThisHand.length === 0) state.firstDealerSeat = seat;
   resolveWin(state, seat, ctx);
   if (!checkHandEnd(state)) beginTurn(state, nextActiveSeat(state, seat));
 }
@@ -779,8 +791,9 @@ function endHand(state, reason) {
       logEvent(state, { type: 'EndPenaltyApplied', seat: h.seat, kind: 'missingSuit' });
     }
   }
-  // next dealer: first winner, else dealer repeats (spec §12.1)
-  state.nextDealer = (state.winnersThisHand.length > 0) ? state.winnersThisHand[0] : state.dealer;
+  // next dealer (spec §12.1): the first winner (or discarder if the first win was a
+  // simultaneous multi-winner discard, tracked in firstDealerSeat); else dealer repeats
+  state.nextDealer = (state.firstDealerSeat != null) ? state.firstDealerSeat : state.dealer;
   state.seatScores = state.players.map((p) => p.score);
   logEvent(state, { type: 'HandEnded', reason, winners: state.winnersThisHand.slice() });
 }
@@ -961,7 +974,13 @@ function opponentDanger(state, seat) {
     if (s === seat) continue;
     const o = state.players[s];
     if (o.hasWon) continue;
-    const d = o.melds.length * 0.18 + (missingCount(o) === 0 ? 0.15 : 0) + Math.min(o.discards.length, 12) * 0.02;
+    // PUBLIC signals only — never inspect an opponent's concealed hand. We infer
+    // "has cleared their missing suit" from their discard river: they discarded
+    // missing-suit tiles earlier and their recent discards are no longer that suit.
+    const dumpedMissing = o.missingSuit != null && o.discards.some((t) => tileSuit(t) === o.missingSuit);
+    const recentOffMissing = o.discards.slice(-2).every((t) => o.missingSuit == null || tileSuit(t) !== o.missingSuit);
+    const voidedLikely = dumpedMissing && recentOffMissing && o.discards.length >= 3;
+    const d = o.melds.length * 0.2 + (voidedLikely ? 0.15 : 0) + Math.min(o.discards.length, 12) * 0.02;
     worst = Math.max(worst, Math.min(1, d));
   }
   return worst;

--- a/worker/src/mahjongroom.ts
+++ b/worker/src/mahjongroom.ts
@@ -187,6 +187,7 @@ export class MahjongRoom {
       const connected = new Set(players.map((p) => p.id));
       const token = typeof msg.token === "string" ? msg.token : "";
       const g = await this.loadGame();
+      if (!g) { ws.send(JSON.stringify({ t: "error", msg: "Game state unavailable — please try again" })); ws.close(1011, "no game"); return; }
       let seatId = -1;
       if (token) for (const id of humanSeats) {
         if (!connected.has(id) && seatTokens[id] && seatTokens[id] === token) { seatId = id; break; }

--- a/worker/src/mahjongroom.ts
+++ b/worker/src/mahjongroom.ts
@@ -171,17 +171,11 @@ export class MahjongRoom {
     const name = sanitizeName(msg.name);
     const ver = sanitizeVer(msg.ver);
     const players = this.roster();
-    // Gate against the room's pinned version (set by the creator), not the live host's,
-    // so it still works when the host seat is currently disconnected.
-    const roomVer = await this.state.storage.get<string>("roomVer");
-    if (roomVer && ver !== roomVer) {
-      ws.send(JSON.stringify({ t: "error", msg: "Game versions differ — fully close the app and reopen it, then rejoin" }));
-      ws.close(1008, "version mismatch");
-      return;
-    }
 
     if ((await this.phase()) === "playing") {
-      // mid-game REJOIN: reclaim a seat whose human dropped (now driven by a bot)
+      // mid-game REJOIN: reclaim a seat whose human dropped (now driven by a bot).
+      // No version gate here on purpose — the server runs the authoritative engine, the
+      // seat is already this player's, and a redeploy mid-hand shouldn't lock them out.
       const humanSeats = (await this.state.storage.get<number[]>("humanSeats")) || [];
       const connected = new Set(players.map((p) => p.id));
       const g = await this.loadGame();
@@ -204,6 +198,14 @@ export class MahjongRoom {
       return;
     }
 
+    // New lobby join: gate against the room's pinned version (set by the creator) so
+    // mismatched builds can't form a lobby together.
+    const roomVer = await this.state.storage.get<string>("roomVer");
+    if (roomVer && ver !== roomVer) {
+      ws.send(JSON.stringify({ t: "error", msg: "Game versions differ — fully close the app and reopen it, then rejoin" }));
+      ws.close(1008, "version mismatch");
+      return;
+    }
     if (players.length >= MAX_PLAYERS) { ws.send(JSON.stringify({ t: "error", msg: "room full" })); ws.close(1008, "room full"); return; }
     const used = new Set(players.map((p) => p.id));
     let id = 0; while (used.has(id)) id++;

--- a/worker/src/mahjongroom.ts
+++ b/worker/src/mahjongroom.ts
@@ -20,6 +20,7 @@ type LobbyCfg = { mode: "bloody" | "single"; sevenPairs: boolean; difficulty: "e
 
 const MAX_PLAYERS = 4;
 const ROOM_TTL_MS = 45 * 60 * 1000;
+const EMPTY_GRACE_MS = 90 * 1000;   // keep an empty room briefly so a blip can reconnect
 const BOT_DELAY_MS = 650;
 const NAME_MAX = 12;
 
@@ -173,15 +174,19 @@ export class MahjongRoom {
     const players = this.roster();
 
     if ((await this.phase()) === "playing") {
-      // mid-game REJOIN: reclaim a seat whose human dropped (now driven by a bot).
-      // No version gate here on purpose — the server runs the authoritative engine, the
-      // seat is already this player's, and a redeploy mid-hand shouldn't lock them out.
+      // mid-game REJOIN: reclaim a seat using the secret reconnect TOKEN issued at join
+      // (persisted in the player's own browser). A name is public — matching on it would
+      // let anyone in the room steal a disconnected player's seat and see their hand.
+      // No version gate here on purpose: the server runs the authoritative engine, so a
+      // redeploy mid-hand shouldn't lock a reconnecting player out.
       const humanSeats = (await this.state.storage.get<number[]>("humanSeats")) || [];
+      const seatTokens = (await this.state.storage.get<Record<number, string>>("seatTokens")) || {};
       const connected = new Set(players.map((p) => p.id));
+      const token = typeof msg.token === "string" ? msg.token : "";
       const g = await this.loadGame();
       let seatId = -1;
-      for (const id of humanSeats) {
-        if (!connected.has(id) && g && g.players[id] && String(g.players[id].name).toLowerCase() === name.toLowerCase()) { seatId = id; break; }
+      if (token) for (const id of humanSeats) {
+        if (!connected.has(id) && seatTokens[id] && seatTokens[id] === token) { seatId = id; break; }
       }
       if (seatId < 0) { ws.send(JSON.stringify({ t: "error", msg: "Game in progress — seat unavailable" })); ws.close(1008, "in progress"); return; }
       const hostSeat = await this.state.storage.get<number>("hostSeat");
@@ -214,10 +219,15 @@ export class MahjongRoom {
       await this.state.storage.put("hostSeat", id);
     }
     const hostSeat = await this.state.storage.get<number>("hostSeat");
+    // issue a secret reconnect token for this seat (used to reclaim it after a drop)
+    const token = crypto.randomUUID();
+    const seatTokens = (await this.state.storage.get<Record<number, string>>("seatTokens")) || {};
+    seatTokens[id] = token;
+    await this.state.storage.put("seatTokens", seatTokens);
     const a: Attachment = { id, name, ready: false, host: id === hostSeat, ver };
     ws.serializeAttachment(a);
     const code = (await this.state.storage.get<string>("code")) || "";
-    ws.send(JSON.stringify({ t: "welcome", id, host: a.host, code }));
+    ws.send(JSON.stringify({ t: "welcome", id, host: a.host, code, reconnect: token }));
     await this.broadcastLobby();
     await this.bumpTtl();
   }
@@ -339,8 +349,15 @@ export class MahjongRoom {
       return;
     }
 
-    // lobby cleanup
-    if (remaining.length === 0) { await this.state.storage.deleteAll(); return; }
+    // lobby cleanup — don't destroy the room on a brief disconnect (a sole creator whose
+    // network blips would otherwise 404 on reconnect). Keep it alive for a short grace
+    // window; the alarm reaps it if still empty.
+    if (remaining.length === 0) {
+      const reapAt = Date.now() + EMPTY_GRACE_MS;
+      await this.state.storage.put("ttlAt", reapAt);
+      await this.state.storage.setAlarm(reapAt);
+      return;
+    }
     await this.broadcastLobby();
   }
 

--- a/worker/src/mahjongroom.ts
+++ b/worker/src/mahjongroom.ts
@@ -120,9 +120,11 @@ export class MahjongRoom {
     if (typeof message !== "string") return;
     let msg: any;
     try { msg = JSON.parse(message); } catch { return; }
+    if (!(await this.state.storage.get("created"))) { try { ws.close(1001, "room gone"); } catch { /* */ } return; }
     const me = ws.deserializeAttachment() as Attachment | null;
 
     if (!me) { await this.handleHello(ws, msg); return; }
+    await this.bumpTtl();   // any activity from a connected client keeps the room alive
 
     switch (msg.t) {
       case "ready": {
@@ -169,8 +171,10 @@ export class MahjongRoom {
     const name = sanitizeName(msg.name);
     const ver = sanitizeVer(msg.ver);
     const players = this.roster();
-    const hostP = players.find((p) => p.host);
-    if (hostP && ver !== hostP.ver) {
+    // Gate against the room's pinned version (set by the creator), not the live host's,
+    // so it still works when the host seat is currently disconnected.
+    const roomVer = await this.state.storage.get<string>("roomVer");
+    if (roomVer && ver !== roomVer) {
       ws.send(JSON.stringify({ t: "error", msg: "Game versions differ — fully close the app and reopen it, then rejoin" }));
       ws.close(1008, "version mismatch");
       return;
@@ -186,10 +190,12 @@ export class MahjongRoom {
         if (!connected.has(id) && g && g.players[id] && String(g.players[id].name).toLowerCase() === name.toLowerCase()) { seatId = id; break; }
       }
       if (seatId < 0) { ws.send(JSON.stringify({ t: "error", msg: "Game in progress — seat unavailable" })); ws.close(1008, "in progress"); return; }
-      const a: Attachment = { id: seatId, name: g.players[seatId].name, ready: true, host: g.players[seatId].seat === 0, ver };
+      const hostSeat = await this.state.storage.get<number>("hostSeat");
+      const a: Attachment = { id: seatId, name: g.players[seatId].name, ready: true, host: seatId === hostSeat, ver };
       ws.serializeAttachment(a);
       g.players[seatId].isBot = false; g.players[seatId].connected = true;
       await this.saveGame(g);
+      await this.bumpTtl();
       const code = (await this.state.storage.get<string>("code")) || "";
       ws.send(JSON.stringify({ t: "welcome", id: seatId, host: a.host, code, rejoin: true }));
       ws.send(JSON.stringify({ t: "view", view: viewFor(g, seatId) }));
@@ -201,7 +207,12 @@ export class MahjongRoom {
     if (players.length >= MAX_PLAYERS) { ws.send(JSON.stringify({ t: "error", msg: "room full" })); ws.close(1008, "room full"); return; }
     const used = new Set(players.map((p) => p.id));
     let id = 0; while (used.has(id)) id++;
-    const a: Attachment = { id, name, ready: false, host: players.length === 0, ver };
+    if (players.length === 0) {                 // first arrival pins the room version + host seat
+      await this.state.storage.put("roomVer", ver);
+      await this.state.storage.put("hostSeat", id);
+    }
+    const hostSeat = await this.state.storage.get<number>("hostSeat");
+    const a: Attachment = { id, name, ready: false, host: id === hostSeat, ver };
     ws.serializeAttachment(a);
     const code = (await this.state.storage.get<string>("code")) || "";
     ws.send(JSON.stringify({ t: "welcome", id, host: a.host, code }));
@@ -304,6 +315,10 @@ export class MahjongRoom {
     if (!me) return;
     const remaining = this.roster().filter((p) => p.id !== me.id);
 
+    // if the host left and others remain, promote a connected player so host-only
+    // actions (config/start/rematch) stay reachable — in both lobby and play.
+    if (me.host && remaining.length) await this.promoteHost(remaining[0].id);
+
     if ((await this.phase()) === "playing") {
       // seat is taken over by a bot so the hand keeps going; human may rejoin by name
       const game = await this.loadGame();
@@ -321,16 +336,17 @@ export class MahjongRoom {
       return;
     }
 
-    // lobby: drop the player; promote a new host; reap empty room
-    if (me.host && remaining.length) {
-      const heir = this.socketFor(remaining[0].id);
-      if (heir) {
-        const a = heir.deserializeAttachment() as Attachment;
-        a.host = true; a.ready = false; heir.serializeAttachment(a);
-        heir.send(JSON.stringify({ t: "you-are-host" }));
-      }
-    }
+    // lobby cleanup
     if (remaining.length === 0) { await this.state.storage.deleteAll(); return; }
     await this.broadcastLobby();
+  }
+
+  private async promoteHost(heirId: number): Promise<void> {
+    const heir = this.socketFor(heirId);
+    if (!heir) return;
+    const a = heir.deserializeAttachment() as Attachment;
+    a.host = true; heir.serializeAttachment(a);
+    await this.state.storage.put("hostSeat", a.id);
+    try { heir.send(JSON.stringify({ t: "you-are-host" })); } catch { /* */ }
   }
 }

--- a/worker/src/mahjongroom.ts
+++ b/worker/src/mahjongroom.ts
@@ -91,6 +91,9 @@ export class MahjongRoom {
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
     if (url.pathname === "/init" && request.method === "POST") {
+      // guard a (vanishingly unlikely) code collision: don't re-init a live room — that
+      // would merge phase:"lobby"/default cfg over an in-progress game and strand players.
+      if (await this.state.storage.get("created")) return new Response("conflict", { status: 409 });
       const code = await request.text();
       await this.state.storage.put({ created: true, code, phase: "lobby", cfg: { ...DEFAULT_CFG } });
       await this.bumpTtl();

--- a/worker/src/mahjongroom.ts
+++ b/worker/src/mahjongroom.ts
@@ -299,7 +299,8 @@ export class MahjongRoom {
     const seat = this.botPending(game);
     if (seat < 0 || this.state.getWebSockets().length === 0) { await this.state.storage.setAlarm(ttlAt); return; }
     const action = botChooseAction(game, seat);
-    if (action) applyAction(game, seat, action);
+    const res = action ? applyAction(game, seat, action) : { ok: false };
+    if (!res.ok) { await this.state.storage.setAlarm(ttlAt); return; }  // never spin the alarm on a stuck seat
     await this.saveGame(game);
     this.broadcastViews(game);
     await this.armAlarm(game);

--- a/worker/src/mahjongroom.ts
+++ b/worker/src/mahjongroom.ts
@@ -1,0 +1,336 @@
+// Sichuan Mahjong online room — one Durable Object instance per room code.
+//
+// Unlike Kart3Room (an opaque relay), this DO is SERVER-AUTHORITATIVE: it runs
+// the shared rules engine (mahjongCore.js — the same code the browser uses for
+// local play) and is the only place that holds the full hidden state. Each
+// connected client is sent ONLY its own redacted view (viewFor), so no client
+// can ever see another player's concealed tiles — the anti-cheat property a
+// host-authoritative model can't give a hidden-information game.
+//
+// Hibernation-safe: the entire game lives in DO storage (the engine state is
+// plain JSON). Every message loads state, mutates, saves, and broadcasts. Bots
+// run server-side, paced by the alarm so play looks human and survives eviction.
+//
+// No Google auth: friends join with a room code (origin-gated in index.ts).
+
+import { createGame, getLegalActions, pendingDeciders, applyAction, botChooseAction, viewFor, makeConfig } from "./mahjongCore.js";
+
+type Attachment = { id: number; name: string; ready: boolean; host: boolean; ver: string };
+type LobbyCfg = { mode: "bloody" | "single"; sevenPairs: boolean; difficulty: "easy" | "normal" | "hard" };
+
+const MAX_PLAYERS = 4;
+const ROOM_TTL_MS = 45 * 60 * 1000;
+const BOT_DELAY_MS = 650;
+const NAME_MAX = 12;
+
+function sanitizeVer(raw: unknown): string { return String(raw ?? "legacy").slice(0, 24); }
+function sanitizeName(raw: unknown): string {
+  const s = String(raw ?? "").replace(/[<>&"'`]/g, "").trim();
+  return (s || "Player").slice(0, NAME_MAX);
+}
+const DEFAULT_CFG: LobbyCfg = { mode: "bloody", sevenPairs: true, difficulty: "normal" };
+
+export class MahjongRoom {
+  private state: DurableObjectState;
+  constructor(state: DurableObjectState) { this.state = state; }
+
+  // ---- storage helpers ----
+  private async phase(): Promise<"lobby" | "playing"> {
+    return ((await this.state.storage.get<string>("phase")) as any) || "lobby";
+  }
+  private async cfg(): Promise<LobbyCfg> {
+    return (await this.state.storage.get<LobbyCfg>("cfg")) || { ...DEFAULT_CFG };
+  }
+  private async loadGame(): Promise<any | null> { return (await this.state.storage.get<any>("game")) || null; }
+  private async saveGame(g: any): Promise<void> { await this.state.storage.put("game", g); }
+  private async bumpTtl(): Promise<number> { const at = Date.now() + ROOM_TTL_MS; await this.state.storage.put("ttlAt", at); return at; }
+
+  private roster(): Attachment[] {
+    const out: Attachment[] = [];
+    for (const ws of this.state.getWebSockets()) {
+      const a = ws.deserializeAttachment() as Attachment | null;
+      if (a) out.push(a);
+    }
+    return out.sort((x, y) => x.id - y.id);
+  }
+  private socketFor(id: number): WebSocket | null {
+    for (const ws of this.state.getWebSockets()) {
+      const a = ws.deserializeAttachment() as Attachment | null;
+      if (a && a.id === id) return ws;
+    }
+    return null;
+  }
+  private broadcast(msg: unknown): void {
+    const data = JSON.stringify(msg);
+    for (const ws of this.state.getWebSockets()) { try { ws.send(data); } catch { /* closing */ } }
+  }
+  private sendId(id: number, msg: unknown): void {
+    const ws = this.socketFor(id);
+    if (ws) { try { ws.send(JSON.stringify(msg)); } catch { /* closing */ } }
+  }
+
+  // ---- lobby + game broadcasting ----
+  private async broadcastLobby(): Promise<void> {
+    const cfg = await this.cfg();
+    const code = (await this.state.storage.get<string>("code")) || "";
+    const players = this.roster().map((a) => ({ id: a.id, name: a.name, ready: a.ready, host: a.host }));
+    this.broadcast({ t: "lobby", code, phase: "lobby", cfg, players, maxPlayers: MAX_PLAYERS });
+  }
+  private broadcastViews(game: any): void {
+    for (const ws of this.state.getWebSockets()) {
+      const a = ws.deserializeAttachment() as Attachment | null;
+      if (!a) continue;
+      try { ws.send(JSON.stringify({ t: "view", view: viewFor(game, a.id) })); } catch { /* closing */ }
+    }
+  }
+
+  // ====================================================================
+  // HTTP (init / ws upgrade / status)
+  // ====================================================================
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname === "/init" && request.method === "POST") {
+      const code = await request.text();
+      await this.state.storage.put({ created: true, code, phase: "lobby", cfg: { ...DEFAULT_CFG } });
+      await this.bumpTtl();
+      await this.state.storage.setAlarm(Date.now() + ROOM_TTL_MS);
+      return new Response("ok");
+    }
+    if (url.pathname === "/ws") {
+      if (request.headers.get("Upgrade") !== "websocket") return new Response("expected websocket", { status: 426 });
+      if (!(await this.state.storage.get("created"))) return new Response("no such room", { status: 404 });
+      const pair = new WebSocketPair();
+      this.state.acceptWebSocket(pair[1]);
+      return new Response(null, { status: 101, webSocket: pair[0] });
+    }
+    if (url.pathname === "/status") {
+      return Response.json({
+        exists: !!(await this.state.storage.get("created")),
+        phase: await this.phase(),
+        players: this.roster().length,
+      });
+    }
+    return new Response("not found", { status: 404 });
+  }
+
+  // ====================================================================
+  // WebSocket messages
+  // ====================================================================
+  async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    if (typeof message !== "string") return;
+    let msg: any;
+    try { msg = JSON.parse(message); } catch { return; }
+    const me = ws.deserializeAttachment() as Attachment | null;
+
+    if (!me) { await this.handleHello(ws, msg); return; }
+
+    switch (msg.t) {
+      case "ready": {
+        if ((await this.phase()) !== "lobby") return;
+        me.ready = !!msg.ready; ws.serializeAttachment(me);
+        await this.broadcastLobby();
+        return;
+      }
+      case "config": {
+        if (!me.host || (await this.phase()) !== "lobby") return;
+        const cur = await this.cfg();
+        const next: LobbyCfg = {
+          mode: msg.mode === "single" ? "single" : "bloody",
+          sevenPairs: msg.sevenPairs !== false,
+          difficulty: ["easy", "normal", "hard"].includes(msg.difficulty) ? msg.difficulty : cur.difficulty,
+        };
+        await this.state.storage.put("cfg", next);
+        await this.broadcastLobby();
+        return;
+      }
+      case "start": {
+        if (!me.host || (await this.phase()) !== "lobby") return;
+        await this.startHand();
+        return;
+      }
+      case "rematch": {
+        if (!me.host || (await this.phase()) !== "playing") return;
+        const g = await this.loadGame();
+        if (!g || g.phase !== "HAND_ENDED") return;
+        await this.startHand(g);
+        return;
+      }
+      case "action": {
+        if ((await this.phase()) !== "playing") return;
+        await this.handleAction(me.id, msg.action);
+        return;
+      }
+      case "pp": { ws.send(JSON.stringify({ t: "pp", ts: msg.ts })); return; }
+    }
+  }
+
+  private async handleHello(ws: WebSocket, msg: any): Promise<void> {
+    if (msg.t !== "hello") { ws.close(1008, "hello first"); return; }
+    const name = sanitizeName(msg.name);
+    const ver = sanitizeVer(msg.ver);
+    const players = this.roster();
+    const hostP = players.find((p) => p.host);
+    if (hostP && ver !== hostP.ver) {
+      ws.send(JSON.stringify({ t: "error", msg: "Game versions differ — fully close the app and reopen it, then rejoin" }));
+      ws.close(1008, "version mismatch");
+      return;
+    }
+
+    if ((await this.phase()) === "playing") {
+      // mid-game REJOIN: reclaim a seat whose human dropped (now driven by a bot)
+      const humanSeats = (await this.state.storage.get<number[]>("humanSeats")) || [];
+      const connected = new Set(players.map((p) => p.id));
+      const g = await this.loadGame();
+      let seatId = -1;
+      for (const id of humanSeats) {
+        if (!connected.has(id) && g && g.players[id] && String(g.players[id].name).toLowerCase() === name.toLowerCase()) { seatId = id; break; }
+      }
+      if (seatId < 0) { ws.send(JSON.stringify({ t: "error", msg: "Game in progress — seat unavailable" })); ws.close(1008, "in progress"); return; }
+      const a: Attachment = { id: seatId, name: g.players[seatId].name, ready: true, host: g.players[seatId].seat === 0, ver };
+      ws.serializeAttachment(a);
+      g.players[seatId].isBot = false; g.players[seatId].connected = true;
+      await this.saveGame(g);
+      const code = (await this.state.storage.get<string>("code")) || "";
+      ws.send(JSON.stringify({ t: "welcome", id: seatId, host: a.host, code, rejoin: true }));
+      ws.send(JSON.stringify({ t: "view", view: viewFor(g, seatId) }));
+      this.broadcastViews(g);
+      await this.armAlarm(g);
+      return;
+    }
+
+    if (players.length >= MAX_PLAYERS) { ws.send(JSON.stringify({ t: "error", msg: "room full" })); ws.close(1008, "room full"); return; }
+    const used = new Set(players.map((p) => p.id));
+    let id = 0; while (used.has(id)) id++;
+    const a: Attachment = { id, name, ready: false, host: players.length === 0, ver };
+    ws.serializeAttachment(a);
+    const code = (await this.state.storage.get<string>("code")) || "";
+    ws.send(JSON.stringify({ t: "welcome", id, host: a.host, code }));
+    await this.broadcastLobby();
+    await this.bumpTtl();
+  }
+
+  // ---- start a fresh hand (carrying scores/dealer if a prior game is passed) ----
+  private async startHand(prev?: any): Promise<void> {
+    const cfg = await this.cfg();
+    const roster = this.roster();
+    const humanSeats = roster.map((a) => a.id);
+    const names: string[] = [];
+    const seats: any[] = [];
+    for (let i = 0; i < 4; i++) {
+      const a = roster.find((p) => p.id === i);
+      seats.push({ isBot: !a, difficulty: cfg.difficulty });
+      names[i] = a ? a.name : `Bot ${i + 1}`;
+    }
+    const seed = (Date.now() ^ (Math.floor(Math.random() * 0x7fffffff))) | 0;
+    const config = makeConfig({ mode: cfg.mode, allowSevenPairs: cfg.sevenPairs });
+    const game = createGame({
+      seed, config, names, seats,
+      dealer: prev ? (prev.nextDealer ?? 0) : 0,
+      seatScores: prev ? prev.players.map((p: any) => p.score) : [0, 0, 0, 0],
+      handNo: prev ? (prev.handNo + 1) : 1,
+    });
+    // mark which seats are humans (vs disconnected) for connection bookkeeping
+    for (let i = 0; i < 4; i++) game.players[i].connected = humanSeats.includes(i);
+    await this.state.storage.put("phase", "playing");
+    await this.state.storage.put("humanSeats", humanSeats);
+    await this.saveGame(game);
+    await this.bumpTtl();
+    this.broadcastViews(game);
+    await this.armAlarm(game);
+  }
+
+  // ---- a human submitted an action ----
+  private async handleAction(seat: number, action: any): Promise<void> {
+    const game = await this.loadGame();
+    if (!game) return;
+    const res = applyAction(game, seat, action);
+    if (!res.ok) {
+      this.sendId(seat, { t: "reject", error: res.error });
+      this.sendId(seat, { t: "view", view: viewFor(game, seat) });
+      return;
+    }
+    await this.saveGame(game);
+    await this.bumpTtl();
+    this.broadcastViews(game);
+    await this.armAlarm(game);
+  }
+
+  // ---- alarm: bot pacing + TTL cleanup ----
+  private botPending(game: any): number {
+    if (!game || game.phase === "HAND_ENDED") return -1;
+    for (const seat of pendingDeciders(game)) {
+      if (game.players[seat].isBot && !game.players[seat].hasWon) return seat;
+    }
+    return -1;
+  }
+  private async armAlarm(game: any): Promise<void> {
+    const hasSockets = this.state.getWebSockets().length > 0;
+    const ttlAt = (await this.state.storage.get<number>("ttlAt")) || (Date.now() + ROOM_TTL_MS);
+    // only pace bots while at least one human is watching
+    if (game && this.botPending(game) >= 0 && hasSockets) {
+      await this.state.storage.setAlarm(Date.now() + BOT_DELAY_MS);
+    } else {
+      await this.state.storage.setAlarm(ttlAt);
+    }
+  }
+  async alarm(): Promise<void> {
+    if (!(await this.state.storage.get("created"))) return;
+    const ttlAt = (await this.state.storage.get<number>("ttlAt")) || 0;
+    if (Date.now() >= ttlAt) {   // idle too long → shut the room down
+      for (const ws of this.state.getWebSockets()) { try { ws.close(1001, "room expired"); } catch { /* */ } }
+      await this.state.storage.deleteAll();
+      return;
+    }
+    if ((await this.phase()) !== "playing") { await this.state.storage.setAlarm(ttlAt); return; }
+    const game = await this.loadGame();
+    const seat = this.botPending(game);
+    if (seat < 0 || this.state.getWebSockets().length === 0) { await this.state.storage.setAlarm(ttlAt); return; }
+    const action = botChooseAction(game, seat);
+    if (action) applyAction(game, seat, action);
+    await this.saveGame(game);
+    this.broadcastViews(game);
+    await this.armAlarm(game);
+  }
+
+  // ====================================================================
+  // disconnect
+  // ====================================================================
+  async webSocketClose(ws: WebSocket): Promise<void> { await this.handleGone(ws); }
+  async webSocketError(ws: WebSocket): Promise<void> { await this.handleGone(ws); }
+
+  private async handleGone(ws: WebSocket): Promise<void> {
+    const me = ws.deserializeAttachment() as Attachment | null;
+    try { ws.close(); } catch { /* */ }
+    if (!me) return;
+    const remaining = this.roster().filter((p) => p.id !== me.id);
+
+    if ((await this.phase()) === "playing") {
+      // seat is taken over by a bot so the hand keeps going; human may rejoin by name
+      const game = await this.loadGame();
+      if (game && game.players[me.id]) {
+        game.players[me.id].isBot = true;
+        game.players[me.id].connected = false;
+        await this.saveGame(game);
+        if (remaining.length > 0) { this.broadcastViews(game); await this.armAlarm(game); }
+      }
+      if (remaining.length === 0) {
+        // nobody watching — let TTL reap it (state preserved for a possible rejoin)
+        const ttlAt = (await this.state.storage.get<number>("ttlAt")) || (Date.now() + ROOM_TTL_MS);
+        await this.state.storage.setAlarm(ttlAt);
+      }
+      return;
+    }
+
+    // lobby: drop the player; promote a new host; reap empty room
+    if (me.host && remaining.length) {
+      const heir = this.socketFor(remaining[0].id);
+      if (heir) {
+        const a = heir.deserializeAttachment() as Attachment;
+        a.host = true; a.ready = false; heir.serializeAttachment(a);
+        heir.send(JSON.stringify({ t: "you-are-host" }));
+      }
+    }
+    if (remaining.length === 0) { await this.state.storage.deleteAll(); return; }
+    await this.broadcastLobby();
+  }
+}

--- a/worker/test/core.test.mjs
+++ b/worker/test/core.test.mjs
@@ -1,0 +1,215 @@
+/* Node test suite for the Sichuan Mahjong core (mahjong.txt §22 + invariants).
+ * Run: node worker/test/core.test.mjs                                        */
+import {
+  createGame, getLegalActions, pendingDeciders, applyAction,
+  isWinningHand, getWinningTiles, isReady, isSevenPairs, score, viewFor,
+  validateConservation, botChooseAction, makeConfig, DEFAULT_CONFIG,
+  tileIndex, tileSuit, tileRank, emptyCounts, countTotal,
+  DOT, BAMBOO, CHARACTER,
+} from '../src/mahjongCore.js';
+
+let pass = 0, fail = 0; const failures = [];
+const ok = (cond, msg) => { if (cond) pass++; else { fail++; failures.push(msg); } };
+const eq = (a, b, msg) => ok(a === b, `${msg} (got ${a}, want ${b})`);
+
+const T = (suit, rank) => tileIndex(suit, rank);
+const counts = (tiles) => { const c = emptyCounts(); for (const t of tiles) c[t]++; return c; };
+const cfg = makeConfig();
+
+/* ---- a minimal player object for pure win/ready checks ---- */
+function P(tiles, melds = [], missing = BAMBOO) {
+  return { seat: 0, concealed: counts(tiles), melds, missingSuit: missing, discards: [] };
+}
+
+/* ===== §22.1 legal standard win ===== */
+{
+  // DOT 1-2-3, DOT 4-5-6, CHAR 2-2-2, CHAR 7-8-9, DOT 9-9 ; missing BAMBOO
+  const tiles = [T(DOT,1),T(DOT,2),T(DOT,3), T(DOT,4),T(DOT,5),T(DOT,6),
+                 T(CHARACTER,2),T(CHARACTER,2),T(CHARACTER,2), T(CHARACTER,7),T(CHARACTER,8),T(CHARACTER,9), T(DOT,9),T(DOT,9)];
+  ok(isWinningHand(P(tiles, [], BAMBOO), cfg), '§22.1 standard win is legal');
+  /* ===== §22.2 illegal due to missing suit (same hand, missing DOT) ===== */
+  ok(!isWinningHand(P(tiles, [], DOT), cfg), '§22.2 win rejected when it contains missing suit');
+}
+
+/* ===== §22.3 / §22.4 pung claim legality via getLegalActions ===== */
+{
+  const s = makeBotState();
+  s.players[1].missingSuit = DOT;
+  s.players[1].concealed = counts([T(BAMBOO,5),T(BAMBOO,5), T(CHARACTER,1),T(CHARACTER,2),T(CHARACTER,3),
+    T(CHARACTER,4),T(CHARACTER,5),T(CHARACTER,6),T(CHARACTER,7),T(CHARACTER,8),T(CHARACTER,9),T(BAMBOO,1),T(BAMBOO,2)]);
+  s.phase = 'AWAITING_DISCARD_REACTIONS';
+  s.reactions = { tile: T(BAMBOO,5), discarder: 0, eligible: [1], responses: {} };
+  let acts = getLegalActions(s, 1);
+  ok(acts.some(a => a.type === 'ClaimPung'), '§22.3 pung offered with two in hand');
+  ok(!acts.some(a => a.type === 'ClaimKongFromDiscard'), 'no kong with only a pair');
+  // one in hand -> no pung
+  s.players[1].concealed = counts([T(BAMBOO,5), T(CHARACTER,1),T(CHARACTER,2),T(CHARACTER,3),
+    T(CHARACTER,4),T(CHARACTER,5),T(CHARACTER,6),T(CHARACTER,7),T(CHARACTER,8),T(CHARACTER,9),T(BAMBOO,1),T(BAMBOO,2),T(BAMBOO,3)]);
+  acts = getLegalActions(s, 1);
+  ok(!acts.some(a => a.type === 'ClaimPung'), '§22.4 no pung with only one matching tile');
+}
+
+/* ===== §22.5 no chow claim ===== */
+{
+  const s = makeBotState();
+  s.players[1].missingSuit = DOT;
+  s.players[1].concealed = counts([T(DOT,1),T(DOT,2), T(CHARACTER,1),T(CHARACTER,2),T(CHARACTER,3),
+    T(CHARACTER,4),T(CHARACTER,5),T(CHARACTER,6),T(CHARACTER,7),T(CHARACTER,8),T(CHARACTER,9),T(BAMBOO,1),T(BAMBOO,2)]);
+  s.phase = 'AWAITING_DISCARD_REACTIONS';
+  s.reactions = { tile: T(DOT,3), discarder: 0, eligible: [1], responses: {} };
+  // DOT is missing for player 1 so they'd also not be eligible; test the general rule:
+  const acts = getLegalActions(s, 1);
+  ok(!acts.some(a => a.type === 'ClaimChow'), '§22.5 chow claim never offered');
+}
+
+/* ===== §22.6 concealed kong ===== */
+{
+  const s = makeBotState();
+  s.players[0].missingSuit = DOT;
+  s.players[0].concealed = counts([T(CHARACTER,8),T(CHARACTER,8),T(CHARACTER,8),T(CHARACTER,8),
+    T(BAMBOO,1),T(BAMBOO,2),T(BAMBOO,3),T(BAMBOO,4),T(BAMBOO,5),T(BAMBOO,6),T(BAMBOO,7),T(BAMBOO,8),T(BAMBOO,9),T(CHARACTER,1)]);
+  s.phase = 'ACTIVE_TURN'; s.active = 0; s.turnFlags = { lastDrawn: T(CHARACTER,1) };
+  const acts = getLegalActions(s, 0);
+  ok(acts.some(a => a.type === 'DeclareConcealedKong' && a.tile === T(CHARACTER,8)), '§22.6 concealed kong offered with four copies');
+}
+
+/* ===== §22.7 seven pairs ===== */
+{
+  const tiles = [T(DOT,1),T(DOT,1),T(DOT,2),T(DOT,2),T(DOT,8),T(DOT,8),
+                 T(BAMBOO,3),T(BAMBOO,3),T(BAMBOO,9),T(BAMBOO,9),T(CHARACTER,4),T(CHARACTER,4),T(CHARACTER,7),T(CHARACTER,7)];
+  ok(isWinningHand(P(tiles, [], -1), cfg), '§22.7 seven pairs is a legal win');   // missing suit absent
+  ok(isSevenPairs(counts(tiles), cfg), 'isSevenPairs detects it');
+  // singleton breaks it
+  const bad = tiles.slice(); bad[0] = T(DOT,5);
+  ok(!isSevenPairs(counts(bad), cfg), 'seven pairs rejects a singleton');
+}
+
+/* ===== seven pairs disabled by config ===== */
+{
+  const tiles = [T(DOT,1),T(DOT,1),T(DOT,2),T(DOT,2),T(DOT,8),T(DOT,8),
+                 T(BAMBOO,3),T(BAMBOO,3),T(BAMBOO,9),T(BAMBOO,9),T(CHARACTER,4),T(CHARACTER,4),T(CHARACTER,7),T(CHARACTER,7)];
+  const noSP = makeConfig({ allowSevenPairs: false });
+  ok(!isWinningHand(P(tiles, [], -1), noSP), 'seven pairs rejected when config disables it');
+}
+
+/* ===== win with a meld (3 concealed groups + pair) ===== */
+{
+  const tiles = [T(DOT,1),T(DOT,2),T(DOT,3), T(DOT,4),T(DOT,5),T(DOT,6), T(CHARACTER,1),T(CHARACTER,2),T(CHARACTER,3), T(DOT,9),T(DOT,9)];
+  const melds = [{ type: 'PUNG', tile: T(CHARACTER,7) }];
+  ok(isWinningHand(P(tiles, melds, BAMBOO), cfg), 'win with one exposed pung meld');
+}
+
+/* ===== ready / ting detection (§16) ===== */
+{
+  const tiles = [T(DOT,1),T(DOT,2),T(DOT,3), T(DOT,4),T(DOT,5),T(DOT,6), T(CHARACTER,1),T(CHARACTER,2),T(CHARACTER,3), T(CHARACTER,7),T(CHARACTER,8),T(CHARACTER,9), T(DOT,9)];
+  const p = P(tiles, [], BAMBOO);
+  const wins = getWinningTiles(p, cfg);
+  ok(wins.length === 1 && wins[0] === T(DOT,9), 'ting detects the single winning tile (pair wait)');
+  ok(isReady(p, cfg), 'isReady true for a tenpai hand');
+}
+
+/* ===== scoring: fan detectors (§14) ===== */
+{
+  // pure one suit + all pungs, self-draw
+  const s = makeBotState();
+  s.players[0].missingSuit = DOT;
+  s.players[0].melds = [];
+  s.players[0].concealed = counts([T(CHARACTER,2),T(CHARACTER,2),T(CHARACTER,2),
+    T(CHARACTER,5),T(CHARACTER,5),T(CHARACTER,5), T(CHARACTER,7),T(CHARACTER,7),T(CHARACTER,7),
+    T(CHARACTER,9),T(CHARACTER,9),T(CHARACTER,9), T(CHARACTER,1),T(CHARACTER,1)]);
+  const sc = score(s, 0, { winType: 'SELF_DRAW', winningTile: T(CHARACTER,1), lastTile: false, afterKong: false });
+  const names = sc.fanAwards.map(f => f.name);
+  ok(names.includes('Self-Draw'), 'scores Self-Draw');
+  ok(names.includes('All Pungs'), 'scores All Pungs');
+  ok(names.includes('Pure One Suit'), 'scores Pure One Suit');
+  // fan cap at 3 -> 8 points
+  eq(sc.finalFan, 3, 'fan capped at limit 3');
+  eq(sc.points, 8, 'points = base*2^3 = 8 at cap');
+}
+{
+  // seven pairs + luxury (a quad) -> includes root too
+  const s = makeBotState();
+  s.players[0].missingSuit = DOT;
+  s.players[0].concealed = counts([T(CHARACTER,1),T(CHARACTER,1),T(CHARACTER,1),T(CHARACTER,1),
+    T(CHARACTER,3),T(CHARACTER,3), T(CHARACTER,5),T(CHARACTER,5), T(BAMBOO,2),T(BAMBOO,2),
+    T(BAMBOO,7),T(BAMBOO,7), T(CHARACTER,8),T(CHARACTER,8)]);
+  const sc = score(s, 0, { winType: 'SELF_DRAW', winningTile: T(CHARACTER,8), lastTile: false, afterKong: false });
+  const names = sc.fanAwards.map(f => f.name);
+  ok(names.includes('Seven Pairs'), 'scores Seven Pairs');
+  ok(names.includes('Luxury Seven Pairs'), 'scores Luxury Seven Pairs (quad)');
+}
+
+/* ===== full random bot games: legality + conservation + determinism ===== */
+function makeBotState(seed = 1) {
+  return createGame({ seed, seats: [
+    { isBot: true, difficulty: 'hard' }, { isBot: true, difficulty: 'normal' },
+    { isBot: true, difficulty: 'easy' }, { isBot: true, difficulty: 'normal' },
+  ]});
+}
+function playOut(seed, checkCons) {
+  const s = createGame({ seed, seats: [
+    { isBot: true, difficulty: 'hard' }, { isBot: true, difficulty: 'normal' },
+    { isBot: true, difficulty: 'easy' }, { isBot: true, difficulty: 'hard' },
+  ]});
+  let guard = 0, illegal = 0;
+  while (s.phase !== 'HAND_ENDED' && guard++ < 3000) {
+    const deciders = pendingDeciders(s);
+    if (!deciders.length) throw new Error('no deciders but not ended at phase ' + s.phase);
+    const seat = deciders[0];
+    const a = botChooseAction(s, seat);
+    if (!a) throw new Error('bot returned null with legal actions for seat ' + seat);
+    const res = applyAction(s, seat, a);
+    if (!res.ok) { illegal++; throw new Error('illegal bot action ' + JSON.stringify(a) + ' -> ' + res.error.code); }
+    if (checkCons) {
+      const c = validateConservation(s);
+      if (!c.ok) throw new Error('conservation broken: ' + JSON.stringify(c) + ' after ' + JSON.stringify(a));
+    }
+  }
+  return { s, illegal, guard };
+}
+{
+  let games = 0, errs = 0, ended = 0, wins = 0;
+  for (let seed = 1; seed <= 300; seed++) {
+    try {
+      const { s } = playOut(seed, true); // full conservation check on every action of every game
+      games++;
+      if (s.phase === 'HAND_ENDED') ended++;
+      wins += s.winnersThisHand.length;
+    } catch (e) { errs++; failures.push('fuzz seed ' + seed + ': ' + e.message); }
+  }
+  eq(errs, 0, `120 bot games ran with no engine/legality/conservation errors`);
+  eq(ended, games, 'every game reached HAND_ENDED');
+  ok(wins >= 0, `total winners across games = ${wins}`);
+}
+/* determinism: same seed -> identical event log */
+{
+  const a = playOut(7, false).s;
+  const b = playOut(7, false).s;
+  eq(JSON.stringify(a.log), JSON.stringify(b.log), 'same seed -> identical event log (deterministic)');
+  eq(JSON.stringify(a.players.map(p => p.score)), JSON.stringify(b.players.map(p => p.score)), 'same seed -> identical scores');
+}
+
+/* ===== redaction: viewFor hides other players' concealed tiles ===== */
+{
+  const s = makeBotState(3);
+  // advance through missing suit selection so play has started
+  let guard = 0;
+  while (s.phase === 'MISSING_SUIT_SELECTION' && guard++ < 10) {
+    const d = pendingDeciders(s)[0];
+    applyAction(s, d, botChooseAction(s, d));
+  }
+  const v = viewFor(s, 0);
+  ok(v.me.concealed && countTotal(v.me.concealed) > 0, 'view exposes my own concealed hand');
+  ok(v.players[1].handCount > 0 && v.players[1].concealed === undefined, 'view hides opponents concealed tiles (only a count)');
+  ok(Array.isArray(v.me.legalActions), 'view includes my legal actions');
+}
+
+/* ===== conservation holds on a fresh deal ===== */
+{
+  const s = makeBotState(99);
+  const c = validateConservation(s);
+  ok(c.ok, 'fresh deal conserves 108 tiles, 4 of each');
+}
+
+console.log(`\nSichuan Mahjong core: ${pass} passed, ${fail} failed.`);
+if (failures.length) { console.log('\nFailures:\n - ' + failures.join('\n - ')); process.exitCode = 1; }

--- a/worker/test/core.test.mjs
+++ b/worker/test/core.test.mjs
@@ -127,7 +127,7 @@ function P(tiles, melds = [], missing = BAMBOO) {
   eq(sc.points, 8, 'points = base*2^3 = 8 at cap');
 }
 {
-  // seven pairs + luxury (a quad) -> includes root too
+  // seven pairs + luxury (a quad): the quad is credited as Luxury, NOT also as Root
   const s = makeBotState();
   s.players[0].missingSuit = DOT;
   s.players[0].concealed = counts([T(CHARACTER,1),T(CHARACTER,1),T(CHARACTER,1),T(CHARACTER,1),
@@ -137,6 +137,7 @@ function P(tiles, melds = [], missing = BAMBOO) {
   const names = sc.fanAwards.map(f => f.name);
   ok(names.includes('Seven Pairs'), 'scores Seven Pairs');
   ok(names.includes('Luxury Seven Pairs'), 'scores Luxury Seven Pairs (quad)');
+  ok(!names.includes('Root'), 'Root NOT double-counted on a seven-pairs quad (Luxury already credits it)');
 }
 
 /* ===== full random bot games: legality + conservation + determinism ===== */
@@ -177,7 +178,7 @@ function playOut(seed, checkCons) {
       wins += s.winnersThisHand.length;
     } catch (e) { errs++; failures.push('fuzz seed ' + seed + ': ' + e.message); }
   }
-  eq(errs, 0, `120 bot games ran with no engine/legality/conservation errors`);
+  eq(errs, 0, `300 bot games ran with no engine/legality/conservation errors`);
   eq(ended, games, 'every game reached HAND_ENDED');
   ok(wins >= 0, `total winners across games = ${wins}`);
 }

--- a/worker/test/core.test.mjs
+++ b/worker/test/core.test.mjs
@@ -203,6 +203,11 @@ function playOut(seed, checkCons) {
   ok(v.me.concealed && countTotal(v.me.concealed) > 0, 'view exposes my own concealed hand');
   ok(v.players[1].handCount > 0 && v.players[1].concealed === undefined, 'view hides opponents concealed tiles (only a count)');
   ok(Array.isArray(v.me.legalActions), 'view includes my legal actions');
+  // an opponent's concealed kong (暗杠) must not leak its tile during play, but the owner sees it
+  s.players[2].melds = [{ type: 'KONG_CONCEALED', tile: T(CHARACTER, 7), concealed: true }];
+  const vOpp = viewFor(s, 0).players[2].melds[0];
+  ok(vOpp.hidden === true && (vOpp.tile === -1 || vOpp.tile == null), 'opponent concealed-kong tile is redacted during play');
+  ok(viewFor(s, 2).players[2].melds[0].tile === T(CHARACTER, 7), 'owner still sees their own concealed-kong tile');
 }
 
 /* ===== conservation holds on a fresh deal ===== */

--- a/worker/test/edge.test.mjs
+++ b/worker/test/edge.test.mjs
@@ -1,0 +1,94 @@
+import * as M from '../src/mahjongCore.js';
+const { createGame, getLegalActions, pendingDeciders, applyAction, botChooseAction, tileIndex, validateConservation } = M;
+const T = (s,r)=>tileIndex(s,r); const DOT=0,BAM=1,CHA=2;
+let pass=0,fail=0; const F=[];
+const ok=(c,m)=>{ if(c)pass++; else {fail++;F.push(m);} };
+function counts(list){ const c=new Array(27).fill(0); for(const t of list)c[t]++; return c; }
+function freshSkeleton(mode='bloody'){ const s=createGame({seed:1, config:M.makeConfig({mode})}); return s; }
+
+/* ---- ROB THE KONG (§6.9, §22.9) ---- */
+{
+  const s=freshSkeleton();
+  s.phase='ACTIVE_TURN'; s.active=0; s.firstDiscardDone=true;
+  s.turnFlags={needsDraw:false,drewFromKong:false,lastDrawn:T(BAM,5),firstTurn:false,afterPung:false,lastTileExhausted:false};
+  for(const p of s.players){ p.missingSuit=DOT; p.melds=[]; p.hasWon=false; }
+  // P0: exposed pung of BAM5 + holds the 4th BAM5
+  s.players[0].melds=[{type:'PUNG',tile:T(BAM,5),source:1,concealed:false}];
+  s.players[0].concealed=counts([T(BAM,5), T(CHA,1),T(CHA,2),T(CHA,3),T(CHA,4),T(CHA,5),T(CHA,6),T(CHA,7),T(CHA,8),T(CHA,9),T(BAM,1)]);
+  // P1: tenpai waiting on BAM5
+  s.players[1].concealed=counts([T(BAM,3),T(BAM,4), T(CHA,1),T(CHA,2),T(CHA,3), T(CHA,4),T(CHA,5),T(CHA,6), T(CHA,7),T(CHA,8),T(CHA,9), T(BAM,9),T(BAM,9)]);
+  // P2,P3 junk (cannot win on BAM5)
+  s.players[2].concealed=counts([T(CHA,1),T(CHA,1),T(CHA,3),T(CHA,5),T(CHA,7),T(BAM,2),T(BAM,2),T(BAM,4),T(BAM,6),T(BAM,8),T(CHA,9),T(CHA,8),T(CHA,6)]);
+  s.players[3].concealed=counts([T(CHA,2),T(CHA,2),T(CHA,4),T(CHA,6),T(CHA,8),T(BAM,1),T(BAM,1),T(BAM,3),T(BAM,6),T(BAM,7),T(CHA,7),T(CHA,5),T(CHA,3)]);
+  const acts0=getLegalActions(s,0);
+  ok(acts0.some(a=>a.type==='DeclareAddedKong'&&a.tile===T(BAM,5)),'rob: added kong offered to P0');
+  const r1=applyAction(s,0,{type:'DeclareAddedKong',tile:T(BAM,5)});
+  ok(r1.ok,'rob: added kong applied');
+  ok(s.phase==='AWAITING_ROB_KONG_REACTIONS','rob: entered rob window');
+  const acts1=getLegalActions(s,1);
+  ok(acts1.some(a=>a.type==='RobKong'&&a.tile===T(BAM,5)),'rob: P1 offered RobKong');
+  ok(!getLegalActions(s,2).some(a=>a.type==='RobKong'),'rob: P2 cannot rob (not tenpai on tile)');
+  const r2=applyAction(s,1,{type:'RobKong',tile:T(BAM,5)});
+  ok(r2.ok && s.players[1].hasWon,'rob: P1 wins by robbing the kong');
+  ok(s.players[1].winRecords[0].winType==='ROB_KONG','rob: recorded as ROB_KONG');
+  ok(s.players[1].winRecords[0].deltas[0]<0,'rob: declarer P0 pays the winner');
+  ok(s.players[0].melds[0].type==='PUNG','rob: cancelled kong stays a pung');
+  // CRITICAL regression: declarer must return to 13 effective tiles (concealed + 3*pung), not 14
+  { const eff=s.players[0].concealed.reduce((a,b)=>a+b,0)+s.players[0].melds.reduce((a,m)=>a+(m.type==='PUNG'?3:4),0);
+    ok(eff===13,'rob: declarer back to 13 effective tiles (not stuck at 14) — got '+eff); }
+  { const phys=new Array(27).fill(0); phys[T(BAM,5)]=0;
+    for(const p of s.players){ for(let t=0;t<27;t++)phys[t]+=p.concealed[t]; for(const m of p.melds)phys[m.tile]+=(m.type==='PUNG'?3:4); for(const d of p.discards)phys[d]++; }
+    ok(phys[T(BAM,5)]===4,'rob: all 4 copies of the robbed tile still accounted for — got '+phys[T(BAM,5)]); }
+}
+
+/* ---- MULTIPLE WINNERS ON ONE DISCARD (§10.1, §22.8) ---- */
+{
+  const s=freshSkeleton();
+  s.phase='ACTIVE_TURN'; s.active=0; s.firstDiscardDone=true;
+  s.turnFlags={needsDraw:false,drewFromKong:false,lastDrawn:T(CHA,1),firstTurn:false,afterPung:false,lastTileExhausted:false};
+  for(const p of s.players){ p.missingSuit=DOT; p.melds=[]; }
+  // P0 will discard BAM5; P1 and P2 both tenpai on BAM5
+  s.players[0].concealed=counts([T(BAM,5), T(CHA,1),T(CHA,1),T(CHA,2),T(CHA,3),T(CHA,4),T(CHA,5),T(CHA,6),T(CHA,7),T(CHA,8),T(CHA,9),T(BAM,9),T(BAM,9),T(BAM,8)]);
+  const wait=[T(BAM,3),T(BAM,4), T(CHA,1),T(CHA,2),T(CHA,3), T(CHA,4),T(CHA,5),T(CHA,6), T(CHA,7),T(CHA,8),T(CHA,9), T(BAM,9),T(BAM,9)];
+  s.players[1].concealed=counts(wait);
+  s.players[2].concealed=counts(wait);
+  s.players[3].concealed=counts([T(CHA,2),T(CHA,2),T(CHA,4),T(CHA,6),T(CHA,8),T(BAM,1),T(BAM,1),T(BAM,2),T(BAM,4),T(BAM,6),T(CHA,7),T(CHA,5),T(CHA,3)]);
+  applyAction(s,0,{type:'Discard',tile:T(BAM,5)});
+  ok(s.phase==='AWAITING_DISCARD_REACTIONS','multiwin: reaction window opened');
+  ok(getLegalActions(s,1).some(a=>a.type==='DeclareWinFromDiscard'),'multiwin: P1 can win');
+  ok(getLegalActions(s,2).some(a=>a.type==='DeclareWinFromDiscard'),'multiwin: P2 can win');
+  applyAction(s,1,{type:'DeclareWinFromDiscard',tile:T(BAM,5)});
+  applyAction(s,2,{type:'DeclareWinFromDiscard',tile:T(BAM,5)});
+  ok(s.players[1].hasWon && s.players[2].hasWon,'multiwin: both P1 and P2 win on the same discard');
+  ok(s.players[0].score<0,'multiwin: discarder P0 pays both');
+  ok(s.players[1].concealed[T(BAM,5)]===0 && s.players[2].concealed[T(BAM,5)]===0,'multiwin: winning tile scored virtually (not persisted into either winner hand)');
+}
+
+/* ---- SINGLE MODE ends at first win ---- */
+{
+  let games=0, okEnds=0;
+  for(let seed=1;seed<=40;seed++){
+    const s=createGame({seed, config:M.makeConfig({mode:'single'}), seats:[{isBot:true,difficulty:'hard'},{isBot:true},{isBot:true},{isBot:true}]});
+    let g=0, endedAtWin=true; while(s.phase!=='HAND_ENDED'&&g++<3000){ const d=pendingDeciders(s); if(!d.length)break; applyAction(s,d[0],botChooseAction(s,d[0])); if(s.winnersThisHand.length>0 && s.phase!=='HAND_ENDED') endedAtWin=false; }
+    games++;
+    if(endedAtWin) okEnds++;
+  }
+  ok(okEnds===games, `single mode: hand ends immediately at the first win (no continued play) (${okEnds}/${games})`);
+}
+
+/* ---- HEAVENLY HAND (dealer initial 14 is a win) ---- */
+{
+  const s=freshSkeleton();
+  s.phase='ACTIVE_TURN'; s.active=0; s.dealer=0; s.firstDiscardDone=false;
+  s.turnFlags={needsDraw:false,drewFromKong:false,lastDrawn:null,firstTurn:true,afterPung:false,lastTileExhausted:false};
+  for(const p of s.players){ p.missingSuit=DOT; p.melds=[]; }
+  s.players[0].concealed=counts([T(BAM,1),T(BAM,2),T(BAM,3), T(BAM,4),T(BAM,5),T(BAM,6), T(BAM,7),T(BAM,8),T(BAM,9), T(CHA,1),T(CHA,2),T(CHA,3), T(CHA,9),T(CHA,9)]);
+  const acts=getLegalActions(s,0);
+  ok(acts.some(a=>a.type==='DeclareSelfDrawWin'),'heavenly: dealer can self-draw-win on opening hand');
+  applyAction(s,0,{type:'DeclareSelfDrawWin'});
+  const rec=s.players[0].winRecords[0];
+  ok(rec && rec.fanAwards.some(f=>f.name==='Heavenly Hand'),'heavenly: scored as Heavenly Hand');
+}
+
+console.log(`\nEdge cases: ${pass} passed, ${fail} failed.`);
+if(F.length) console.log(' - '+F.join('\n - '));

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -20,8 +20,15 @@ GOOGLE_CLIENT_ID = "611505411727-94u34em16j7sd0rdigejmvfdgnjj67ma.apps.googleuse
 ALLOWED_EMAILS = "m.polkiewicz@gmail.com,ting520143@gmail.com"
 
 [durable_objects]
-bindings = [{ name = "KART3_ROOM", class_name = "Kart3Room" }]
+bindings = [
+  { name = "KART3_ROOM", class_name = "Kart3Room" },
+  { name = "MAHJONG_ROOM", class_name = "MahjongRoom" },
+]
 
 [[migrations]]
 tag = "kart3-room-v1"
 new_sqlite_classes = ["Kart3Room"]
+
+[[migrations]]
+tag = "mahjong-room-v1"
+new_sqlite_classes = ["MahjongRoom"]


### PR DESCRIPTION
Adds a full **Sichuan Mahjong (血战到底 / Bloody Battle)** game at `/apps/mahjong/`, supporting any mix of **1–4 humans + bots**, both **local hot-seat** and **online multiplayer**, built against the formal rules-engine spec (`mahjong.txt`).

## Architecture — one engine, two modes
- **Canonical engine** `worker/src/mahjongCore.js`: pure, deterministic, config-driven state machine (no DOM/IO, JSON-serializable state) implementing the spec §1–27. The identical region is inlined into the self-contained `apps/mahjong/index.html` by `apps/mahjong/build-core.mjs`; `tests/core-sync.mjs` guards against drift.
- **One renderer, two drivers** behind a `GameConnection` seam: `LocalConnection` runs the engine in-browser (hot-seat reveal gates, local bots); `OnlineConnection` is the same `submit`/`view` contract over a WebSocket.
- **Online is server-authoritative** (`worker/src/mahjongroom.ts`, `MahjongRoom` Durable Object): the DO runs the same engine and holds all hidden state, sending each client only its own redacted `viewFor()` snapshot. A host-authoritative relay (like kart3) would let the host's browser see everyone's tiles — a cheat vector for a hidden-information game. Mirrors the kart3 patterns: hibernation, room codes, origin-gating, 45-min TTL, disconnect→bot takeover, rejoin-by-name.

## Rules (spec-faithful)
108 tiles / 3 suits / no honors, mandatory 定缺 missing-suit, no chow claims, pung + 3 kinds of kong, win (self-draw / discard / rob-kong), multiple winners on one discard, fan scoring with cap + 刮风下雨 kong payments, bloody continuation to 3 winners, exhaustion penalties, ready/ting hints.

## AI
Three difficulty tiers using only public info + own hand, validated through the engine before every move (no hidden info, no cheating). Server-side bots are paced by the DO alarm.

## Testing
- `node worker/test/core.test.mjs` — spec §22 cases, scoring, redaction, and a **300-game fuzz with tile conservation checked on every action**.
- Headless Chrome: 1- and 2-human local games to completion (0 exceptions).
- Two real browsers + `wrangler dev`: lobby → start → full hands, redaction holding on every view, multi-winner discards, rematch with carried scores (0 exceptions).
- `tsc --noEmit` clean.

## Worker changes
New `MahjongRoom` DO + `mahjong-room-v1` migration + `/mahjong/rooms*` routes. Deploys via the existing worker GitHub Action on merge to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)