### PR TITLE
Mahjong: offline support (service worker) — local play with no network

### DIFF
--- a/apps/mahjong/index.html
+++ b/apps/mahjong/index.html
@@ -1991,6 +1991,11 @@ function startOnline(mode) {
 
 wireSetup();
 window.__mahjongClient = { onUpdate, render, get conn() { return conn; }, set conn(c) { conn = c; }, set online(v) { online = v; }, viewFor, createGame, makeConfig };
+
+/* register the offline service worker (local play works with no network once cached) */
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => { navigator.serviceWorker.register('sw.js').catch(() => {}); });
+}
 </script>
 </body>
 </html>

--- a/apps/mahjong/index.html
+++ b/apps/mahjong/index.html
@@ -1994,7 +1994,7 @@ window.__mahjongClient = { onUpdate, render, get conn() { return conn; }, set co
 
 /* register the offline service worker (local play works with no network once cached) */
 if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => { navigator.serviceWorker.register('sw.js').catch(() => {}); });
+  window.addEventListener('load', () => { navigator.serviceWorker.register('sw.js').catch((err) => console.warn('[mahjong SW]', err)); });
 }
 </script>
 </body>

--- a/apps/mahjong/sw.js
+++ b/apps/mahjong/sw.js
@@ -16,7 +16,7 @@
 const VERSION = 'v1';
 const CACHE = 'mahjong-' + VERSION;
 const SHELL = [
-  './',
+  './',                       // the start_url; GitHub Pages serves index.html (200) here
   './index.html',
   './manifest.webmanifest',
   './icon-180.png',
@@ -24,9 +24,18 @@ const SHELL = [
   './icon-512.png',
 ];
 
+// Cache a response, keeping the SW alive until the write finishes (iOS can otherwise
+// terminate it mid-write). Best-effort: never reject the request on a cache failure.
+function cachePut(event, req, resClone) {
+  event.waitUntil(caches.open(CACHE).then((c) => c.put(req, resClone)).catch(() => {}));
+}
+
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE).then((c) => c.addAll(SHELL)).then(() => self.skipWaiting())
+    caches.open(CACHE)
+      // resilient: a single bad entry shouldn't fail the whole install
+      .then((c) => Promise.all(SHELL.map((u) => c.add(u).catch(() => {}))))
+      .then(() => self.skipWaiting())
   );
 });
 
@@ -49,18 +58,21 @@ self.addEventListener('fetch', (event) => {
 
   const isHTML = req.mode === 'navigate' || (req.headers.get('accept') || '').includes('text/html');
   if (isHTML) {
+    // network-first: fresh when online, cached index.html when offline
     event.respondWith(
       fetch(req)
-        .then((res) => { const copy = res.clone(); caches.open(CACHE).then((c) => c.put(req, copy)); return res; })
+        .then((res) => { if (res.ok) cachePut(event, req, res.clone()); return res; })
         .catch(() => caches.match(req).then((r) => r || caches.match('./index.html')))
     );
     return;
   }
+  // static assets: cache-first, fill cache on first fetch
   event.respondWith(
-    caches.match(req).then((cached) =>
-      cached || fetch(req).then((res) => {
-        const copy = res.clone(); caches.open(CACHE).then((c) => c.put(req, copy)); return res;
-      }).catch(() => cached)
-    )
+    caches.match(req).then((cached) => {
+      if (cached) return cached;
+      return fetch(req)
+        .then((res) => { if (res.ok) cachePut(event, req, res.clone()); return res; })
+        .catch(() => new Response('Offline', { status: 503, statusText: 'Offline' }));
+    })
   );
 });

--- a/apps/mahjong/sw.js
+++ b/apps/mahjong/sw.js
@@ -1,0 +1,66 @@
+/* Sichuan Mahjong — offline service worker.
+ *
+ * The app is one self-contained index.html, so caching the app shell lets LOCAL
+ * (hot-seat + bots) play run with no network at all — e.g. launched from the Home
+ * Screen on a plane. Online multiplayer still needs the Cloudflare worker; those
+ * cross-origin requests are passed straight through and just fail gracefully when
+ * offline (the client already shows "Disconnected").
+ *
+ * Strategy:
+ *   - HTML/navigations: network-first (you always get the latest build when online,
+ *     matching the site's "always fresh" convention) with the cached copy as the
+ *     offline fallback.
+ *   - static assets (icons, manifest): cache-first, populated on first fetch.
+ *
+ * Bump VERSION on release to refresh the precached shell and drop old caches. */
+const VERSION = 'v1';
+const CACHE = 'mahjong-' + VERSION;
+const SHELL = [
+  './',
+  './index.html',
+  './manifest.webmanifest',
+  './icon-180.png',
+  './icon-192.png',
+  './icon-512.png',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE).then((c) => c.addAll(SHELL)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys()
+      .then((keys) => Promise.all(
+        keys.filter((k) => k.startsWith('mahjong-') && k !== CACHE).map((k) => caches.delete(k))
+      ))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+  if (req.method !== 'GET') return;                          // never touch POST/etc.
+  const url = new URL(req.url);
+  if (url.origin !== self.location.origin) return;           // let online-play requests hit the network
+  if (!url.pathname.startsWith('/apps/mahjong/')) return;    // only this app's scope
+
+  const isHTML = req.mode === 'navigate' || (req.headers.get('accept') || '').includes('text/html');
+  if (isHTML) {
+    event.respondWith(
+      fetch(req)
+        .then((res) => { const copy = res.clone(); caches.open(CACHE).then((c) => c.put(req, copy)); return res; })
+        .catch(() => caches.match(req).then((r) => r || caches.match('./index.html')))
+    );
+    return;
+  }
+  event.respondWith(
+    caches.match(req).then((cached) =>
+      cached || fetch(req).then((res) => {
+        const copy = res.clone(); caches.open(CACHE).then((c) => c.put(req, copy)); return res;
+      }).catch(() => cached)
+    )
+  );
+});


### PR DESCRIPTION
Makes the mahjong PWA work **offline** so you can launch it from the Home Screen and play locally with no connection (e.g. on a plane).

## How
Adds `apps/mahjong/sw.js` (registered from `index.html`). The app is a single self-contained `index.html`, so caching the app shell is enough to run **local hot-seat + bot** play with zero network.

**Caching strategy**
- **HTML / navigations: network-first** — you always get the latest build when online (matches the site's "always fresh" convention); the cached copy is the offline fallback.
- **Static assets (icons, manifest): cache-first.**
- **Versioned cache** (`mahjong-v1`); `activate` drops old caches. Bump `VERSION` on release.

**Online multiplayer is untouched.** The service worker only intercepts same-origin `/apps/mahjong/` GET requests and passes everything else through — including the cross-origin Cloudflare worker `fetch` and the WebSocket — so online play is unaffected when online and fails gracefully when offline.

## What works offline vs not
- ✅ Local / hot-seat play (1–4 humans + bots) — fully offline once cached.
- ❌ Online multiplayer — needs the server (expected).

## Verification (headless Chrome)
- App shell precached (root, `index.html`, manifest, 3 icons); page is SW-controlled.
- Forced the network **offline**, **reloaded**, and the app **loaded from cache**; a **full local hand played to completion** (scores conserve, 0 exceptions).
- With the SW active and **online**, a **two-browser online game still completed** normally (cross-origin requests pass through).
- `core-sync` intact (engine untouched); `sw.js` serves 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)