### PR TITLE
Mahjong online reliability: rejoin, bot-stall, reconnect

### DIFF
--- a/apps/mahjong/index.html
+++ b/apps/mahjong/index.html
@@ -2056,9 +2056,13 @@ class OnlineConnection {
   }
   onClose() {
     if (!this.alive) return;
+    this.retries++;
+    // Keep retrying with capped backoff for several minutes — the server holds your seat for
+    // ~45 min, so a tunnel / elevator / longer outage should recover on its own instead of
+    // stranding you after a few seconds. (retries resets to 0 on a successful reconnect.)
+    if (this.retries > 40) { updateConnPill({ text: 'Disconnected', state: 'bad' }); toast('Connection lost — reopen the app to rejoin', 2400); return; }
     updateConnPill({ text: 'Reconnecting…', state: 'bad' });
-    if (this.retries < 6) { this.retries++; setTimeout(() => { if (this.alive) this.connect(); }, 700 * this.retries); }
-    else { updateConnPill({ text: 'Disconnected', state: 'bad' }); toast('Connection lost', 1600); }
+    setTimeout(() => { if (this.alive) this.connect(); }, Math.min(6000, 700 * this.retries));
   }
   setReady(r) { this.rawsend({ t: 'ready', ready: r }); }
   setConfig(c) { this.rawsend({ t: 'config', ...c }); }

--- a/worker/src/mahjongroom.ts
+++ b/worker/src/mahjongroom.ts
@@ -184,15 +184,23 @@ export class MahjongRoom {
       // redeploy mid-hand shouldn't lock a reconnecting player out.
       const humanSeats = (await this.state.storage.get<number[]>("humanSeats")) || [];
       const seatTokens = (await this.state.storage.get<Record<number, string>>("seatTokens")) || {};
-      const connected = new Set(players.map((p) => p.id));
       const token = typeof msg.token === "string" ? msg.token : "";
       const g = await this.loadGame();
       if (!g) { ws.send(JSON.stringify({ t: "error", msg: "Game state unavailable — please try again" })); ws.close(1011, "no game"); return; }
+      // Match purely on the secret token (the credential) — NOT on whether the seat looks
+      // free. On a mobile blip the reconnect can beat the old socket's close, so the seat may
+      // still look "connected"; the rightful owner (proven by token) must still get back in.
       let seatId = -1;
       if (token) for (const id of humanSeats) {
-        if (!connected.has(id) && seatTokens[id] && seatTokens[id] === token) { seatId = id; break; }
+        if (seatTokens[id] && seatTokens[id] === token) { seatId = id; break; }
       }
       if (seatId < 0) { ws.send(JSON.stringify({ t: "error", msg: "Game in progress — seat unavailable" })); ws.close(1008, "in progress"); return; }
+      // evict any stale socket still holding this seat so the returning player takes it over
+      for (const sock of this.state.getWebSockets()) {
+        if (sock === ws) continue;
+        const at = sock.deserializeAttachment() as Attachment | null;
+        if (at && at.id === seatId) { try { sock.close(1000, "reconnected"); } catch { /* */ } }
+      }
       const hostSeat = await this.state.storage.get<number>("hostSeat");
       const a: Attachment = { id: seatId, name: g.players[seatId].name, ready: true, host: seatId === hostSeat, ver };
       ws.serializeAttachment(a);
@@ -240,13 +248,21 @@ export class MahjongRoom {
   private async startHand(prev?: any): Promise<void> {
     const cfg = await this.cfg();
     const roster = this.roster();
-    const humanSeats = roster.map((a) => a.id);
+    const connectedIds = new Set(roster.map((a) => a.id));
+    const seatTokens = (await this.state.storage.get<Record<number, string>>("seatTokens")) || {};
     const names: string[] = [];
     const seats: any[] = [];
+    const humanSeats: number[] = [];
     for (let i = 0; i < 4; i++) {
       const a = roster.find((p) => p.id === i);
+      // A seat is "human-owned" while someone holds its reconnect token. Keep that ownership
+      // ACROSS hands: a player who's briefly disconnected when the next hand is dealt would
+      // otherwise be dropped from humanSeats and could never rejoin (the reported bug). A bot
+      // plays the seat until they return; seats no human ever took are permanent bots.
+      const owned = !!a || !!seatTokens[i];
       seats.push({ isBot: !a, difficulty: cfg.difficulty });
-      names[i] = a ? a.name : `Bot ${i + 1}`;
+      names[i] = a ? a.name : (owned && prev && prev.players[i] ? prev.players[i].name : `Bot ${i + 1}`);
+      if (owned) humanSeats.push(i);
     }
     const seed = (Date.now() ^ (Math.floor(Math.random() * 0x7fffffff))) | 0;
     const config = makeConfig({ mode: cfg.mode, allowSevenPairs: cfg.sevenPairs });
@@ -256,8 +272,9 @@ export class MahjongRoom {
       seatScores: prev ? prev.players.map((p: any) => p.score) : [0, 0, 0, 0],
       handNo: prev ? (prev.handNo + 1) : 1,
     });
-    // mark which seats are humans (vs disconnected) for connection bookkeeping
-    for (let i = 0; i < 4; i++) game.players[i].connected = humanSeats.includes(i);
+    // a seat is "connected" only if its human is actually present right now (an owned seat
+    // whose player is away is played by a bot, but stays in humanSeats so they can rejoin)
+    for (let i = 0; i < 4; i++) game.players[i].connected = connectedIds.has(i);
     await this.state.storage.put("phase", "playing");
     await this.state.storage.put("humanSeats", humanSeats);
     await this.saveGame(game);
@@ -330,6 +347,14 @@ export class MahjongRoom {
     const me = ws.deserializeAttachment() as Attachment | null;
     try { ws.close(); } catch { /* */ }
     if (!me) return;
+    // If a newer socket already holds this seat (a fast reconnect replaced us), this is just
+    // the stale socket closing — don't demote the seat or touch the roster.
+    const stillHeld = this.state.getWebSockets().some((s) => {
+      if (s === ws) return false;
+      const a2 = s.deserializeAttachment() as Attachment | null;
+      return a2 != null && a2.id === me.id;
+    });
+    if (stillHeld) return;
     const remaining = this.roster().filter((p) => p.id !== me.id);
 
     // if the host left and others remain, promote a connected player so host-only

--- a/worker/src/mahjongroom.ts
+++ b/worker/src/mahjongroom.ts
@@ -326,12 +326,20 @@ export class MahjongRoom {
       return;
     }
     if ((await this.phase()) !== "playing") { await this.state.storage.setAlarm(ttlAt); return; }
-    const game = await this.loadGame();
+    let game = await this.loadGame();
     const seat = this.botPending(game);
     if (seat < 0 || this.state.getWebSockets().length === 0) { await this.state.storage.setAlarm(ttlAt); return; }
     const action = botChooseAction(game, seat);
-    const res = action ? applyAction(game, seat, action) : { ok: false };
-    if (!res.ok) { await this.state.storage.setAlarm(ttlAt); return; }  // never spin the alarm on a stuck seat
+    let res = action ? applyAction(game, seat, action) : { ok: false };
+    if (!res.ok) {
+      // The bot returned no/an illegal action. Rather than freeze the whole table until TTL,
+      // reload a clean state and play ANY legal move so the hand always progresses. Defensive:
+      // botChooseAction shouldn't fail, but a single edge case must not strand real players.
+      game = await this.loadGame();
+      res = { ok: false };
+      for (const alt of getLegalActions(game, seat)) { const r = applyAction(game, seat, alt); if (r.ok) { res = r; break; } }
+      if (!res.ok) { await this.state.storage.setAlarm(ttlAt); return; }  // truly nothing legal — don't spin
+    }
     await this.saveGame(game);
     this.broadcastViews(game);
     await this.armAlarm(game);

--- a/worker/src/mahjongroom.ts
+++ b/worker/src/mahjongroom.ts
@@ -195,15 +195,19 @@ export class MahjongRoom {
         if (seatTokens[id] && seatTokens[id] === token) { seatId = id; break; }
       }
       if (seatId < 0) { ws.send(JSON.stringify({ t: "error", msg: "Game in progress — seat unavailable" })); ws.close(1008, "in progress"); return; }
-      // evict any stale socket still holding this seat so the returning player takes it over
+      // Attach the new socket to this seat BEFORE evicting any stale one. The eviction's
+      // webSocketClose can interleave at an await, and handleGone's stillHeld guard only
+      // short-circuits if it can see our attachment — otherwise it treats the close as a real
+      // disconnect and (if this seat is the host) reassigns the host out from under us.
+      const hostSeat = await this.state.storage.get<number>("hostSeat");
+      const a: Attachment = { id: seatId, name: g.players[seatId].name, ready: true, host: seatId === hostSeat, ver };
+      ws.serializeAttachment(a);
+      // now evict any stale socket still holding this seat so the returning player takes over
       for (const sock of this.state.getWebSockets()) {
         if (sock === ws) continue;
         const at = sock.deserializeAttachment() as Attachment | null;
         if (at && at.id === seatId) { try { sock.close(1000, "reconnected"); } catch { /* */ } }
       }
-      const hostSeat = await this.state.storage.get<number>("hostSeat");
-      const a: Attachment = { id: seatId, name: g.players[seatId].name, ready: true, host: seatId === hostSeat, ver };
-      ws.serializeAttachment(a);
       g.players[seatId].isBot = false; g.players[seatId].connected = true;
       await this.saveGame(g);
       await this.bumpTtl();
@@ -236,6 +240,11 @@ export class MahjongRoom {
     const seatTokens = (await this.state.storage.get<Record<number, string>>("seatTokens")) || {};
     seatTokens[id] = token;
     await this.state.storage.put("seatTokens", seatTokens);
+    // remember the name too, so a player who's absent when the first hand is dealt (joined the
+    // lobby, then blipped) keeps their real name instead of falling back to "Bot N"
+    const seatNames = (await this.state.storage.get<Record<number, string>>("seatNames")) || {};
+    seatNames[id] = name;
+    await this.state.storage.put("seatNames", seatNames);
     const a: Attachment = { id, name, ready: false, host: id === hostSeat, ver };
     ws.serializeAttachment(a);
     const code = (await this.state.storage.get<string>("code")) || "";
@@ -250,6 +259,7 @@ export class MahjongRoom {
     const roster = this.roster();
     const connectedIds = new Set(roster.map((a) => a.id));
     const seatTokens = (await this.state.storage.get<Record<number, string>>("seatTokens")) || {};
+    const seatNames = (await this.state.storage.get<Record<number, string>>("seatNames")) || {};
     const names: string[] = [];
     const seats: any[] = [];
     const humanSeats: number[] = [];
@@ -261,7 +271,9 @@ export class MahjongRoom {
       // plays the seat until they return; seats no human ever took are permanent bots.
       const owned = !!a || !!seatTokens[i];
       seats.push({ isBot: !a, difficulty: cfg.difficulty });
-      names[i] = a ? a.name : (owned && prev && prev.players[i] ? prev.players[i].name : `Bot ${i + 1}`);
+      // keep the absent owner's real name (from this hand's roster, or the name they joined
+      // with, or last hand's) — never let an owned seat show up as "Bot N"
+      names[i] = a ? a.name : (owned ? (seatNames[i] || (prev && prev.players[i] ? prev.players[i].name : `Bot ${i + 1}`)) : `Bot ${i + 1}`);
       if (owned) humanSeats.push(i);
     }
     const seed = (Date.now() ^ (Math.floor(Math.random() * 0x7fffffff))) | 0;


### PR DESCRIPTION
Hardening pass on online multiplayer. Three issues, all verified against `wrangler dev`.

## 1. Briefly-disconnected player kicked at the next hand (the reported bug)
`startHand` rebuilt `humanSeats` from only the *currently-connected* sockets, so a player whose connection blipped right as the next hand was dealt got dropped — and their reconnect (valid token) was refused *"seat unavailable."*

**Fix:** seat ownership now persists across hands via the reconnect token. A seat stays human-owned while anyone holds its token (a bot covers it until they return); only seats no human ever took are permanent bots. The rejoin matcher keys purely on the token, and a stale socket on that seat is evicted; `handleGone` won't demote a seat a newer socket already holds.

## 2. A bad bot move could freeze the whole table
If `botChooseAction` ever returned an illegal/empty action, `alarm()` stopped scheduling and the game sat frozen for everyone until the 45-min TTL. **Fix:** reload clean state and play any legal move, so the hand always progresses (defensive).

## 3. Client gave up reconnecting after ~15s
Only 6 retries — a tunnel/elevator/longer blip stranded a player even though the server holds the seat ~45 min. **Fix:** retry with capped backoff for several minutes before giving up.

## Verified
- blip-at-rematch player **rejoins** (was: kicked out)
- clean rematch with everyone connected still works (regression)
- fast-reconnect race (old socket still attached) takes the seat over cleanly
- full online game + rematch completes; bot pacing unaffected

Engine untouched — `core-sync` intact, core **33/33**, `tsc` clean.

### Known gap (not in this PR)
No AFK turn-timer: a player who walks away on *their* turn still stalls the table until TTL. Happy to add a timer (auto-pass/auto-discard after N seconds) as a follow-up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)