### PR TITLE
Marble Odyssey roadmap: creator tools, more content, meta loop, polish

### DIFF
--- a/apps/marble/index.html
+++ b/apps/marble/index.html
@@ -2027,6 +2027,8 @@ window.addEventListener('orientationchange', () => { setTimeout(onResize, 100); 
 //  MAIN LOOP
 //============================================================================
 const clock = new THREE.Clock();
+const FIXED_DT = 1 / 120;
+let physAcc = 0;
 function tick() {
   requestAnimationFrame(tick);
   let dt = clock.getDelta(); if (dt > 0.05) dt = 0.05;
@@ -2034,7 +2036,11 @@ function tick() {
 
   if (running && state === 'play') {
     readKeyboard();
-    physicsStep(dt);
+    // fixed-timestep physics → consistent feel across framerates, no tunneling
+    physAcc += dt;
+    let n = 0;
+    while (physAcc >= FIXED_DT && n < 6) { physicsStep(FIXED_DT); physAcc -= FIXED_DT; n++; }
+    if (physAcc > FIXED_DT * 4) physAcc = 0;   // avoid spiral-of-death after a stall
     gameplay(dt);
     SFX.roll(Math.hypot(ball.vel.x, ball.vel.z), grounded);
     if (Math.floor(levelTime * 100) !== lastTimeShown) { lastTimeShown = Math.floor(levelTime * 100); $('hudTime').textContent = levelTime.toFixed(2); }

--- a/apps/marble/index.html
+++ b/apps/marble/index.html
@@ -164,6 +164,40 @@
   .tune-row input[type=range] { width: 100%; accent-color: var(--accent); height: 18px; }
   .tune-foot { display: flex; justify-content: space-between; align-items: center; margin-top: 10px; }
   .tune-hint { opacity: .45; font-size: 11px; }
+
+  /* Level editor */
+  #editor { position: absolute; inset: 0; display: none; pointer-events: none; z-index: 70; }
+  #editor.show { display: block; }
+  #edTopbar { position: absolute; top: calc(env(safe-area-inset-top) + 8px); left: 50%; transform: translateX(-50%); pointer-events: auto; }
+  #edTools { display: flex; gap: 5px; flex-wrap: wrap; justify-content: center; background: rgba(10,12,30,.8);
+    backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); padding: 6px; border-radius: 12px; box-shadow: inset 0 0 0 1px rgba(255,255,255,.12); max-width: 94vw; }
+  .ed-tool { pointer-events: auto; cursor: pointer; border: none; background: rgba(255,255,255,.08); color: var(--ink);
+    font-family: inherit; font-weight: 700; font-size: 12px; padding: 7px 10px; border-radius: 8px; }
+  .ed-tool.on { background: linear-gradient(180deg, var(--accent), #5e6ce0); box-shadow: 0 3px 10px rgba(60,80,220,.4); }
+  #edSide { position: absolute; top: calc(env(safe-area-inset-top) + 58px); left: calc(env(safe-area-inset-left) + 10px);
+    width: 230px; pointer-events: auto; background: rgba(10,12,30,.82); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
+    border-radius: 12px; padding: 12px; box-shadow: inset 0 0 0 1px rgba(255,255,255,.12); font-size: 12px; max-height: 76vh; overflow-y: auto; }
+  .ed-sec { margin-bottom: 12px; }
+  .ed-h { font-weight: 800; text-transform: uppercase; letter-spacing: 1px; opacity: .7; font-size: 11px; margin-bottom: 7px; }
+  #edSide label { display: flex; align-items: center; justify-content: space-between; gap: 6px; margin: 5px 0; opacity: .85; }
+  #edSide input, #edSide select { background: rgba(255,255,255,.08); border: none; color: var(--ink); font-family: inherit;
+    border-radius: 7px; padding: 5px 7px; font-size: 12px; width: 92px; }
+  #edSide input[type=text] { width: 130px; }
+  .ed-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 4px 8px; }
+  .ed-grid label { justify-content: space-between; }
+  .ed-grid input { width: 62px; }
+  .ed-btn { pointer-events: auto; cursor: pointer; border: none; background: linear-gradient(180deg, var(--accent), #5e6ce0); color: var(--ink);
+    font-family: inherit; font-weight: 700; font-size: 13px; padding: 9px 14px; border-radius: 10px; box-shadow: 0 4px 12px rgba(60,80,220,.3); }
+  .ed-btn.warn { background: rgba(255,90,120,.85); }
+  #edDel { width: 100%; margin-top: 8px; }
+  .ed-hint { opacity: .5; font-size: 11px; line-height: 1.5; }
+  #edActions { position: absolute; bottom: calc(env(safe-area-inset-bottom) + 12px); left: 50%; transform: translateX(-50%);
+    display: flex; gap: 8px; pointer-events: auto; background: rgba(10,12,30,.8); backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
+    padding: 8px; border-radius: 12px; box-shadow: inset 0 0 0 1px rgba(255,255,255,.12); }
+  #edExportText { position: absolute; bottom: calc(env(safe-area-inset-bottom) + 70px); left: 50%; transform: translateX(-50%);
+    width: min(640px, 92vw); height: 130px; display: none; pointer-events: auto; background: rgba(6,8,20,.95); color: #bfe0ff;
+    border: 1px solid rgba(255,255,255,.15); border-radius: 10px; padding: 10px; font: 11px/1.4 ui-monospace, Menlo, monospace; }
+  #edExportText.show { display: block; }
 </style>
 </head>
 <body>
@@ -283,6 +317,46 @@
   </div>
 
   <div id="toast"></div>
+
+  <!-- Level editor -->
+  <div id="editor">
+    <div id="edTopbar">
+      <div id="edTools"></div>
+    </div>
+    <div id="edSide">
+      <div class="ed-sec">
+        <div class="ed-h">Stage</div>
+        <label>Name <input id="edName" type="text" maxlength="22"></label>
+        <label>Theme <select id="edTheme"></select></label>
+        <label>Par (s) <input id="edPar" type="number" min="5" max="300" step="1"></label>
+      </div>
+      <div class="ed-sec" id="edSelBox">
+        <div class="ed-h">Selected <span id="edSelType"></span></div>
+        <div class="ed-grid">
+          <label>X <input id="edpx" type="number" step="0.5"></label>
+          <label>Y <input id="edpy" type="number" step="0.25"></label>
+          <label>Z <input id="edpz" type="number" step="0.5"></label>
+          <label>W <input id="edpw" type="number" step="0.5" min="0.5"></label>
+          <label>H <input id="edph" type="number" step="0.25" min="0.25"></label>
+          <label>D <input id="edpd" type="number" step="0.5" min="0.5"></label>
+          <label>rotX <input id="edprx" type="number" step="0.05"></label>
+          <label>rotZ <input id="edprz" type="number" step="0.05"></label>
+          <label id="edPushXrow">pushX <input id="edpushx" type="number" step="1"></label>
+          <label id="edPushZrow">pushZ <input id="edpushz" type="number" step="1"></label>
+        </div>
+        <button class="ed-btn warn" id="edDel">Delete tile</button>
+      </div>
+      <div class="ed-hint" id="edHint">Click ground to place · click a tile to select · drag to move</div>
+    </div>
+    <div id="edActions">
+      <button class="ed-btn" id="edTest">▶ Test</button>
+      <button class="ed-btn" id="edSave">Save</button>
+      <button class="ed-btn" id="edExport">Export</button>
+      <button class="ed-btn warn" id="edClear">Clear</button>
+      <button class="ed-btn" id="edExit">Exit</button>
+    </div>
+    <textarea id="edExportText" readonly></textarea>
+  </div>
 
   <!-- Dev tuning panel -->
   <div id="tunePanel">
@@ -929,12 +1003,14 @@ function clearLevel() {
   fadeTiles.length = 0; conveyors.length = 0; padMats.length = 0;
 }
 
-let levelIndex = 0, gemsTotal = 0;
-function loadLevel(idx) {
-  levelIndex = idx;
-  const L = LEVELS[idx];
+let levelIndex = 0, gemsTotal = 0, curLevel = null;
+function loadLevel(idxOrL) {
+  const isObj = typeof idxOrL !== 'number';
+  levelIndex = isObj ? -1 : idxOrL;
+  const L = isObj ? idxOrL : LEVELS[idxOrL];
+  curLevel = L;
   clearLevel();
-  applyTheme(THEMES[L.theme]);
+  applyTheme(THEMES[L.theme] || THEMES.dawn);
   L.build();
   gemsTotal = crystals.length;
   // place marble
@@ -1223,8 +1299,8 @@ function showScreen(name) {
 }
 function setState(s) { state = s; if (s in screens) showScreen(s); }
 
-function startLevel(idx) {
-  loadLevel(idx);
+function startLevel(idxOrL) {
+  loadLevel(idxOrL);
   gems = 0; lives = 3; levelTime = 0; levelDone = false;
   updateHud();
   showScreen('hud'); state = 'countdown'; running = false;
@@ -1246,9 +1322,13 @@ function runCountdown() {
   step();
 }
 function loseLife() {
-  lives--; updateHud();
   SFX.fall(); haptic(3);
   spawn(spawnPos, 20, { color: [0xff5d7e, 0xffffff], speed: 5, life: 0.8, up: 3 });
+  if (editor.testing) {       // infinite retries while testing in the editor
+    ball.pos.copy(spawnPos); ball.vel.set(0, 0, 0); tiltX = tiltZ = 0; tiltTarget.set(0, 0);
+    marbleRoot.position.copy(ball.pos); shake = 0.4; return;
+  }
+  lives--; updateHud();
   if (lives <= 0) { setState('over'); running = false; SFX.stopMusic(); return; }
   // respawn
   ball.pos.copy(spawnPos); ball.vel.set(0, 0, 0); tiltX = tiltZ = 0; tiltTarget.set(0, 0);
@@ -1264,36 +1344,43 @@ function winLevel() {
   for (let i = 0; i < 4; i++) setTimeout(() => spawn(_ballWorld, 40,
     { color: [0x6effce, 0xffd27a, 0xff7ab0, 0x7df9ff, 0xffffff], speed: 11, size: 18, life: 1.4, up: 8, grav: 14 }), i * 130);
   const t = levelTime;
-  const L = LEVELS[levelIndex];
-  const prevBest = save.best[levelIndex];
-  const isBest = prevBest == null || t < prevBest;
-  if (isBest) save.best[levelIndex] = t;
-  save.cleared[levelIndex] = Math.max(save.cleared[levelIndex] || 0, gems === gemsTotal ? 2 : 1);
-  persist();
-  // rank
+  const L = curLevel;
   const allGems = gems === gemsTotal;
   let rank = 'C';
   if (t <= L.par * 0.7 && allGems) rank = 'S';
   else if (t <= L.par * 0.9 && allGems) rank = 'A';
   else if (t <= L.par) rank = 'B';
-  else rank = 'C';
+  // editor test-play: skip the results card, hop back to the editor
+  if (editor.testing) { toast('Goal! ' + rank + ' · ' + fmt(t)); setTimeout(editorReturn, 1000); return; }
+  let isBest = false;
+  if (levelIndex >= 0) {
+    const prevBest = save.best[levelIndex];
+    isBest = prevBest == null || t < prevBest;
+    if (isBest) save.best[levelIndex] = t;
+    save.cleared[levelIndex] = Math.max(save.cleared[levelIndex] || 0, allGems ? 2 : 1);
+    const ord = { C: 0, B: 1, A: 2, S: 3 };
+    if (!save.medals[levelIndex] || ord[rank] > ord[save.medals[levelIndex]]) save.medals[levelIndex] = rank;
+    // ghost: keep the fastest run's recording
+    if (isBest && recording.length) save.ghost = { idx: levelIndex, frames: recording.slice() };
+    persist();
+  }
   $('clearRank').textContent = rank;
   $('clearTime').textContent = fmt(t);
   $('clearGems').textContent = gems + '/' + gemsTotal;
-  $('clearBestTime').textContent = fmt(save.best[levelIndex]);
+  $('clearBestTime').textContent = levelIndex >= 0 ? fmt(save.best[levelIndex]) : fmt(t);
   $('clearBest').textContent = isBest ? '★ NEW BEST ★' : '';
-  $('btnNext').style.display = levelIndex < LEVELS.length - 1 ? '' : 'none';
+  $('btnNext').style.display = (levelIndex >= 0 && levelIndex < LEVELS.length - 1) ? '' : 'none';
   setTimeout(() => setState('clear'), 700);
 }
 
 function pause() { if (state !== 'play') return; state = 'pause'; running = false; showScreen('pause'); $('hud').classList.add('show'); SFX.duck(true); }
 function resume() { if (state !== 'pause') return; showScreen('hud'); state = 'play'; running = true; SFX.duck(false); }
-function quitToMenu() { running = false; SFX.stopMusic(); buildLevelGrid(); setState('levels'); }
+function quitToMenu() { running = false; SFX.stopMusic(); if (editor.testing) { editorReturn(); return; } buildLevelGrid(); setState('levels'); }
 
 function fmt(t) { if (t == null) return '—'; return t.toFixed(2) + 's'; }
 function updateHud() {
-  $('hudLvl').textContent = 'Stage ' + (levelIndex + 1);
-  $('hudName').textContent = LEVELS[levelIndex].name;
+  $('hudLvl').textContent = levelIndex >= 0 ? 'Stage ' + (levelIndex + 1) : 'Custom';
+  $('hudName').textContent = curLevel ? curLevel.name : '';
   $('hudGems').textContent = gems; $('hudGemsTot').textContent = gemsTotal;
   $('hudLives').innerHTML = '<span style="color:#ff8aa0">' + '●'.repeat(Math.max(0, lives)) + '</span><span style="opacity:.22">' + '●'.repeat(Math.max(0, 3 - lives)) + '</span>';
 }
@@ -1338,6 +1425,209 @@ function toggleTune(force) {
   const show = force != null ? force : !p.classList.contains('show');
   p.classList.toggle('show', show);
   if (show) buildTunePanel();
+}
+
+//============================================================================
+//  LEVEL EDITOR
+//============================================================================
+let recording = [];   // ghost-recording buffer (populated by the ghost system)
+const editor = {
+  on: false, testing: false, tool: 'floor', sel: -1, dragging: false,
+  tiles: [], crystals: [], start: [-3, 1.2, 0], goal: [3, 0, 0],
+  name: 'My Stage', par: 40, theme: 'dawn',
+  camTarget: new THREE.Vector3(0, 0, 0), camDist: 34, camRot: 0.5,
+};
+const ED_TOOLS = ['select', 'floor', 'wall', 'ice', 'sticky', 'bumper', 'pad', 'conveyor', 'fade', 'crystal', 'start', 'goal', 'delete'];
+const TILE_DEF = {
+  floor: { w: 6, h: 1, d: 6, y: -0.5 }, wall: { w: 6, h: 1.6, d: 0.7, y: 0.4 }, ice: { w: 6, h: 1, d: 6, y: -0.5 },
+  sticky: { w: 6, h: 1, d: 6, y: -0.5 }, bumper: { w: 1.4, h: 2, d: 1.4, y: 0.6 }, pad: { w: 5, h: 1, d: 5, y: -0.5 },
+  conveyor: { w: 6, h: 1, d: 6, y: -0.5, push: [1, 0] }, fade: { w: 4, h: 1, d: 4, y: -0.5 },
+};
+const edRay = new THREE.Raycaster(), edPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+const _ndc = new THREE.Vector2(), _hit = new THREE.Vector3();
+const edOutline = new THREE.LineSegments(new THREE.EdgesGeometry(boxGeo),
+  new THREE.LineBasicMaterial({ color: 0xffe24a }));
+edOutline.visible = false; stage.add(edOutline);
+
+function edToData() {
+  return { name: editor.name, theme: editor.theme, par: editor.par, start: editor.start.slice(), goal: editor.goal.slice(),
+    tiles: editor.tiles.map(t => Object.assign({}, t)), crystals: editor.crystals.map(c => c.slice()) };
+}
+function edFromData(d) {
+  editor.name = d.name || 'My Stage'; editor.theme = d.theme || 'dawn'; editor.par = d.par || 40;
+  editor.start = (d.start || [-3, 1.2, 0]).slice(); editor.goal = (d.goal || [3, 0, 0]).slice();
+  editor.tiles = (d.tiles || []).map(t => Object.assign({}, t)); editor.crystals = (d.crystals || []).map(c => c.slice());
+  editor.sel = -1;
+}
+function edLevelObject(d) {
+  d = d || edToData();
+  return { name: d.name, theme: d.theme, par: d.par, start: d.start.slice(), goal: d.goal.slice(),
+    build() {
+      d.tiles.forEach(t => { const o = { type: t.type, rx: t.rx || 0, rz: t.rz || 0 }; if (t.push) o.push = t.push; addBox(t.x, t.y, t.z, t.w, t.h, t.d, o); });
+      d.crystals.forEach(c => addCrystal(c[0], c[1], c[2]));
+      buildGoal(d.goal[0], d.goal[1], d.goal[2]);
+    } };
+}
+function edTopAt(x, z) {
+  let top = 0;
+  for (const t of editor.tiles) { if (Math.abs(x - t.x) <= t.w / 2 && Math.abs(z - t.z) <= t.d / 2) top = Math.max(top, t.y + t.h / 2); }
+  return top;
+}
+function edRebuild() {
+  clearLevel(); applyTheme(THEMES[editor.theme] || THEMES.dawn);
+  editor.tiles.forEach((t, i) => {
+    const o = { type: t.type, rx: t.rx || 0, rz: t.rz || 0 }; if (t.push) o.push = t.push;
+    const m = addBox(t.x, t.y, t.z, t.w, t.h, t.d, o); m.userData.edIndex = i;
+  });
+  editor.crystals.forEach(c => addCrystal(c[0], c[1], c[2]));
+  buildGoal(editor.goal[0], editor.goal[1], editor.goal[2]);
+  marbleRoot.position.set(editor.start[0], editor.start[1], editor.start[2]); marbleRoot.visible = true;
+  edUpdateOutline();
+}
+function edUpdateOutline() {
+  const t = editor.tiles[editor.sel];
+  if (!t) { edOutline.visible = false; return; }
+  edOutline.visible = true; edOutline.position.set(t.x, t.y, t.z); edOutline.scale.set(t.w + 0.08, t.h + 0.08, t.d + 0.08);
+  edOutline.quaternion.setFromEuler(new THREE.Euler(t.rx || 0, 0, t.rz || 0));
+}
+function setNDC(e) { _ndc.set((e.clientX / window.innerWidth) * 2 - 1, -(e.clientY / window.innerHeight) * 2 + 1); }
+function edGroundPoint(out) { edRay.setFromCamera(_ndc, camera); return edRay.ray.intersectPlane(edPlane, out) != null; }
+function edPick() {
+  edRay.setFromCamera(_ndc, camera);
+  const hits = edRay.intersectObjects(levelGroup.children, false);
+  for (const h of hits) if (h.object.userData.edIndex != null) return h.object.userData.edIndex;
+  return -1;
+}
+function edPointerDown(e) {
+  if (!editor.on || editor.testing) return;
+  setNDC(e);
+  if (editor.tool === 'select' || editor.tool === 'delete') {
+    const idx = edPick();
+    if (editor.tool === 'delete') { if (idx >= 0) { editor.tiles.splice(idx, 1); editor.sel = -1; edRebuild(); refreshProps(); } return; }
+    editor.sel = idx; editor.dragging = idx >= 0; refreshProps(); edUpdateOutline(); return;
+  }
+  if (!edGroundPoint(_hit)) return;
+  const gx = Math.round(_hit.x), gz = Math.round(_hit.z);
+  if (editor.tool === 'start') editor.start = [gx, edTopAt(gx, gz) + 1.2, gz];
+  else if (editor.tool === 'goal') editor.goal = [gx, edTopAt(gx, gz), gz];
+  else if (editor.tool === 'crystal') editor.crystals.push([gx, edTopAt(gx, gz) + 1.2, gz]);
+  else {
+    const def = TILE_DEF[editor.tool]; const t = { type: editor.tool, x: gx, y: def.y, z: gz, w: def.w, h: def.h, d: def.d, rx: 0, rz: 0 };
+    if (def.push) t.push = def.push.slice(); editor.tiles.push(t); editor.sel = editor.tiles.length - 1;
+  }
+  edRebuild(); refreshProps();
+}
+function edPointerMove(e) {
+  if (!editor.on || editor.testing || !editor.dragging || editor.sel < 0) return;
+  setNDC(e); if (!edGroundPoint(_hit)) return;
+  const t = editor.tiles[editor.sel]; t.x = Math.round(_hit.x); t.z = Math.round(_hit.z);
+  edRebuild(); refreshProps();
+}
+function edPointerUp() { editor.dragging = false; }
+cv.addEventListener('pointerdown', edPointerDown);
+cv.addEventListener('pointermove', edPointerMove);
+window.addEventListener('pointerup', edPointerUp);
+window.addEventListener('wheel', e => { if (editor.on && !editor.testing) editor.camDist = clamp(editor.camDist + Math.sign(e.deltaY) * 2, 14, 70); }, { passive: true });
+
+function edUpdate(dt) {
+  const sp = editor.camDist * dt * 0.9, cr = editor.camRot, fx = Math.sin(cr), fz = Math.cos(cr);
+  if (keys['KeyW'] || keys['ArrowUp']) { editor.camTarget.x += fx * sp; editor.camTarget.z += fz * sp; }
+  if (keys['KeyS'] || keys['ArrowDown']) { editor.camTarget.x -= fx * sp; editor.camTarget.z -= fz * sp; }
+  if (keys['KeyA'] || keys['ArrowLeft']) { editor.camTarget.x -= fz * sp; editor.camTarget.z += fx * sp; }
+  if (keys['KeyD'] || keys['ArrowRight']) { editor.camTarget.x += fz * sp; editor.camTarget.z -= fx * sp; }
+  if (keys['KeyQ']) editor.camRot -= dt * 1.4;
+  if (keys['KeyE']) editor.camRot += dt * 1.4;
+  const tgt = editor.camTarget, h = editor.camDist * 0.82, back = editor.camDist * 0.55;
+  camera.position.set(tgt.x - Math.sin(editor.camRot) * back, tgt.y + h, tgt.z - Math.cos(editor.camRot) * back);
+  camera.fov = 52; camera.lookAt(tgt.x, tgt.y, tgt.z); camera.updateProjectionMatrix();
+}
+
+// --- editor UI ---
+function buildEditorTools() {
+  const host = $('edTools'); host.innerHTML = '';
+  ED_TOOLS.forEach(tool => {
+    const b = document.createElement('button'); b.className = 'ed-tool' + (tool === editor.tool ? ' on' : '');
+    b.textContent = tool; b.onclick = () => { editor.tool = tool; [...host.children].forEach(c => c.classList.toggle('on', c === b)); };
+    host.appendChild(b);
+  });
+}
+function fillThemeSelect() {
+  const sel = $('edTheme'); sel.innerHTML = '';
+  Object.keys(THEMES).forEach(name => { const o = document.createElement('option'); o.value = name; o.textContent = name; sel.appendChild(o); });
+  sel.value = editor.theme;
+}
+function refreshProps() {
+  const t = editor.tiles[editor.sel];
+  $('edSelBox').style.display = t ? '' : 'none';
+  if (!t) { edUpdateOutline(); return; }
+  $('edSelType').textContent = t.type;
+  const set = (id, v) => { $(id).value = v; };
+  set('edpx', t.x); set('edpy', t.y); set('edpz', t.z); set('edpw', t.w); set('edph', t.h); set('edpd', t.d);
+  set('edprx', t.rx || 0); set('edprz', t.rz || 0);
+  const isConv = t.type === 'conveyor';
+  $('edPushXrow').style.display = isConv ? '' : 'none'; $('edPushZrow').style.display = isConv ? '' : 'none';
+  if (isConv) { set('edpushx', (t.push && t.push[0]) || 0); set('edpushz', (t.push && t.push[1]) || 0); }
+  edUpdateOutline();
+}
+function wireEditorUI() {
+  buildEditorTools(); fillThemeSelect();
+  const bindMeta = (id, key, num) => $(id).addEventListener('input', () => { editor[key] = num ? parseFloat($(id).value) || 0 : $(id).value; });
+  bindMeta('edName', 'name', false); bindMeta('edPar', 'par', true);
+  $('edTheme').addEventListener('change', () => { editor.theme = $('edTheme').value; edRebuild(); });
+  const fields = { edpx: 'x', edpy: 'y', edpz: 'z', edpw: 'w', edph: 'h', edpd: 'd', edprx: 'rx', edprz: 'rz' };
+  Object.entries(fields).forEach(([id, key]) => $(id).addEventListener('input', () => {
+    const t = editor.tiles[editor.sel]; if (!t) return; t[key] = parseFloat($(id).value) || 0; edRebuild(); refreshProps();
+  }));
+  ['edpushx', 'edpushz'].forEach((id, i) => $(id).addEventListener('input', () => {
+    const t = editor.tiles[editor.sel]; if (!t) return; t.push = t.push || [0, 0]; t.push[i] = parseFloat($(id).value) || 0; edRebuild();
+  }));
+  $('edDel').onclick = () => { if (editor.sel >= 0) { editor.tiles.splice(editor.sel, 1); editor.sel = -1; edRebuild(); refreshProps(); } };
+  $('edTest').onclick = () => edTest();
+  $('edSave').onclick = () => edSave();
+  $('edExport').onclick = () => edExport();
+  $('edClear').onclick = () => { if (confirm('Clear all tiles?')) { editor.tiles = []; editor.crystals = []; editor.sel = -1; edRebuild(); refreshProps(); } };
+  $('edExit').onclick = () => exitEditor();
+}
+function enterEditor(data) {
+  if (data) edFromData(data);
+  else if (!editor.tiles.length) {
+    editor.tiles = [{ type: 'floor', x: 0, y: -0.5, z: 0, w: 10, h: 1, d: 10, rx: 0, rz: 0 }];
+    editor.crystals = [[0, 1.2, 0]]; editor.start = [-3, 1.2, 0]; editor.goal = [3, 0, 0];
+  }
+  editor.on = true; editor.testing = false; editor.sel = -1; running = false; state = 'editor';
+  SFX.stopMusic(); showScreen(null); $('editor').classList.add('show'); $('edExportText').classList.remove('show');
+  $('edName').value = editor.name; $('edPar').value = editor.par; fillThemeSelect();
+  editor.camTarget.set(0, 0, 0); editor.camDist = 34;
+  edRebuild(); refreshProps();
+}
+function exitEditor() {
+  editor.on = false; editor.testing = false; edOutline.visible = false; $('editor').classList.remove('show');
+  loadLevel(0); setState('title');
+}
+function edTest() {
+  editor.testing = true; $('editor').classList.remove('show'); edOutline.visible = false;
+  startLevel(edLevelObject());
+}
+function editorReturn() {
+  editor.testing = false; running = false; state = 'editor';
+  SFX.stopMusic(); showScreen(null); $('editor').classList.add('show');
+  editor.camTarget.set(0, 0, 0);
+  edRebuild(); refreshProps();
+}
+function edSave() {
+  save.customLevels = save.customLevels || [];
+  const d = edToData(); const i = save.customLevels.findIndex(c => c.name === d.name);
+  if (i >= 0) save.customLevels[i] = d; else save.customLevels.push(d);
+  persist(); toast('Saved "' + d.name + '"');
+}
+function edExport() {
+  const d = edToData();
+  const ti = d.tiles.map(t => '      addBox(' + [t.x, t.y, t.z, t.w, t.h, t.d].join(', ') +
+    (t.type !== 'floor' || t.rx || t.rz || t.push ? ', { type: \'' + t.type + '\'' + (t.rx ? ', rx: ' + t.rx : '') + (t.rz ? ', rz: ' + t.rz : '') + (t.push ? ', push: [' + t.push + ']' : '') + ' }' : '') + ');').join('\n');
+  const cr = d.crystals.map(c => '      addCrystal(' + c.join(', ') + ');').join('\n');
+  const str = `  {\n    name: '${d.name}', theme: '${d.theme}', par: ${d.par}, start: [${d.start}], goal: [${d.goal}],\n    build() {\n${ti}\n${cr}\n      buildGoal(${d.goal});\n    }\n  },`;
+  const ta = $('edExportText'); ta.value = str; ta.classList.add('show'); ta.select();
+  try { navigator.clipboard.writeText(str); toast('Copied to clipboard'); } catch (e) { toast('Select + copy the text'); }
 }
 function flash() { const f = $('fx-flash'); f.style.transition = 'none'; f.style.opacity = 0.85; void f.offsetWidth; f.style.transition = 'opacity .6s ease'; f.style.opacity = 0; }
 const fxSpeed = $('fx-speed');
@@ -1535,6 +1825,7 @@ const SFX = (function () {
 //============================================================================
 //  UI WIRING
 //============================================================================
+const MEDAL_COLOR = { S: '#ffd35a', A: '#7df9ff', B: '#b6c2ff', C: '#cfd6ff' };
 function buildLevelGrid() {
   const grid = $('lvlGrid'); grid.innerHTML = '';
   let clearedCount = 0;
@@ -1542,16 +1833,33 @@ function buildLevelGrid() {
     const unlocked = i === 0 || save.cleared[i - 1];
     if (save.cleared[i]) clearedCount++;
     const t = THEMES[L.theme];
+    const medal = save.medals[i];
     const el = document.createElement('div');
     el.className = 'lvl' + (unlocked ? '' : ' locked') + (save.cleared[i] ? ' cleared' : '');
     el.innerHTML = `<div class="swatch" style="background:#${t.skyMid.toString(16).padStart(6,'0')}"></div>
       <div class="num">STAGE ${i + 1}</div><div class="nm">${L.name}</div>
       <div class="meta"><span>${save.best[i] != null ? '⏱ ' + fmt(save.best[i]) : 'Par ' + L.par + 's'}</span>
-      <span class="star">${save.cleared[i] === 2 ? '★ All' : save.cleared[i] ? '✓' : ''}</span></div>
+      <span class="star">${medal ? '<b style="color:' + MEDAL_COLOR[medal] + '">' + medal + '</b>' : ''} ${save.cleared[i] === 2 ? '◆' : save.cleared[i] ? '✓' : ''}</span></div>
       ${unlocked ? '' : '<div class="lock">🔒</div>'}`;
     if (unlocked) el.onclick = () => { SFX.click(); startLevel(i); };
     grid.appendChild(el);
   });
+  // custom levels
+  (save.customLevels || []).forEach((d, i) => {
+    const t = THEMES[d.theme] || THEMES.dawn;
+    const el = document.createElement('div'); el.className = 'lvl cleared';
+    el.innerHTML = `<div class="swatch" style="background:#${t.skyMid.toString(16).padStart(6,'0')}"></div>
+      <div class="num">CUSTOM</div><div class="nm">${d.name}</div>
+      <div class="meta"><span>Par ${d.par}s</span><span class="star" data-edit="${i}">✎ edit</span></div>`;
+    el.onclick = (ev) => { SFX.click(); if (ev.target.dataset && ev.target.dataset.edit != null) { enterEditor(d); } else { startLevel(edLevelObject(d)); } };
+    grid.appendChild(el);
+  });
+  // create-new card
+  const create = document.createElement('div'); create.className = 'lvl';
+  create.style.cssText = 'display:flex;align-items:center;justify-content:center;text-align:center;border:1.5px dashed rgba(255,255,255,.25);box-shadow:none;';
+  create.innerHTML = '<div><div style="font-size:26px">＋</div><div class="nm">Create Stage</div></div>';
+  create.onclick = () => { SFX.click(); enterEditor(); };
+  grid.appendChild(create);
   $('lvlProgress').textContent = clearedCount + ' of ' + LEVELS.length + ' cleared';
 }
 function setupSeg(id, key, after) {
@@ -1621,7 +1929,8 @@ function tick() {
     SFX.roll(0, false);
     if (state === 'title') { stage.rotation.y += dt * 0.04; }
   }
-  updateCamera(dt);
+  if (editor.on && !editor.testing) edUpdate(dt);
+  else updateCamera(dt);
   updateParticles(dt);
   // animate clouds
   for (const c of clouds) { c.position.x += dt * 2; if (c.position.x > 520) c.position.x = -520; }
@@ -1638,6 +1947,7 @@ let lastTimeShown = -1;
 //  BOOT
 //============================================================================
 wireUI();
+wireEditorUI();
 applyGfx();
 applyTune();
 loadLevel(0);
@@ -1653,7 +1963,7 @@ window.__dbg = { THREE, scene, camera, renderer, ball, keys, tiltTarget, get sta
   get info() { return { state, levelIndex, gems, gemsTotal, lives, levelTime, ballPos: ball.pos.toArray(), grounded }; },
   get movers() { return movers.map(m => ({ x: +m.col.c.x.toFixed(2), z: +m.col.c.z.toFixed(2) })); },
   get fades() { return fadeTiles.map(f => ({ t: f.col.fadeT == null ? null : +f.col.fadeT.toFixed(2), alive: f.col.alive })); },
-  TUNE, toggleTune };
+  TUNE, toggleTune, editor, enterEditor, edTest, edToData };
 
 } catch (e) { window.__err(e); }
 </script>

--- a/apps/marble/index.html
+++ b/apps/marble/index.html
@@ -148,6 +148,22 @@
   @keyframes spin { to { transform: rotate(360deg); } }
   #loader .lbl { font-size: 12px; letter-spacing: 4px; text-transform: uppercase; opacity: .6; }
   .scrollable { overflow-y: auto; -webkit-overflow-scrolling: touch; max-height: 84vh; width: 100%; display: flex; flex-direction: column; align-items: center; }
+
+  /* Dev tuning panel */
+  #tunePanel { position: absolute; top: calc(env(safe-area-inset-top) + 56px); right: calc(env(safe-area-inset-right) + 12px);
+    width: 270px; max-height: 78vh; overflow-y: auto; -webkit-overflow-scrolling: touch; display: none;
+    background: rgba(10,12,30,.82); backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
+    border-radius: 14px; padding: 12px 14px; pointer-events: auto; z-index: 80;
+    box-shadow: 0 18px 50px rgba(0,0,0,.5), inset 0 0 0 1px rgba(255,255,255,.12); font-size: 12px; }
+  #tunePanel.show { display: block; }
+  .tune-head { display: flex; justify-content: space-between; align-items: center; font-weight: 800; letter-spacing: 1px; text-transform: uppercase; font-size: 12px; opacity: .85; margin-bottom: 8px; }
+  .tune-head button, .tune-foot button { pointer-events: auto; cursor: pointer; border: none; background: rgba(255,255,255,.1); color: var(--ink); border-radius: 8px; font-family: inherit; font-weight: 700; padding: 5px 9px; font-size: 12px; }
+  .tune-row { margin: 9px 0; }
+  .tune-row label { display: flex; justify-content: space-between; opacity: .75; margin-bottom: 3px; }
+  .tune-row .tval { font-variant-numeric: tabular-nums; opacity: 1; font-weight: 700; color: var(--accent2); }
+  .tune-row input[type=range] { width: 100%; accent-color: var(--accent); height: 18px; }
+  .tune-foot { display: flex; justify-content: space-between; align-items: center; margin-top: 10px; }
+  .tune-hint { opacity: .45; font-size: 11px; }
 </style>
 </head>
 <body>
@@ -267,6 +283,13 @@
   </div>
 
   <div id="toast"></div>
+
+  <!-- Dev tuning panel -->
+  <div id="tunePanel">
+    <div class="tune-head"><span>Tuning</span><button id="tuneClose">✕</button></div>
+    <div id="tuneRows"></div>
+    <div class="tune-foot"><button id="tuneReset">Reset</button><span class="tune-hint">press T to toggle</span></div>
+  </div>
 </div>
 
 <div id="loader"><div class="spinner"></div><div class="lbl">Marble Odyssey</div></div>
@@ -322,9 +345,26 @@ function haptic(taps) {
 }
 
 const SAVE_KEY = 'marble_odyssey_v1';
-const defaults = { gfx: isMobile ? 'med' : 'high', music: 'on', sfx: 'on', ctl: 'drag', best: {}, cleared: {} };
+const defaults = { gfx: isMobile ? 'med' : 'high', music: 'on', sfx: 'on', ctl: 'drag', best: {}, cleared: {}, medals: {} };
 let save = Object.assign({}, defaults, JSON.parse(localStorage.getItem(SAVE_KEY) || '{}'));
 function persist() { localStorage.setItem(SAVE_KEY, JSON.stringify(save)); }
+
+// Live-tunable feel parameters (dev panel writes these; physics/camera read them).
+const TUNE_KEY = 'marble_tune_v1';
+const TUNE_DEF = {
+  grav: 28, maxTilt: 0.34, tiltResp: 10, maxSpeed: 30,
+  floorFric: 0.992, iceFric: 0.9992, restitution: 0.22,
+  camDist: 10.8, camHeight: 6.4, camFollow: 3.4, fov: 58, bloom: 0.5,
+};
+let TUNE = Object.assign({}, TUNE_DEF, JSON.parse(localStorage.getItem(TUNE_KEY) || '{}'));
+function persistTune() { localStorage.setItem(TUNE_KEY, JSON.stringify(TUNE)); }
+function applyTune() {
+  if (typeof MATS !== 'undefined') {
+    MATS.floor.fric = TUNE.floorFric; MATS.ramp.fric = TUNE.floorFric; MATS.ice.fric = TUNE.iceFric;
+    MATS.floor.rest = TUNE.restitution; MATS.ramp.rest = TUNE.restitution;
+  }
+  if (typeof bloom !== 'undefined' && bloom) bloom.strength = TUNE.bloom;
+}
 
 const TIER = () => save.gfx;                 // 'low' | 'med' | 'high'
 const useHalfFloat = !isMobile;
@@ -910,7 +950,7 @@ function loadLevel(idx) {
   camYaw = (gx || gz) ? Math.atan2(gx, gz) : 0;
   marbleRoot.getWorldPosition(_ballWorld);
   introTime = 1.7;
-  const yaw = camYaw + 0.55, dist = CAM_DIST + 8, height = CAM_HEIGHT + 6.5;
+  const yaw = camYaw + 0.55, dist = TUNE.camDist + 8, height = TUNE.camHeight + 6.5;
   camPos.set(_ballWorld.x - Math.sin(yaw) * dist, _ballWorld.y + height, _ballWorld.z - Math.cos(yaw) * dist);
   camLook.copy(_ballWorld);
 }
@@ -944,6 +984,7 @@ window.addEventListener('keydown', e => {
   if (['ArrowUp','ArrowDown','ArrowLeft','ArrowRight','Space'].includes(e.code)) e.preventDefault();
   keys[e.code] = true;
   if (e.code === 'Escape' || e.code === 'KeyP') { if (state === 'play') pause(); else if (state === 'pause') resume(); }
+  if (e.code === 'KeyT' && !e.repeat) toggleTune();
 }, { passive: false });
 window.addEventListener('keyup', e => { keys[e.code] = false; });
 
@@ -997,10 +1038,8 @@ function readKeyboard() {
 //============================================================================
 //  PHYSICS
 //============================================================================
-const MAX_TILT = 0.34, GRAV = 28;
 const ball = { pos: new THREE.Vector3(), vel: new THREE.Vector3(), prev: new THREE.Vector3() };
 const spawnPos = new THREE.Vector3();
-const MAX_SPEED = 30;
 let tiltX = 0, tiltZ = 0, grounded = false, groundMat = MATS.floor, lastSpeed = 0;
 let squash = 0, squashAxis = new THREE.Vector3(0, 1, 0);
 let shake = 0;
@@ -1010,12 +1049,12 @@ const _local = new THREE.Vector3(), _closest = new THREE.Vector3(), _delta = new
 const _n = new THREE.Vector3();
 
 function physicsStep(dt) {
-  tiltX += (tiltTarget.x * MAX_TILT - tiltX) * Math.min(1, dt * 10);
-  tiltZ += (-tiltTarget.y * MAX_TILT - tiltZ) * Math.min(1, dt * 10);
+  tiltX += (tiltTarget.x * TUNE.maxTilt - tiltX) * Math.min(1, dt * TUNE.tiltResp);
+  tiltZ += (-tiltTarget.y * TUNE.maxTilt - tiltZ) * Math.min(1, dt * TUNE.tiltResp);
   stage.rotation.set(tiltX, 0, tiltZ); stage.updateMatrixWorld();
 
   _e.set(tiltX, 0, tiltZ); _q.setFromEuler(_e).invert();
-  _g.set(0, -GRAV, 0).applyQuaternion(_q);
+  _g.set(0, -TUNE.grav, 0).applyQuaternion(_q);
   ball.vel.addScaledVector(_g, dt);
 
   if (grounded) {
@@ -1023,7 +1062,7 @@ function physicsStep(dt) {
     ball.vel.x *= f; ball.vel.z *= f;
   }
   ball.vel.multiplyScalar(Math.pow(0.997, dt * 60));
-  const sp0 = ball.vel.length(); if (sp0 > MAX_SPEED) ball.vel.multiplyScalar(MAX_SPEED / sp0);
+  const sp0 = ball.vel.length(); if (sp0 > TUNE.maxSpeed) ball.vel.multiplyScalar(TUNE.maxSpeed / sp0);
   ball.prev.copy(ball.pos);     // for swept goal detection
 
   // move movers, and carry the ball if it's resting on top (once per frame)
@@ -1133,8 +1172,7 @@ const _moverV = new THREE.Vector3(), _moverD = new THREE.Vector3();
 //============================================================================
 const camPos = new THREE.Vector3(0, 10, 15), camLook = new THREE.Vector3(), _ballWorld = new THREE.Vector3();
 const _camWant = new THREE.Vector3(), _lookTgt = new THREE.Vector3();
-let camYaw = 0, baseFov = 58, introTime = 0;
-const CAM_DIST = 10.8, CAM_HEIGHT = 6.4;
+let camYaw = 0, introTime = 0;
 function updateCamera(dt) {
   marbleRoot.getWorldPosition(_ballWorld);
   const speed = Math.hypot(ball.vel.x, ball.vel.z);
@@ -1146,15 +1184,15 @@ function updateCamera(dt) {
   // intro pull-in during countdown
   if (introTime > 0) introTime -= dt;
   const intro = clamp(introTime / 1.7, 0, 1), ease = intro * intro;
-  const dist = CAM_DIST + ease * 8, height = CAM_HEIGHT + ease * 6.5;
+  const dist = TUNE.camDist + ease * 8, height = TUNE.camHeight + ease * 6.5;
   const yaw = camYaw + ease * 0.55;
   _camWant.set(_ballWorld.x - Math.sin(yaw) * dist, _ballWorld.y + height, _ballWorld.z - Math.cos(yaw) * dist);
-  camPos.lerp(_camWant, Math.min(1, dt * 3.4));
+  camPos.lerp(_camWant, Math.min(1, dt * TUNE.camFollow));
   // look slightly ahead of the marble for anticipation
   _lookTgt.set(_ballWorld.x + ball.vel.x * 0.12, _ballWorld.y, _ballWorld.z + ball.vel.z * 0.12);
   camLook.lerp(_lookTgt, Math.min(1, dt * 6.5));
   // dynamic fov
-  const targetFov = baseFov + clamp(speed * 0.8, 0, 14);
+  const targetFov = TUNE.fov + clamp(speed * 0.8, 0, 14);
   camera.fov += (targetFov - camera.fov) * Math.min(1, dt * 3);
   // shake
   let ox = 0, oy = 0;
@@ -1261,6 +1299,46 @@ function updateHud() {
 }
 let toastTimer;
 function toast(msg) { const t = $('toast'); t.textContent = msg; t.classList.add('show'); clearTimeout(toastTimer); toastTimer = setTimeout(() => t.classList.remove('show'), 1600); }
+
+//============================================================================
+//  TUNING PANEL
+//============================================================================
+const TUNE_SPEC = [
+  { k: 'grav', l: 'Gravity', min: 12, max: 50, step: 0.5 },
+  { k: 'maxTilt', l: 'Max tilt', min: 0.15, max: 0.6, step: 0.01 },
+  { k: 'tiltResp', l: 'Tilt response', min: 3, max: 20, step: 0.5 },
+  { k: 'maxSpeed', l: 'Max speed', min: 12, max: 50, step: 1 },
+  { k: 'floorFric', l: 'Floor grip', min: 0.95, max: 1, step: 0.001 },
+  { k: 'iceFric', l: 'Ice grip', min: 0.99, max: 1, step: 0.0002 },
+  { k: 'restitution', l: 'Bounciness', min: 0, max: 0.6, step: 0.02 },
+  { k: 'camDist', l: 'Cam distance', min: 6, max: 18, step: 0.2 },
+  { k: 'camHeight', l: 'Cam height', min: 3, max: 12, step: 0.2 },
+  { k: 'camFollow', l: 'Cam follow', min: 1, max: 8, step: 0.1 },
+  { k: 'fov', l: 'Field of view', min: 45, max: 80, step: 1 },
+  { k: 'bloom', l: 'Bloom', min: 0, max: 1.2, step: 0.05 },
+];
+function buildTunePanel() {
+  const host = $('tuneRows'); host.innerHTML = '';
+  TUNE_SPEC.forEach(s => {
+    const row = document.createElement('div'); row.className = 'tune-row';
+    const dec = s.step < 0.01 ? 4 : s.step < 1 ? 2 : 0;
+    row.innerHTML = `<label>${s.l}<span class="tval" id="tv_${s.k}">${TUNE[s.k].toFixed(dec)}</span></label>
+      <input type="range" id="ts_${s.k}" min="${s.min}" max="${s.max}" step="${s.step}" value="${TUNE[s.k]}">`;
+    host.appendChild(row);
+    const input = row.querySelector('input');
+    input.addEventListener('input', () => {
+      TUNE[s.k] = parseFloat(input.value);
+      $('tv_' + s.k).textContent = TUNE[s.k].toFixed(dec);
+      applyTune(); persistTune();
+    });
+  });
+}
+function toggleTune(force) {
+  const p = $('tunePanel');
+  const show = force != null ? force : !p.classList.contains('show');
+  p.classList.toggle('show', show);
+  if (show) buildTunePanel();
+}
 function flash() { const f = $('fx-flash'); f.style.transition = 'none'; f.style.opacity = 0.85; void f.offsetWidth; f.style.transition = 'opacity .6s ease'; f.style.opacity = 0; }
 const fxSpeed = $('fx-speed');
 
@@ -1503,7 +1581,9 @@ function wireUI() {
   setupSeg('segMusic', 'music', () => SFX.setMusicVol());
   setupSeg('segSfx', 'sfx');
   setupSeg('segCtl', 'ctl', v => { if (v === 'tilt') enableTilt(); });
-  if (!isMobile) $('titleHint').textContent = 'WASD or Arrow keys to tilt the world toward the goal';
+  $('tuneClose').onclick = () => toggleTune(false);
+  $('tuneReset').onclick = () => { TUNE = Object.assign({}, TUNE_DEF); applyTune(); persistTune(); buildTunePanel(); toast('Tuning reset'); };
+  if (!isMobile) $('titleHint').textContent = 'WASD / Arrows to tilt · T for tuning panel';
   else $('titleHint').textContent = 'Drag anywhere to tilt the world · collect crystals · reach the ring';
 }
 function firstUnclearedOrFirst() { for (let i = 0; i < LEVELS.length; i++) if (!save.cleared[i]) return (i === 0 || save.cleared[i - 1]) ? i : 0; return 0; }
@@ -1559,6 +1639,7 @@ let lastTimeShown = -1;
 //============================================================================
 wireUI();
 applyGfx();
+applyTune();
 loadLevel(0);
 setState('title');
 showScreen('title');
@@ -1571,7 +1652,8 @@ setTimeout(() => $('loader').classList.add('hide'), 400);
 window.__dbg = { THREE, scene, camera, renderer, ball, keys, tiltTarget, get state() { return state; }, startLevel, loadLevel,
   get info() { return { state, levelIndex, gems, gemsTotal, lives, levelTime, ballPos: ball.pos.toArray(), grounded }; },
   get movers() { return movers.map(m => ({ x: +m.col.c.x.toFixed(2), z: +m.col.c.z.toFixed(2) })); },
-  get fades() { return fadeTiles.map(f => ({ t: f.col.fadeT == null ? null : +f.col.fadeT.toFixed(2), alive: f.col.alive })); } };
+  get fades() { return fadeTiles.map(f => ({ t: f.col.fadeT == null ? null : +f.col.fadeT.toFixed(2), alive: f.col.alive })); },
+  TUNE, toggleTune };
 
 } catch (e) { window.__err(e); }
 </script>

--- a/apps/marble/index.html
+++ b/apps/marble/index.html
@@ -112,6 +112,8 @@
   .card { background: var(--panel); border-radius: 24px; padding: 30px 34px; width: min(440px, 92vw);
     box-shadow: 0 30px 80px rgba(0,0,0,.5), inset 0 0 0 1.5px rgba(255,255,255,.1); text-align: center; }
   .card h2 { font-size: 30px; font-weight: 800; letter-spacing: 1px; }
+  .screen.show .card { animation: cardPop .42s cubic-bezier(.2,.9,.3,1.2) both; }
+  @keyframes cardPop { 0% { transform: scale(.88); opacity: 0; } 100% { transform: scale(1); opacity: 1; } }
   .stat-row { display: flex; justify-content: space-between; align-items: center; padding: 12px 4px; font-size: 17px; border-bottom: 1px solid rgba(255,255,255,.08); }
   .stat-row:last-of-type { border-bottom: none; }
   .stat-row .v { font-weight: 800; font-variant-numeric: tabular-nums; }
@@ -2056,7 +2058,8 @@ function buildLevelGrid() {
   create.innerHTML = '<div><div style="font-size:26px">＋</div><div class="nm">Create Stage</div></div>';
   create.onclick = () => { SFX.click(); enterEditor(); };
   grid.appendChild(create);
-  $('lvlProgress').textContent = clearedCount + ' of ' + LEVELS.length + ' cleared';
+  const medalCount = Object.keys(save.medals).length;
+  $('lvlProgress').textContent = clearedCount + ' of ' + LEVELS.length + ' cleared · ' + medalCount + ' ★';
 }
 function setupSeg(id, key, after) {
   const seg = $(id);

--- a/apps/marble/index.html
+++ b/apps/marble/index.html
@@ -423,7 +423,7 @@ function haptic(taps) {
 }
 
 const SAVE_KEY = 'marble_odyssey_v1';
-const defaults = { gfx: isMobile ? 'med' : 'high', music: 'on', sfx: 'on', ctl: 'drag', skin: 'rose', best: {}, cleared: {}, medals: {} };
+const defaults = { gfx: isMobile ? 'med' : 'high', music: 'on', sfx: 'on', ctl: 'drag', skin: 'rose', best: {}, cleared: {}, medals: {}, ghosts: {} };
 let save = Object.assign({}, defaults, JSON.parse(localStorage.getItem(SAVE_KEY) || '{}'));
 function persist() { localStorage.setItem(SAVE_KEY, JSON.stringify(save)); }
 
@@ -567,6 +567,11 @@ function applySkin(name) {
 }
 marbleMesh.castShadow = true;
 marbleSquash.add(marbleMesh); marbleRoot.add(marbleSquash); stage.add(marbleRoot);
+
+// ghost marble (replays your best run, in stage-local space so it rides the tilt)
+const ghostMesh = new THREE.Mesh(new THREE.SphereGeometry(BALL_R, 32, 24),
+  new THREE.MeshBasicMaterial({ color: 0x9fe8ff, transparent: true, opacity: 0.28, depthWrite: false }));
+ghostMesh.visible = false; stage.add(ghostMesh);
 
 // fake soft contact shadow blob (helps read height on platforms)
 const blobTex = (() => {
@@ -1328,6 +1333,11 @@ function setState(s) { state = s; if (s in screens) showScreen(s); }
 function startLevel(idxOrL) {
   loadLevel(idxOrL);
   gems = 0; lives = 3; levelTime = 0; levelDone = false;
+  // ghost replay setup (real stages only)
+  recording = []; recAccum = 0; ghostIdx = 0;
+  ghostFrames = (levelIndex >= 0 && save.ghosts[levelIndex] && save.ghosts[levelIndex].length) ? save.ghosts[levelIndex] : null;
+  ghostActive = !editor.testing && !!ghostFrames;
+  ghostMesh.visible = ghostActive;
   updateHud();
   showScreen('hud'); state = 'countdown'; running = false;
   SFX.music();
@@ -1364,6 +1374,7 @@ function loseLife() {
 }
 function winLevel() {
   if (levelDone) return; levelDone = true; running = false;
+  ghostMesh.visible = false;
   SFX.goal(); SFX.stopMusic(); haptic(4);
   flash(); shake = 0.5;
   marbleRoot.getWorldPosition(_ballWorld);
@@ -1386,8 +1397,8 @@ function winLevel() {
     save.cleared[levelIndex] = Math.max(save.cleared[levelIndex] || 0, allGems ? 2 : 1);
     const ord = { C: 0, B: 1, A: 2, S: 3 };
     if (!save.medals[levelIndex] || ord[rank] > ord[save.medals[levelIndex]]) save.medals[levelIndex] = rank;
-    // ghost: keep the fastest run's recording
-    if (isBest && recording.length) save.ghost = { idx: levelIndex, frames: recording.slice() };
+    // ghost: keep the fastest run's recording for this stage
+    if (isBest && recording.length) save.ghosts[levelIndex] = recording.slice();
     persist();
   }
   $('clearRank').textContent = rank;
@@ -1401,7 +1412,7 @@ function winLevel() {
 
 function pause() { if (state !== 'play') return; state = 'pause'; running = false; showScreen('pause'); $('hud').classList.add('show'); SFX.duck(true); }
 function resume() { if (state !== 'pause') return; showScreen('hud'); state = 'play'; running = true; SFX.duck(false); }
-function quitToMenu() { running = false; SFX.stopMusic(); if (editor.testing) { editorReturn(); return; } buildLevelGrid(); setState('levels'); }
+function quitToMenu() { running = false; ghostMesh.visible = false; SFX.stopMusic(); if (editor.testing) { editorReturn(); return; } buildLevelGrid(); setState('levels'); }
 
 function fmt(t) { if (t == null) return '—'; return t.toFixed(2) + 's'; }
 function updateHud() {
@@ -1456,7 +1467,8 @@ function toggleTune(force) {
 //============================================================================
 //  LEVEL EDITOR
 //============================================================================
-let recording = [];   // ghost-recording buffer (populated by the ghost system)
+let recording = [];   // ghost-recording buffer: [t, x, y, z] samples in stage-local space
+let recAccum = 0, ghostFrames = null, ghostActive = false, ghostIdx = 0;
 const editor = {
   on: false, testing: false, tool: 'floor', sel: -1, dragging: false,
   tiles: [], crystals: [], start: [-3, 1.2, 0], goal: [3, 0, 0],
@@ -1675,6 +1687,25 @@ function segDistXZ(a, b, p) {
 }
 function gameplay(dt) {
   levelTime += dt;
+  // record path for the ghost (stage-local samples)
+  recAccum += dt;
+  if (recAccum >= 0.05 && recording.length < 3000) {
+    recording.push([+levelTime.toFixed(3), +ball.pos.x.toFixed(2), +ball.pos.y.toFixed(2), +ball.pos.z.toFixed(2)]);
+    recAccum = 0;
+  }
+  // replay the ghost of the best run
+  if (ghostActive) {
+    const f = ghostFrames, t = levelTime, last = f[f.length - 1];
+    if (t <= last[0]) {
+      let i = ghostIdx;
+      while (i < f.length - 1 && f[i + 1][0] <= t) i++;
+      while (i > 0 && f[i][0] > t) i--;
+      ghostIdx = i;
+      const a = f[i], b = f[Math.min(i + 1, f.length - 1)], span = (b[0] - a[0]) || 1, u = clamp((t - a[0]) / span, 0, 1);
+      ghostMesh.position.set(a[1] + (b[1] - a[1]) * u, a[2] + (b[2] - a[2]) * u, a[3] + (b[3] - a[3]) * u);
+      ghostMesh.visible = true;
+    } else ghostMesh.visible = false;
+  }
   // speed trail behind the marble
   const sp = Math.hypot(ball.vel.x, ball.vel.z);
   if (sp > 6.5 && Math.random() < dt * 40) {
@@ -1999,7 +2030,8 @@ window.__dbg = { THREE, scene, camera, renderer, ball, keys, tiltTarget, get sta
   get info() { return { state, levelIndex, gems, gemsTotal, lives, levelTime, ballPos: ball.pos.toArray(), grounded }; },
   get movers() { return movers.map(m => ({ x: +m.col.c.x.toFixed(2), z: +m.col.c.z.toFixed(2) })); },
   get fades() { return fadeTiles.map(f => ({ t: f.col.fadeT == null ? null : +f.col.fadeT.toFixed(2), alive: f.col.alive })); },
-  TUNE, toggleTune, editor, enterEditor, edTest, edToData, applySkin, save };
+  TUNE, toggleTune, editor, enterEditor, edTest, edToData, applySkin, save,
+  get ghost() { return { active: ghostActive, frames: ghostFrames ? ghostFrames.length : 0, vis: ghostMesh.visible, rec: recording.length }; } };
 
 } catch (e) { window.__err(e); }
 </script>

--- a/apps/marble/index.html
+++ b/apps/marble/index.html
@@ -133,6 +133,16 @@
     opacity: 0; transition: opacity .3s, transform .3s; pointer-events: none; box-shadow: inset 0 0 0 1px rgba(255,255,255,.12); }
   #toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
 
+  .popup { position: absolute; transform: translate(-50%, -50%); font-weight: 800; font-size: 20px;
+    color: var(--accent2); pointer-events: none; text-shadow: 0 2px 10px rgba(0,0,0,.55); white-space: nowrap;
+    animation: floatUp .9s ease-out forwards; z-index: 60; }
+  .popup .cx { color: #ffd35a; }
+  @keyframes floatUp {
+    0% { opacity: 0; transform: translate(-50%, -30%) scale(.6); }
+    20% { opacity: 1; transform: translate(-50%, -65%) scale(1.12); }
+    100% { opacity: 0; transform: translate(-50%, -165%) scale(1); }
+  }
+
   /* settings rows */
   .set-row { display: flex; align-items: center; justify-content: space-between; gap: 14px; padding: 14px 2px;
     border-bottom: 1px solid rgba(255,255,255,.08); font-size: 16px; }
@@ -1321,7 +1331,8 @@ function updateCamera(dt) {
   // intro pull-in during countdown
   if (introTime > 0) introTime -= dt;
   const intro = clamp(introTime / 1.7, 0, 1), ease = intro * intro;
-  const dist = TUNE.camDist + ease * 8, height = TUNE.camHeight + ease * 6.5;
+  const win = clamp(celebrate / 1.1, 0, 1);   // push in on win
+  const dist = (TUNE.camDist + ease * 8) * (1 - win * 0.4), height = TUNE.camHeight + ease * 6.5 - win * 1.2;
   const yaw = camYaw + ease * 0.55;
   _camWant.set(_ballWorld.x - Math.sin(yaw) * dist, _ballWorld.y + height, _ballWorld.z - Math.cos(yaw) * dist);
   camPos.lerp(_camWant, Math.min(1, dt * TUNE.camFollow));
@@ -1351,7 +1362,7 @@ const _keyOff = new THREE.Vector3(-22, 36, 16);
 //============================================================================
 //  GAME STATE
 //============================================================================
-let state = 'title', time = 0, levelTime = 0, lives = 3, gems = 0, running = false, levelDone = false;
+let state = 'title', time = 0, levelTime = 0, lives = 3, gems = 0, running = false, levelDone = false, celebrate = 0;
 const screens = { title: 'scrTitle', levels: 'scrLevels', settings: 'scrSettings', pause: 'scrPause', clear: 'scrClear', over: 'scrOver' };
 function showScreen(name) {
   Object.values(screens).forEach(id => $(id).classList.remove('show'));
@@ -1362,7 +1373,14 @@ function setState(s) { state = s; if (s in screens) showScreen(s); }
 
 function startLevel(idxOrL) {
   loadLevel(idxOrL);
-  gems = 0; lives = 3; levelTime = 0; levelDone = false;
+  gems = 0; lives = 3; levelTime = 0; levelDone = false; celebrate = 0; comboCount = 0; lastGemT = -9;
+  // first-time tutorial hints on stage 1
+  if (levelIndex === 0 && !save.tutDone && !editor.testing) {
+    save.tutDone = true; persist();
+    setTimeout(() => { if (state === 'play') toast('Tilt the world to roll the marble'); }, 3600);
+    setTimeout(() => { if (state === 'play') toast('Grab the glowing crystals ◆'); }, 7200);
+    setTimeout(() => { if (state === 'play') toast('Roll into the ring to finish'); }, 10800);
+  }
   // ghost replay setup (real stages only)
   recording = []; recAccum = 0; ghostIdx = 0;
   ghostFrames = (levelIndex >= 0 && save.ghosts[levelIndex] && save.ghosts[levelIndex].length) ? save.ghosts[levelIndex] : null;
@@ -1403,13 +1421,13 @@ function loseLife() {
   toast('Try again! ' + '●'.repeat(lives));
 }
 function winLevel() {
-  if (levelDone) return; levelDone = true; running = false;
+  if (levelDone) return; levelDone = true;
   ghostMesh.visible = false;
   SFX.goal(); SFX.stopMusic(); haptic(4);
-  flash(); shake = 0.5;
+  flash(); shake = 0.55;
   marbleRoot.getWorldPosition(_ballWorld);
-  for (let i = 0; i < 4; i++) setTimeout(() => spawn(_ballWorld, 40,
-    { color: [0x6effce, 0xffd27a, 0xff7ab0, 0x7df9ff, 0xffffff], speed: 11, size: 18, life: 1.4, up: 8, grav: 14 }), i * 130);
+  for (let i = 0; i < 6; i++) setTimeout(() => spawn(_ballWorld, 50,
+    { color: [0x6effce, 0xffd27a, 0xff7ab0, 0x7df9ff, 0xffffff], speed: 13, size: 20, life: 1.6, up: 9, grav: 13 }), i * 110);
   const t = levelTime;
   const L = curLevel;
   const allGems = gems === gemsTotal;
@@ -1437,8 +1455,9 @@ function winLevel() {
   $('clearBestTime').textContent = levelIndex >= 0 ? fmt(save.best[levelIndex]) : fmt(t);
   $('clearBest').textContent = isBest ? '★ NEW BEST ★' : '';
   $('btnNext').style.display = (levelIndex >= 0 && levelIndex < LEVELS.length - 1) ? '' : 'none';
-  setTimeout(() => setState('clear'), 700);
+  celebrate = 1.1;   // slow-mo celebration; results card shown when it ends (finishWin)
 }
+function finishWin() { setState('clear'); }
 
 function pause() { if (state !== 'play') return; state = 'pause'; running = false; showScreen('pause'); $('hud').classList.add('show'); SFX.duck(true); }
 function resume() { if (state !== 'pause') return; showScreen('hud'); state = 'play'; running = true; SFX.duck(false); }
@@ -1699,6 +1718,17 @@ function edExport() {
 }
 function flash() { const f = $('fx-flash'); f.style.transition = 'none'; f.style.opacity = 0.85; void f.offsetWidth; f.style.transition = 'opacity .6s ease'; f.style.opacity = 0; }
 const fxSpeed = $('fx-speed');
+// floating world-anchored popup (e.g. "+1 ×3")
+const _proj = new THREE.Vector3(), _proj2 = new THREE.Vector3();
+function showPopup(worldPos, html) {
+  _proj.copy(worldPos).project(camera);
+  if (_proj.z > 1) return;
+  const el = document.createElement('div'); el.className = 'popup'; el.innerHTML = html;
+  el.style.left = ((_proj.x * 0.5 + 0.5) * window.innerWidth) + 'px';
+  el.style.top = ((-_proj.y * 0.5 + 0.5) * window.innerHeight) + 'px';
+  $('ui').appendChild(el); setTimeout(() => el.remove(), 900);
+}
+let comboCount = 0, lastGemT = -9;
 
 //============================================================================
 //  GAMEPLAY UPDATE (crystals, goal, fall)
@@ -1751,7 +1781,11 @@ function gameplay(dt) {
     cr.mesh.position.y = cr.baseY + Math.sin(time * 2 + cr.pos.x) * 0.18;
     cr.gem.rotation.y += dt * 1.8; cr.gem.rotation.x += dt * 0.9;
     if (ball.pos.distanceToSquared(cr.pos) < 1.15 * 1.15) {
-      cr.got = true; cr.mesh.visible = false; gems++;
+      cr.got = true; gems++;
+      comboCount = (levelTime - lastGemT < 1.6) ? comboCount + 1 : 1; lastGemT = levelTime;
+      cr.mesh.getWorldPosition(_proj2);
+      showPopup(_proj2, comboCount > 1 ? '+1 <span class="cx">×' + comboCount + '</span>' : '+1');
+      cr.mesh.visible = false;
       updateHud(); SFX.crystal(gems); haptic(1);
       spawn(cr.pos, 18, { color: [0x7df9ff, 0xffffff, 0xb0ffff], speed: 6, size: 13, life: 0.7, up: 2 });
     }
@@ -2034,7 +2068,14 @@ function tick() {
   let dt = clock.getDelta(); if (dt > 0.05) dt = 0.05;
   time += dt;
 
-  if (running && state === 'play') {
+  if (running && state === 'play' && celebrate > 0) {
+    // win celebration: slow-mo, marble rolls on, camera pushes in, then results
+    celebrate -= dt;
+    physAcc += dt * 0.3; let n = 0;
+    while (physAcc >= FIXED_DT && n < 6) { physicsStep(FIXED_DT); physAcc -= FIXED_DT; n++; }
+    SFX.roll(Math.hypot(ball.vel.x, ball.vel.z) * 0.3, grounded);
+    if (celebrate <= 0) { celebrate = 0; running = false; finishWin(); }
+  } else if (running && state === 'play') {
     readKeyboard();
     // fixed-timestep physics → consistent feel across framerates, no tunneling
     physAcc += dt;
@@ -2085,7 +2126,8 @@ window.__dbg = { THREE, scene, camera, renderer, ball, keys, tiltTarget, get sta
   get movers() { return movers.map(m => ({ x: +m.col.c.x.toFixed(2), z: +m.col.c.z.toFixed(2) })); },
   get fades() { return fadeTiles.map(f => ({ t: f.col.fadeT == null ? null : +f.col.fadeT.toFixed(2), alive: f.col.alive })); },
   TUNE, toggleTune, editor, enterEditor, edTest, edToData, applySkin, save,
-  get ghost() { return { active: ghostActive, frames: ghostFrames ? ghostFrames.length : 0, vis: ghostMesh.visible, rec: recording.length }; } };
+  get ghost() { return { active: ghostActive, frames: ghostFrames ? ghostFrames.length : 0, vis: ghostMesh.visible, rec: recording.length }; },
+  get win() { return { celebrate, levelDone, running }; } };
 
 } catch (e) { window.__err(e); }
 </script>

--- a/apps/marble/index.html
+++ b/apps/marble/index.html
@@ -1052,6 +1052,63 @@ const LEVELS = [
       buildGoal(16, 0, 0);
     }
   },
+  {
+    name: 'Tightrope', theme: 'twilight', par: 45, start: [-10, 1.2, 6], goal: [10, 0, -6],
+    build() {
+      addBox(-10, -0.5, 6, 5, 1, 5);
+      addBox(-10, 0.4, 8.2, 5, 1.4, 0.7, { type: 'wall' });
+      addBox(-10, -0.5, -0.5, 2.6, 1, 13);            // narrow vertical, no rails
+      addBox(-1.5, -0.5, -6, 17, 1, 2.6);             // narrow horizontal
+      addBox(10, -0.5, -6, 5, 1, 5);
+      addBox(10, 0.4, -8.2, 5, 1.4, 0.7, { type: 'wall' });
+      addCrystal(-10, 1.2, 6); addCrystal(-10, 1.3, 1); addCrystal(-10, 1.3, -5);
+      addCrystal(-2, 1.3, -6); addCrystal(5, 1.3, -6); addCrystal(10, 1.2, -6);
+      buildGoal(10, 0, -6);
+    }
+  },
+  {
+    name: 'Crosswind', theme: 'glacier', par: 44, start: [-12, 1.2, 0], goal: [12, 0, 0],
+    build() {
+      addBox(-12, -0.5, 0, 7, 1, 8);
+      addBox(-12, 0.4, -4.2, 7, 1.6, 0.7, { type: 'wall' }); addBox(-12, 0.4, 4.2, 7, 1.6, 0.7, { type: 'wall' }); addBox(-15.2, 0.4, 0, 0.7, 1.6, 8, { type: 'wall' });
+      addBox(-5, -0.5, 0, 8, 1, 9, { type: 'conveyor', push: [0, 1], color: 0x3aa8c8 });
+      addBox(-5, 0.4, -4.7, 8, 1.6, 0.7, { type: 'wall' });   // open +z
+      addBox(4, -0.5, 0, 8, 1, 9, { type: 'conveyor', push: [0, -1], color: 0x3aa8c8 });
+      addBox(4, 0.4, 4.7, 8, 1.6, 0.7, { type: 'wall' });     // open -z
+      addBox(12, -0.5, 0, 7, 1, 8);
+      addBox(12, 0.4, -4.2, 7, 1.6, 0.7, { type: 'wall' }); addBox(12, 0.4, 4.2, 7, 1.6, 0.7, { type: 'wall' }); addBox(15.2, 0.4, 0, 0.7, 1.6, 8, { type: 'wall' });
+      addCrystal(-12, 1.2, 0); addCrystal(-5, 1.3, -3); addCrystal(4, 1.3, 3); addCrystal(12, 1.2, 0);
+      buildGoal(12, 0, 0);
+    }
+  },
+  {
+    name: 'Twin Spin', theme: 'verdant', par: 42, start: [-9, 1.2, 0], goal: [9, 0, 0],
+    build() {
+      addBox(0, -0.5, 0, 20, 1, 14);
+      addBox(0, 0.4, -7.2, 20, 1.8, 0.7, { type: 'wall' }); addBox(0, 0.4, 7.2, 20, 1.8, 0.7, { type: 'wall' });
+      addBox(-10.2, 0.4, 0, 0.7, 1.8, 14, { type: 'wall' }); addBox(10.2, 0.4, 0, 0.7, 1.8, 14, { type: 'wall' });
+      addBox(-5, -0.5, 0, 7, 1, 7, { rotor: { speed: 0.9 }, color: 0x4fae6a });
+      addBox(5, -0.5, 0, 7, 1, 7, { rotor: { speed: -0.9 }, color: 0x5fb87a });
+      addCrystal(-9, 1.2, 0); addCrystal(-5, 1.3, 0); addCrystal(0, 1.3, 0); addCrystal(5, 1.3, 0); addCrystal(9, 1.2, 0);
+      buildGoal(9, 0, 0);
+    }
+  },
+  {
+    name: 'Inferno', theme: 'ember', par: 60, start: [-13, 1.2, 0], goal: [14, 2.5, 0],
+    build() {
+      addBox(-13, -0.5, 0, 5, 1, 7);
+      addBox(-13, 0.4, -3.6, 5, 1.6, 0.7, { type: 'wall' }); addBox(-13, 0.4, 3.6, 5, 1.6, 0.7, { type: 'wall' }); addBox(-16.2, 0.4, 0, 0.7, 1.6, 7, { type: 'wall' });
+      addBox(-4, -0.5, 0, 13, 1, 7);
+      addBox(-4, 0.4, -3.6, 13, 1.6, 0.7, { type: 'wall' }); addBox(-4, 0.4, 3.6, 13, 1.6, 0.7, { type: 'wall' });
+      [[-7, -1.5], [-7, 1.5], [-3, 0], [0, -2], [0, 2]].forEach(([x, z]) => addBox(x, 0.7, z, 1.3, 1.9, 1.3, { type: 'bumper', color: 0xff7a4d }));
+      addBox(4.5, -0.5, 0, 3, 1, 6, { type: 'fade', color: 0xe08a5a }); addBox(7.5, -0.5, 0, 3, 1, 6, { type: 'fade', color: 0xe08a5a });
+      addBox(10.5, -0.5, 0, 3, 1, 6, { type: 'pad', color: 0xffb24f });
+      addBox(14, 2.0, 0, 5, 1, 7);
+      addBox(14, 2.9, -3.6, 5, 1.8, 0.7, { type: 'wall' }); addBox(14, 2.9, 3.6, 5, 1.8, 0.7, { type: 'wall' }); addBox(16.7, 2.9, 0, 0.7, 1.8, 7, { type: 'wall' });
+      addCrystal(-13, 1.2, 0); addCrystal(-3, 1.3, 0); addCrystal(6, 1.3, 0); addCrystal(10.5, 1.3, 0); addCrystal(14, 3.2, 0);
+      buildGoal(14, 2.5, 0);
+    }
+  },
 ];
 
 function clearLevel() {
@@ -1961,7 +2018,7 @@ const SFX = (function () {
 //  UI WIRING
 //============================================================================
 const MEDAL_COLOR = { S: '#ffd35a', A: '#7df9ff', B: '#b6c2ff', C: '#cfd6ff' };
-const WORLDS = [{ name: 'Sky Meadow', from: 0 }, { name: 'Frozen Reach', from: 4 }, { name: 'The Mechanism', from: 8 }, { name: 'The Summit', from: 13 }];
+const WORLDS = [{ name: 'Sky Meadow', from: 0 }, { name: 'Frozen Reach', from: 4 }, { name: 'The Mechanism', from: 8 }, { name: 'The Summit', from: 13 }, { name: 'Aurora Heights', from: 16 }];
 function buildLevelGrid() {
   const grid = $('lvlGrid'); grid.innerHTML = '';
   let clearedCount = 0;

--- a/apps/marble/index.html
+++ b/apps/marble/index.html
@@ -76,6 +76,9 @@
   .lvl .lock { position: absolute; right: 12px; top: 12px; font-size: 16px; opacity: .8; }
   .lvl.cleared { box-shadow: inset 0 0 0 1.5px rgba(85,255,204,.45); }
   .lvl .star { color: var(--accent2); }
+  .lvl-world { grid-column: 1 / -1; text-align: left; font-weight: 800; letter-spacing: 1.5px; text-transform: uppercase;
+    font-size: 13px; opacity: .6; margin: 8px 2px 2px; display: flex; align-items: center; gap: 10px; }
+  .lvl-world::after { content: ''; flex: 1; height: 1px; background: linear-gradient(90deg, rgba(255,255,255,.18), transparent); }
 
   /* HUD */
   #hud { position: absolute; inset: 0; display: none; }
@@ -639,6 +642,7 @@ const fadeTiles = [], conveyors = [], padMats = [];
 //============================================================================
 const colliders = [];
 const movers = [];     // {collider, mesh, axis, amp, speed, phase, base}
+const rotors = [];     // {col, mesh, center, speed}  spinning platforms (yaw)
 class Collider {
   constructor(c, h, q, mat, type) {
     this.c = c; this.h = h; this.q = q || null; this.qi = q ? q.clone().invert() : null;
@@ -649,12 +653,12 @@ class Collider {
 function addBox(x, y, z, w, h, d, opts = {}) {
   const type = opts.type || 'floor';
   const color = opts.color != null ? opts.color : (type === 'wall' ? theme.wall : theme.floor);
-  const q = (opts.rx || opts.rz) ? new THREE.Quaternion().setFromEuler(new THREE.Euler(opts.rx || 0, 0, opts.rz || 0)) : null;
+  const q = (opts.rx || opts.rz || opts.rotor) ? new THREE.Quaternion().setFromEuler(new THREE.Euler(opts.rx || 0, 0, opts.rz || 0)) : null;
   const mesh = new THREE.Mesh(roundedGeo(w, h, d), surfaceMat(type, color));
   mesh.position.set(x, y, z); if (q) mesh.quaternion.copy(q);
   mesh.castShadow = type !== 'ice'; mesh.receiveShadow = true; levelGroup.add(mesh);
   // Two-tone deck: a lighter, inset top cap turns plain boxes into crafted platforms.
-  if ((type === 'floor' || type === 'ramp') && w > 1.4 && d > 1.4 && !opts.mover) {
+  if ((type === 'floor' || type === 'ramp') && w > 1.4 && d > 1.4 && !opts.mover && !opts.rotor) {
     const cap = new THREE.Mesh(roundedGeo(w - 0.35, 0.12, d - 0.35), deckMat(color));
     const up = new THREE.Vector3(0, h / 2 - 0.05, 0); if (q) up.applyQuaternion(q);
     cap.position.set(x + up.x, y + up.y, z + up.z);
@@ -668,6 +672,7 @@ function addBox(x, y, z, w, h, d, opts = {}) {
     fadeTiles.push({ col, mesh });
   }
   if (type === 'pad' && padMats.indexOf(mesh.material) < 0) padMats.push(mesh.material);
+  if (opts.rotor) rotors.push({ col, mesh, center: new THREE.Vector3(x, y, z), speed: opts.rotor.speed || 0.8 });
   if (type === 'conveyor') {
     const dir = new THREE.Vector3(opts.push ? opts.push[0] : 1, 0, opts.push ? opts.push[1] : 0);
     if (dir.lengthSq() < 1e-6) dir.set(1, 0, 0); dir.normalize();
@@ -1007,6 +1012,18 @@ const LEVELS = [
     }
   },
   {
+    name: 'Carousel', theme: 'verdant', par: 40, start: [0, 1.2, 9], goal: [0, 0, -9],
+    build() {
+      // big arena with a flush spinning disc in the middle that carries you around
+      addBox(0, -0.5, 0, 16, 1, 22);
+      addBox(-8.2, 0.4, 0, 0.7, 1.8, 22, { type: 'wall' }); addBox(8.2, 0.4, 0, 0.7, 1.8, 22, { type: 'wall' });
+      addBox(0, 0.4, -11.2, 16, 1.8, 0.7, { type: 'wall' }); addBox(0, 0.4, 11.2, 16, 1.8, 0.7, { type: 'wall' });
+      addBox(0, -0.5, 0, 8, 1, 8, { rotor: { speed: 0.75 }, color: 0x4fae6a });   // spinner (flush)
+      addCrystal(0, 1.2, 9); addCrystal(-3, 1.3, 0); addCrystal(3, 1.3, 0); addCrystal(0, 1.3, 3); addCrystal(0, 1.2, -9);
+      buildGoal(0, 0, -9);
+    }
+  },
+  {
     name: 'Apex', theme: 'twilight', par: 75, start: [-16, 1.2, 0], goal: [16, 0, 0],
     build() {
       // a medley of every mechanic on one connected run
@@ -1030,7 +1047,7 @@ const LEVELS = [
 function clearLevel() {
   // remove level meshes / colliders
   while (levelGroup.children.length) { const c = levelGroup.children.pop(); levelGroup.remove(c); }
-  colliders.length = 0; movers.length = 0; crystals = []; goalGroup = null; goalLight = null;
+  colliders.length = 0; movers.length = 0; rotors.length = 0; crystals = []; goalGroup = null; goalLight = null;
   fadeTiles.length = 0; conveyors.length = 0; padMats.length = 0;
 }
 
@@ -1186,6 +1203,18 @@ function physicsStep(dt) {
     }
   }
 
+  // spin rotors (yaw) and carry a resting ball tangentially
+  for (const r of rotors) {
+    const a = time * r.speed, prev = (r._a === undefined) ? a : r._a; r._a = a;
+    _rotQ.setFromAxisAngle(_UP, a); r.col.q.copy(_rotQ); r.col.qi.copy(_rotQ).invert(); r.mesh.quaternion.copy(_rotQ);
+    if (grounded && _groundCol === r.col) {
+      const da = a - prev, c = Math.cos(da), s = Math.sin(da);
+      const dx = ball.pos.x - r.center.x, dz = ball.pos.z - r.center.z;
+      ball.pos.x = r.center.x + dx * c - dz * s; ball.pos.z = r.center.z + dx * s + dz * c;
+      const vx = ball.vel.x, vz = ball.vel.z; ball.vel.x = vx * c - vz * s; ball.vel.z = vx * s + vz * c;
+    }
+  }
+
   const steps = Math.max(1, Math.min(8, Math.ceil(ball.vel.length() * dt / (BALL_R * 0.5))));
   const h = dt / steps;
   grounded = false; let hitBumper = false, hitPad = false, prevGround = false;
@@ -1273,6 +1302,7 @@ function collide() {
 }
 let _groundCol = null;
 const _moverV = new THREE.Vector3(), _moverD = new THREE.Vector3();
+const _rotQ = new THREE.Quaternion(), _UP = new THREE.Vector3(0, 1, 0);
 
 //============================================================================
 //  CAMERA
@@ -1897,10 +1927,13 @@ const SFX = (function () {
 //  UI WIRING
 //============================================================================
 const MEDAL_COLOR = { S: '#ffd35a', A: '#7df9ff', B: '#b6c2ff', C: '#cfd6ff' };
+const WORLDS = [{ name: 'Sky Meadow', from: 0 }, { name: 'Frozen Reach', from: 4 }, { name: 'The Mechanism', from: 8 }, { name: 'The Summit', from: 13 }];
 function buildLevelGrid() {
   const grid = $('lvlGrid'); grid.innerHTML = '';
   let clearedCount = 0;
   LEVELS.forEach((L, i) => {
+    const w = WORLDS.find(w => w.from === i);
+    if (w) { const hd = document.createElement('div'); hd.className = 'lvl-world'; hd.textContent = w.name; grid.appendChild(hd); }
     const unlocked = i === 0 || save.cleared[i - 1];
     if (save.cleared[i]) clearedCount++;
     const t = THEMES[L.theme];
@@ -1916,6 +1949,7 @@ function buildLevelGrid() {
     grid.appendChild(el);
   });
   // custom levels
+  const ch = document.createElement('div'); ch.className = 'lvl-world'; ch.textContent = 'Your Stages'; grid.appendChild(ch);
   (save.customLevels || []).forEach((d, i) => {
     const t = THEMES[d.theme] || THEMES.dawn;
     const el = document.createElement('div'); el.className = 'lvl cleared';

--- a/apps/marble/index.html
+++ b/apps/marble/index.html
@@ -269,6 +269,9 @@
       <div class="set-row">Touch Controls
         <div class="seg" id="segCtl"><button data-v="drag">Drag</button><button data-v="tilt">Tilt</button></div>
       </div>
+      <div class="set-row">Marble
+        <div class="seg" id="skinRow" style="flex-wrap:wrap;gap:6px;"></div>
+      </div>
       <div class="btn-row"><button class="btn ghost" id="btnSetReset">Reset Progress</button><button class="btn" id="btnSetBack">Done</button></div>
     </div>
   </div>
@@ -392,6 +395,7 @@ import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
+import { RoundedBoxGeometry } from 'three/addons/geometries/RoundedBoxGeometry.js';
 
 try {
 const $ = id => document.getElementById(id);
@@ -419,7 +423,7 @@ function haptic(taps) {
 }
 
 const SAVE_KEY = 'marble_odyssey_v1';
-const defaults = { gfx: isMobile ? 'med' : 'high', music: 'on', sfx: 'on', ctl: 'drag', best: {}, cleared: {}, medals: {} };
+const defaults = { gfx: isMobile ? 'med' : 'high', music: 'on', sfx: 'on', ctl: 'drag', skin: 'rose', best: {}, cleared: {}, medals: {} };
 let save = Object.assign({}, defaults, JSON.parse(localStorage.getItem(SAVE_KEY) || '{}'));
 function persist() { localStorage.setItem(SAVE_KEY, JSON.stringify(save)); }
 
@@ -548,6 +552,19 @@ const marbleMesh = new THREE.Mesh(new THREE.SphereGeometry(BALL_R, 56, 40),
   new THREE.MeshPhysicalMaterial({ color: 0xff4d72, metalness: 0.35, roughness: 0.16, envMapIntensity: 1.4,
     clearcoat: 1.0, clearcoatRoughness: 0.08, sheen: 0.4, sheenColor: 0xff9fc0,
     emissive: 0x2a000c, emissiveIntensity: 0.35 }));
+const MARBLE_SKINS = {
+  rose:     { sw: '#ff5d7e', color: 0xff4d72, metalness: 0.35, roughness: 0.16, clearcoat: 1.0, sheen: 0.4, sheenColor: 0xff9fc0, emissive: 0x2a000c, ei: 0.35 },
+  aqua:     { sw: '#35d6ff', color: 0x35d6ff, metalness: 0.4, roughness: 0.12, clearcoat: 1.0, sheen: 0.4, sheenColor: 0x9ff0ff, emissive: 0x002028, ei: 0.3 },
+  gold:     { sw: '#ffcf5a', color: 0xffcf5a, metalness: 1.0, roughness: 0.18, clearcoat: 0.6, sheen: 0.0, sheenColor: 0x000000, emissive: 0x1a1000, ei: 0.2 },
+  pearl:    { sw: '#eef0ff', color: 0xffffff, metalness: 0.2, roughness: 0.07, clearcoat: 1.0, sheen: 0.9, sheenColor: 0xbfd0ff, emissive: 0x101018, ei: 0.2 },
+  obsidian: { sw: '#2a2c40', color: 0x20223a, metalness: 0.6, roughness: 0.05, clearcoat: 1.0, sheen: 0.3, sheenColor: 0x6f8cff, emissive: 0x000008, ei: 0.2 },
+  magma:    { sw: '#ff5a2a', color: 0xff5a2a, metalness: 0.3, roughness: 0.3, clearcoat: 0.8, sheen: 0.2, sheenColor: 0xffaa66, emissive: 0x661500, ei: 1.2 },
+};
+function applySkin(name) {
+  const s = MARBLE_SKINS[name] || MARBLE_SKINS.rose, m = marbleMesh.material;
+  m.color.setHex(s.color); m.metalness = s.metalness; m.roughness = s.roughness; m.clearcoat = s.clearcoat;
+  m.sheen = s.sheen; m.sheenColor.setHex(s.sheenColor); m.emissive.setHex(s.emissive); m.emissiveIntensity = s.ei; m.needsUpdate = true;
+}
 marbleMesh.castShadow = true;
 marbleSquash.add(marbleMesh); marbleRoot.add(marbleSquash); stage.add(marbleRoot);
 
@@ -600,6 +617,15 @@ const MATS = {
 };
 const boxGeo = new THREE.BoxGeometry(1, 1, 1);
 const coneGeo = new THREE.ConeGeometry(0.34, 0.7, 4);
+// Cached rounded-box geometries (soft GameCube edges) keyed by quantized size.
+const roundedCache = {};
+function roundedGeo(w, h, d) {
+  const k = w.toFixed(2) + '_' + h.toFixed(2) + '_' + d.toFixed(2);
+  if (roundedCache[k]) return roundedCache[k];
+  const r = Math.min(0.14, w * 0.45, h * 0.45, d * 0.45);
+  const g = new RoundedBoxGeometry(w, h, d, 2, Math.max(0.04, r));
+  roundedCache[k] = g; return g;
+}
 const JUMP_VEL = 15, CONV_ACCEL = 8, FADE_TIME = 0.9;
 const fadeTiles = [], conveyors = [], padMats = [];
 
@@ -619,14 +645,14 @@ function addBox(x, y, z, w, h, d, opts = {}) {
   const type = opts.type || 'floor';
   const color = opts.color != null ? opts.color : (type === 'wall' ? theme.wall : theme.floor);
   const q = (opts.rx || opts.rz) ? new THREE.Quaternion().setFromEuler(new THREE.Euler(opts.rx || 0, 0, opts.rz || 0)) : null;
-  const mesh = new THREE.Mesh(boxGeo, surfaceMat(type, color));
-  mesh.scale.set(w, h, d); mesh.position.set(x, y, z); if (q) mesh.quaternion.copy(q);
+  const mesh = new THREE.Mesh(roundedGeo(w, h, d), surfaceMat(type, color));
+  mesh.position.set(x, y, z); if (q) mesh.quaternion.copy(q);
   mesh.castShadow = type !== 'ice'; mesh.receiveShadow = true; levelGroup.add(mesh);
   // Two-tone deck: a lighter, inset top cap turns plain boxes into crafted platforms.
   if ((type === 'floor' || type === 'ramp') && w > 1.4 && d > 1.4 && !opts.mover) {
-    const cap = new THREE.Mesh(boxGeo, deckMat(color));
+    const cap = new THREE.Mesh(roundedGeo(w - 0.35, 0.12, d - 0.35), deckMat(color));
     const up = new THREE.Vector3(0, h / 2 - 0.05, 0); if (q) up.applyQuaternion(q);
-    cap.scale.set(w - 0.35, 0.12, d - 0.35); cap.position.set(x + up.x, y + up.y, z + up.z);
+    cap.position.set(x + up.x, y + up.y, z + up.z);
     if (q) cap.quaternion.copy(q); cap.receiveShadow = true; levelGroup.add(cap);
   }
   const col = new Collider(new THREE.Vector3(x, y, z), new THREE.Vector3(w/2, h/2, d/2), q, MATS[type] || MATS.floor, type);
@@ -1889,6 +1915,15 @@ function wireUI() {
   setupSeg('segMusic', 'music', () => SFX.setMusicVol());
   setupSeg('segSfx', 'sfx');
   setupSeg('segCtl', 'ctl', v => { if (v === 'tilt') enableTilt(); });
+  // marble skin swatches
+  const skinRow = $('skinRow'); skinRow.innerHTML = '';
+  Object.keys(MARBLE_SKINS).forEach(name => {
+    const b = document.createElement('button'); b.dataset.v = name;
+    b.style.cssText = `width:26px;height:26px;border-radius:50%;padding:0;background:${MARBLE_SKINS[name].sw};box-shadow:${name === save.skin ? '0 0 0 2px #fff' : 'inset 0 0 0 1px rgba(255,255,255,.3)'};opacity:1;`;
+    b.onclick = () => { save.skin = name; persist(); applySkin(name); SFX.click();
+      [...skinRow.children].forEach(c => c.style.boxShadow = c === b ? '0 0 0 2px #fff' : 'inset 0 0 0 1px rgba(255,255,255,.3)'); };
+    skinRow.appendChild(b);
+  });
   $('tuneClose').onclick = () => toggleTune(false);
   $('tuneReset').onclick = () => { TUNE = Object.assign({}, TUNE_DEF); applyTune(); persistTune(); buildTunePanel(); toast('Tuning reset'); };
   if (!isMobile) $('titleHint').textContent = 'WASD / Arrows to tilt · T for tuning panel';
@@ -1950,6 +1985,7 @@ wireUI();
 wireEditorUI();
 applyGfx();
 applyTune();
+applySkin(save.skin);
 loadLevel(0);
 setState('title');
 showScreen('title');
@@ -1963,7 +1999,7 @@ window.__dbg = { THREE, scene, camera, renderer, ball, keys, tiltTarget, get sta
   get info() { return { state, levelIndex, gems, gemsTotal, lives, levelTime, ballPos: ball.pos.toArray(), grounded }; },
   get movers() { return movers.map(m => ({ x: +m.col.c.x.toFixed(2), z: +m.col.c.z.toFixed(2) })); },
   get fades() { return fadeTiles.map(f => ({ t: f.col.fadeT == null ? null : +f.col.fadeT.toFixed(2), alive: f.col.alive })); },
-  TUNE, toggleTune, editor, enterEditor, edTest, edToData };
+  TUNE, toggleTune, editor, enterEditor, edTest, edToData, applySkin, save };
 
 } catch (e) { window.__err(e); }
 </script>

--- a/apps/marble/index.html
+++ b/apps/marble/index.html
@@ -1340,7 +1340,7 @@ function startLevel(idxOrL) {
   ghostMesh.visible = ghostActive;
   updateHud();
   showScreen('hud'); state = 'countdown'; running = false;
-  SFX.music();
+  SFX.music(curLevel.theme);
   runCountdown();
 }
 function runCountdown() {
@@ -1708,6 +1708,9 @@ function gameplay(dt) {
   }
   // speed trail behind the marble
   const sp = Math.hypot(ball.vel.x, ball.vel.z);
+  // adaptive music intensity: faster + nearer the goal = brighter
+  const goalProx = goalGroup ? clamp(1 - Math.hypot(ball.pos.x - goalPos.x, ball.pos.z - goalPos.z) / 16, 0, 1) : 0;
+  SFX.setIntensity(clamp(sp / 15, 0, 1) * 0.7 + goalProx * 0.55);
   if (sp > 6.5 && Math.random() < dt * 40) {
     _trail.copy(ball.pos); _trail.y -= 0.15;
     spawn(_trail, 1, { color: [0xff6e90, 0xffb0c8, 0xffd0dc], speed: 0.6, size: 8, life: 0.38, grav: 1.5, up: 0.2 });
@@ -1808,14 +1811,17 @@ const SFX = (function () {
     o.start(); o.stop(ctx.currentTime + dur + 0.02);
   }
   // ---- generative music ----
-  let playing = false, schedTimer = null, step16 = 0, nextTime = 0;
+  let playing = false, schedTimer = null, step16 = 0, nextTime = 0, intensity = 0, intTarget = 0;
   const BPM = 92, beat = 60 / BPM, eighth = beat / 2;
-  const CHORDS = [
-    { pad: [57, 60, 64, 67], bass: 45 },   // Am
-    { pad: [53, 57, 60, 65], bass: 41 },   // F
-    { pad: [48, 52, 55, 60], bass: 36 },   // C
-    { pad: [55, 59, 62, 67], bass: 43 },   // G
-  ];
+  const PROGRESSIONS = {
+    // each: 4 bars of {pad chord, bass root} (MIDI)
+    a: [{ pad: [57, 60, 64, 67], bass: 45 }, { pad: [53, 57, 60, 65], bass: 41 }, { pad: [48, 52, 55, 60], bass: 36 }, { pad: [55, 59, 62, 67], bass: 43 }], // Am F C G
+    b: [{ pad: [48, 52, 55, 60], bass: 36 }, { pad: [55, 59, 62, 67], bass: 43 }, { pad: [57, 60, 64, 67], bass: 45 }, { pad: [53, 57, 60, 65], bass: 41 }], // C G Am F
+    c: [{ pad: [50, 53, 57, 62], bass: 38 }, { pad: [46, 50, 53, 58], bass: 34 }, { pad: [53, 57, 60, 65], bass: 41 }, { pad: [48, 52, 55, 60], bass: 36 }], // Dm Bb F C
+    d: [{ pad: [52, 55, 59, 64], bass: 40 }, { pad: [48, 52, 55, 60], bass: 36 }, { pad: [55, 59, 62, 67], bass: 43 }, { pad: [50, 54, 57, 62], bass: 38 }], // Em C G D
+  };
+  const THEME_PROG = { dawn: 'a', twilight: 'a', verdant: 'b', glacier: 'b', sunset: 'c', ember: 'c', _alt: 'd' };
+  let prog = PROGRESSIONS.a;
   const ARP = [0, 2, 1, 3, 2, 3, 1, 2];
   function voice(freq, t, dur, type, peak, atk, dest, send) {
     const o = ctx.createOscillator(), g = ctx.createGain();
@@ -1828,17 +1834,22 @@ const SFX = (function () {
     return o;
   }
   function schedNote(t) {
-    const bar = Math.floor(step16 / 8) % 4, ch = CHORDS[bar], e = step16 % 8;
+    intensity += (intTarget - intensity) * 0.06;
+    const bar = Math.floor(step16 / 8) % 4, ch = prog[bar], e = step16 % 8;
     if (e === 0) {
-      // pad chord
-      ch.pad.forEach((m, i) => { const o = voice(mf(m), t, beat * 4 * 0.98, i % 2 ? 'sawtooth' : 'triangle', 0.05, 0.45, musicGain, true); o.detune.value = (i % 2 ? 6 : -6); });
+      ch.pad.forEach((m, i) => { const o = voice(mf(m), t, beat * 4 * 0.98, i % 2 ? 'sawtooth' : 'triangle', 0.045 + intensity * 0.02, 0.45, musicGain, true); o.detune.value = (i % 2 ? 6 : -6); });
       voice(mf(ch.bass), t, beat * 3.6, 'sine', 0.13, 0.04, musicGain, false);
       voice(mf(ch.bass + 12), t, beat * 3.2, 'triangle', 0.03, 0.06, musicGain, false);
     }
-    // arpeggio bell
+    // arpeggio bell — brightens with intensity
     const note = ch.pad[ARP[e]] + 12;
-    voice(mf(note), t, 0.5, 'triangle', e % 2 ? 0.05 : 0.075, 0.006, musicGain, true);
+    voice(mf(note), t, 0.5, 'triangle', (e % 2 ? 0.05 : 0.075) * (0.6 + intensity * 0.7), 0.006, musicGain, true);
     if (e === 4) voice(mf(note + 12), t, 0.7, 'sine', 0.035, 0.006, musicGain, true);
+    // high shimmer + 16th fills when intense
+    if (intensity > 0.45) {
+      voice(mf(ch.pad[(ARP[e] + 1) % 4] + 24), t, 0.3, 'sine', 0.02 * intensity, 0.004, musicGain, true);
+      voice(mf(note + 7), t + eighth * 0.5, 0.18, 'triangle', 0.03 * intensity, 0.004, musicGain, true);
+    }
     step16++;
   }
   function scheduler() {
@@ -1868,8 +1879,11 @@ const SFX = (function () {
       rollOsc.frequency.value = 55 + speed * 5.5; rollOsc2.frequency.value = 82 + speed * 7; rollFilter.frequency.value = 220 + speed * 38;
     },
     duck(d) { if (musicGain && ctx) musicGain.gain.setTargetAtTime(save.music === 'on' ? (d ? 0.12 : 0.4) : 0, ctx.currentTime, 0.1); },
-    music() {
+    setProgression(theme) { prog = PROGRESSIONS[THEME_PROG[theme] || 'a'] || PROGRESSIONS.a; },
+    setIntensity(v) { intTarget = clamp(v, 0, 1); },
+    music(theme) {
       ensure(); if (!ctx) return;
+      this.setProgression(theme); intensity = 0; intTarget = 0;
       if (musicGain) musicGain.gain.setTargetAtTime(save.music === 'on' ? 0.4 : 0, ctx.currentTime, 0.2);
       if (playing) return; playing = true; step16 = 0; nextTime = ctx.currentTime + 0.1;
       schedTimer = setInterval(scheduler, 25);


### PR DESCRIPTION
Follow-up to #232 (the base game, now merged). Brings Marble Odyssey toward GameCube quality across the roadmap (gamepad intentionally skipped). 10 commits.

## Creator tools
- **Live tuning panel** (press **T**): sliders for gravity, max-tilt, tilt response, max-speed, floor/ice grip, bounciness, camera distance/height/follow, FOV, bloom. Live-applies + persists — dial feel on a real device.
- **In-page level editor** (Stages → "Create Stage"): place/move/edit every tile type, set start/goal/crystals, test-play, **Save** custom stages (localStorage, appear in stage select), **Export** paste-ready `addBox()` code.

## Feel & visuals
- **Rounded platform edges** (RoundedBoxGeometry) for the soft GameCube look.
- **6 marble skins** (rose/aqua/gold/pearl/obsidian/magma) with a Settings picker.
- **Fixed 1/120s-timestep physics** (consistent feel across framerates, no tunneling).
- **Win slow-mo + camera push-in**, bigger confetti, results-card pop.

## Content — now 20 stages / 5 worlds
- New mechanics: **jump pads, conveyors, crumbling fade-tiles, rotating platforms**.
- New stages incl. an expert world (Aurora Heights: Tightrope, Crosswind, Twin Spin, Inferno).
- Stage select grouped into worlds with headers, best times, and medals.

## Meta & audio
- **Ghost replays** (race your best run), **medals** (S/A/B/C + totals).
- **Per-theme music with adaptive intensity**, **tutorial hints**, **+1 ×N combo popups**.

## Verification
Regression-tested headlessly throughout (Chrome + CDP + SwiftShader): clean boot, all 20 stages build with valid geometry and spawn grounded, every mechanic exercised (ramp climb, gap/crumble crossings, pad launch, conveyor steering, mover & rotor carry, fall/respawn/lives), win→results, editor round-trip, all menus — no runtime errors.

> Still verified on software GL, not a real iPhone — the tuning panel exists precisely so feel can be dialed on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)