### PR TITLE
Pixel Run: apply outstanding PR-review findings

### DIFF
--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -107,11 +107,13 @@ function resize() {
   canvas.width = W; canvas.height = H;
   canvas.style.width = cw + 'px'; canvas.style.height = chh + 'px';
   ctx.imageSmoothingEnabled = false;
-  readInsets();
+  readInsets(cw, chh);
 }
 let safeTop = 0, safeBot = 0, safeL = 0, safeR = 0;
-function readInsets() {
-  // notch/home-indicator overlay the canvas in standalone mode; keep UI clear of them
+function readInsets(cw, chh) {
+  // notch/home-indicator overlay the canvas in standalone mode; keep UI clear of them.
+  // uses the same visualViewport-corrected size as resize() so bottom/right insets
+  // aren't computed against a stale innerWidth/innerHeight on iOS launch/rotation
   const probe = document.createElement('div');
   probe.style.cssText = 'position:fixed;top:env(safe-area-inset-top);bottom:env(safe-area-inset-bottom);' +
     'left:env(safe-area-inset-left);right:env(safe-area-inset-right);pointer-events:none;visibility:hidden;';
@@ -120,9 +122,9 @@ function readInsets() {
   probe.remove();
   const s = (window.devicePixelRatio || 1) / SCALE;
   safeTop = Math.ceil(r.top * s);
-  safeBot = Math.ceil(Math.max(0, window.innerHeight - r.bottom) * s);
+  safeBot = Math.ceil(Math.max(0, chh - r.bottom) * s);
   safeL = Math.ceil(r.left * s);
-  safeR = Math.ceil(Math.max(0, window.innerWidth - r.right) * s);
+  safeR = Math.ceil(Math.max(0, cw - r.right) * s);
 }
 window.addEventListener('resize', resize);
 window.addEventListener('orientationchange', () => setTimeout(resize, 250));
@@ -1362,6 +1364,7 @@ for (const k in SONGS) {
   const s = SONGS[k];
   s.pl = parseTrack(s.lead); s.ph = parseTrack(s.harm); s.pb = parseTrack(s.bass);
 }
+if (MUSIC_ERRORS.length) console.error('pixelrun: miscounted music bars:', MUSIC_ERRORS);
 
 const audio = {
   ctx: null, master: null, mgain: null, sgain: null,
@@ -1583,7 +1586,14 @@ function tileAt(tx, ty) {
 function solidAt(tx, ty) { return SOLID.has(tileAt(tx, ty)); }
 function groundTopPx(tx) { const g = ground.get(tx); return g === undefined ? Infinity : -g * TILE; }
 function waterSurfaceAt(px) { return water.get(Math.floor(px / TILE)); }
-function inWaterAt(px, py) { const s = waterSurfaceAt(px); return s !== undefined && py > s; }
+function warpUnderfoot() {
+  // the warp pipe the player is standing on, if any (shared by swipe + slam entry)
+  const pc = player.x + player.w / 2, feet = player.y + player.h;
+  for (const e of ents)
+    if (e.type === 'warp' && !e.dead && pc > e.x + 2 && pc < e.x + 30 && Math.abs(feet - e.y) < 6)
+      return e;
+  return null;
+}
 function difficulty() {
   return Math.min(1.25, gen.totalTiles / 2600 * 0.85 + Math.floor((game.worldNum - 1) / THEMES.length) * 0.3);
 }
@@ -1956,9 +1966,9 @@ function update() {
   if (player.inWater && player.mode === 'run' && game.frame % 24 === 0)
     parts.push({ x: player.x + 11, y: player.y + 3, vx: R(-0.2, 0.1), vy: -0.5,
       life: 34, color: '#bfeaff', size: 1, grav: -0.01 });
-  if (game.rain > 0) {
-    game.rain--;
-    if (game.frame % 5 === 0 && !game.inBonus)   // it's raining money
+  if (game.rain > 0 && !game.inBonus) {   // countdown pauses in bonus rooms so a
+    game.rain--;                          // grotto-granted rain isn't silently wasted
+    if (game.frame % 5 === 0)             // it's raining money
       coins.push({ x: cam.x + 30 + rng() * (W - 50), y: cam.y - 14, vx: 0, vy: 0,
         fall: 1.5 + rng() * 1.2, taken: 0 });
   }
@@ -2085,13 +2095,8 @@ function updatePlayer() {
       burst(player.x + 5, player.y + 6, '#fff', 3, 1, 0);
     } else if (player.onGround && player.mode === 'run' && !game.inBonus) {
       // swipe down while standing on a warp pipe: go in
-      const pc = player.x + player.w / 2, feet = player.y + player.h;
-      for (const e of ents) {
-        if (e.type === 'warp' && !e.dead && pc > e.x + 2 && pc < e.x + 30 && Math.abs(feet - e.y) < 5) {
-          enterPipe(e);
-          return;
-        }
-      }
+      const w = warpUnderfoot();
+      if (w) { enterPipe(w); return; }
     }
   }
 
@@ -2201,13 +2206,8 @@ function slamLand() {
   player.slam = false;
   // slamming onto a warp pipe dives straight in — the natural gesture
   if (!game.inBonus) {
-    const pc = player.x + player.w / 2, feet = player.y + player.h;
-    for (const e of ents) {
-      if (e.type === 'warp' && !e.dead && pc > e.x + 2 && pc < e.x + 30 && Math.abs(feet - e.y) < 6) {
-        enterPipe(e);
-        return;
-      }
-    }
+    const w = warpUnderfoot();
+    if (w) { enterPipe(w); return; }
   }
   player.landT = 9;
   game.shake = 6;
@@ -2453,25 +2453,22 @@ function updateEnts() {
     }
     if (e.type === 'chomp' || e.type === 'rollo' || e.type === 'spiny' || e.type === 'shell') {
       // walkers with gravity
-      {
-        const v = e.vx;
-        e.x += v;
-        // turn at walls
-        const dir = v > 0 ? 1 : -1;
-        const ftx = Math.floor((e.x + 8 + dir * 7) / TILE);
-        const fty = Math.floor((e.y + 12) / TILE);
-        if (solidAt(ftx, fty)) {
-          if (e.type === 'shell') { burst(e.x + 8, e.y + 8, '#59c8ff', 10, 2.4, 0.15); e.dead = 2; e.deadT = 1; sfx.kick(); }
-          else { e.vx = -e.vx; e.x += e.vx * 2; }
-        }
-        e.vy = Math.min(e.vy + GRAV, MAX_FALL);
-        e.y += e.vy;
-        const tyB = Math.floor((e.y + 16) / TILE);
-        for (let tx = Math.floor((e.x + 3) / TILE); tx <= Math.floor((e.x + 13) / TILE); tx++) {
-          const id = tileAt(tx, tyB);
-          if (SOLID.has(id) || (id === T_PLAT && e.vy >= 0 && e.y + 16 - e.vy <= tyB * TILE + 3)) {
-            e.y = tyB * TILE - 16; e.vy = 0; break;
-          }
+      e.x += e.vx;
+      // turn at walls
+      const dir = e.vx > 0 ? 1 : -1;
+      const ftx = Math.floor((e.x + 8 + dir * 7) / TILE);
+      const fty = Math.floor((e.y + 12) / TILE);
+      if (solidAt(ftx, fty)) {
+        if (e.type === 'shell') { burst(e.x + 8, e.y + 8, '#59c8ff', 10, 2.4, 0.15); e.dead = 2; e.deadT = 1; sfx.kick(); }
+        else { e.vx = -e.vx; e.x += e.vx * 2; }
+      }
+      e.vy = Math.min(e.vy + GRAV, MAX_FALL);
+      e.y += e.vy;
+      const tyB = Math.floor((e.y + 16) / TILE);
+      for (let tx = Math.floor((e.x + 3) / TILE); tx <= Math.floor((e.x + 13) / TILE); tx++) {
+        const id = tileAt(tx, tyB);
+        if (SOLID.has(id) || (id === T_PLAT && e.vy >= 0 && e.y + 16 - e.vy <= tyB * TILE + 3)) {
+          e.y = tyB * TILE - 16; e.vy = 0; break;
         }
       }
     } else if (e.type === 'bat') {

--- a/apps/pixelrun/sw.js
+++ b/apps/pixelrun/sw.js
@@ -2,7 +2,7 @@
 // shell makes it fully playable offline. Strategy is stale-while-revalidate —
 // instant load from cache, silently refreshed from the network for next launch.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'pixelrun-v4';
+const CACHE = 'pixelrun-v5';
 const SHELL = ['./', './index.html', './icon.png', './apple-touch-icon.png'];
 
 self.addEventListener('install', e => {
@@ -23,16 +23,18 @@ self.addEventListener('activate', e => {
 
 self.addEventListener('fetch', e => {
   if (e.request.method !== 'GET') return;
-  e.respondWith(
-    caches.match(e.request, { ignoreSearch: true }).then(hit => {
-      const refresh = fetch(e.request).then(res => {
-        if (res && res.ok) {
-          const copy = res.clone();
-          caches.open(CACHE).then(c => c.put(e.request, copy));
-        }
-        return res;
-      }).catch(() => hit);
-      return hit || refresh;
-    })
+  const cached = caches.match(e.request, { ignoreSearch: true });
+  const refresh = cached.then(hit =>
+    fetch(e.request).then(res => {
+      if (res && res.ok) {
+        const copy = res.clone();
+        return caches.open(CACHE).then(c => c.put(e.request, copy)).then(() => res);
+      }
+      return res;
+    }).catch(() => hit)
   );
+  // keep the worker alive until the background revalidation lands — without this
+  // the browser may kill the SW right after responding, so updates never stick
+  e.waitUntil(refresh);
+  e.respondWith(cached.then(hit => hit || refresh));
 });


### PR DESCRIPTION
The automated Claude reviews on #239–#246 contained real findings that had never been triaged (mea culpa — they weren't being read). This PR applies everything still outstanding:

## Real fixes
- **Service worker updates now actually stick** (#239 review): the background revalidation fetch wasn't wrapped in `event.waitUntil()`, so the browser could terminate the worker immediately after serving from cache — the "silently refreshed for next launch" half of stale-while-revalidate often never happened. This is likely why deploys felt like they needed extra reloads. Cache bumped to v5.
- **Safe-area insets use corrected viewport dims** (#239): `readInsets()` computed bottom/right insets from raw `innerWidth/innerHeight`, the exact values `resize()` had just corrected via `visualViewport` for iOS launch/rotation lag.
- **COIN RAIN no longer wasted in bonus rooms** (#240): the timer ticked underground while the coin spawner was gated off — a grotto-granted rain could burn out entirely before you surfaced. The countdown now pauses while `inBonus`.
- **Music validation surfaces in prod** (#239): miscounted bars now `console.error` at boot instead of hiding in the debug hook.

## Cleanups
- Warp-pipe hit-test deduplicated into `warpUnderfoot()` — the swipe-entry and slam-entry copies had already drifted (5px vs 6px tolerance), exactly the trap the #242 review predicted.
- Dead `inWaterAt()` helper removed (#246), vestigial bare `{}` block from the pow-entity removal un-nested (#240).

## Already fixed before reading the reviews (for the record)
- The #240 review caught the **giga hitbox/visual mismatch before the playtest report** that led to #242 — reading it would have saved a round trip.
- Drum-length validation dedup, dead `exitCapY`, grotto palette choice: fixed or confirmed-intentional in later PRs.

Verified: slam pipe entry round trip via the shared helper, rain freezing in bonus and resuming outside, offline reload still served from SW cache, 15k-frame soak with zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fcibXj5NnHHSGBiSh51Et