### PR TITLE
Pixel Run v13: extend canvas to the physical screen (bottom bar, round 2)

### DIFF
--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -60,7 +60,7 @@ const MAX_SPEED = 3.05;
 const PIT_Y = 11 * TILE;             // below this = pit death
 const WORLD_LEN = 500;               // tiles per world before the flag
 const SAVE = 'pixelrun_';
-const VERSION = 12;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
+const VERSION = 13;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
 
 // ---------- utils ----------
 const clamp = (v, a, b) => v < a ? a : v > b ? b : v;
@@ -96,12 +96,22 @@ let W = 240, H = 420, SCALE = 2;
 let lastSize = '';
 function resize() {
   const dpr = window.devicePixelRatio || 1;
-  // CSS (fixed, inset:0, 100dvh) owns the canvas ELEMENT size; measure it and any
-  // viewport report, take the largest — iOS standalone lags these at launch/rotation
+  // measure the element and every viewport report, take the largest —
+  // iOS standalone lags these at launch/rotation
   const vv = window.visualViewport;
   const rect = canvas.getBoundingClientRect();
-  const cw = Math.round(Math.max(window.innerWidth, vv ? vv.width : 0, rect.width));
-  const chh = Math.round(Math.max(window.innerHeight, vv ? vv.height : 0, rect.height));
+  let cw = Math.round(Math.max(window.innerWidth, vv ? vv.width : 0, rect.width));
+  let chh = Math.round(Math.max(window.innerHeight, vv ? vv.height : 0, rect.height));
+  // Some iOS versions size the standalone layout viewport SHORT of the home
+  // indicator, so 100dvh / inset:0 / innerHeight all agree on a height that ends
+  // above the screen bottom (the bar). The physical screen doesn't lie: extend the
+  // canvas to it — fixed elements paint into the inset zone under viewport-fit=cover,
+  // and the inset math below then measures the home-indicator gap naturally.
+  if (navigator.standalone && screen && screen.width) {
+    const sMin = Math.min(screen.width, screen.height), sMax = Math.max(screen.width, screen.height);
+    if (chh >= cw) { cw = Math.max(cw, sMin); chh = Math.max(chh, sMax); }
+    else { cw = Math.max(cw, sMax); chh = Math.max(chh, sMin); }
+  }
   // insets are cheap — refresh them on EVERY call. env() resolves late on iOS,
   // and if the first size measurement is already correct no further resize fires,
   // so gating this behind the size guard left safeTop stuck at 0 (HUD under the clock)
@@ -116,6 +126,7 @@ function resize() {
   W = Math.ceil(cw * dpr / SCALE);
   H = Math.ceil(chh * dpr / SCALE);
   canvas.width = W; canvas.height = H;
+  canvas.style.width = cw + 'px'; canvas.style.height = chh + 'px';   // JS wins over the CSS fallback
   ctx.imageSmoothingEnabled = false;
   readInsets(cw, chh);          // again with the fresh SCALE
 }

--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -17,9 +17,10 @@
   html, body { height:100%; width:100%; overflow:hidden; background:#63b9ff; overscroll-behavior:none; }
   body { touch-action:none; -webkit-user-select:none; user-select:none; }
   #game {
-    /* fixed + inset:0 keeps the canvas glued to the FULL viewport even when iOS
-       reports a stale height at launch — CSS owns the element size, JS only sizes
-       the pixel buffer. dvh fallback chain covers older WebKit. */
+    /* In-browser: CSS owns the element size (fixed + dvh tracks the viewport
+       fluidly). In STANDALONE mode resize() overrides with inline styles sized to
+       the physical screen, because iOS's standalone layout viewport can end above
+       the home indicator and no CSS unit can reach past it. */
     position:fixed; inset:0;
     width:100vw; height:100vh; height:100dvh;
     touch-action:none;
@@ -126,7 +127,9 @@ function resize() {
   W = Math.ceil(cw * dpr / SCALE);
   H = Math.ceil(chh * dpr / SCALE);
   canvas.width = W; canvas.height = H;
-  canvas.style.width = cw + 'px'; canvas.style.height = chh + 'px';   // JS wins over the CSS fallback
+  if (navigator.standalone) {   // only standalone needs the physical-screen override;
+    canvas.style.width = cw + 'px'; canvas.style.height = chh + 'px';
+  }                             // in-browser the CSS dvh keeps tracking the viewport fluidly
   ctx.imageSmoothingEnabled = false;
   readInsets(cw, chh);          // again with the fresh SCALE
 }

--- a/apps/pixelrun/sw.js
+++ b/apps/pixelrun/sw.js
@@ -2,7 +2,7 @@
 // shell makes it fully playable offline. Strategy is stale-while-revalidate —
 // instant load from cache, silently refreshed from the network for next launch.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'pixelrun-v7';
+const CACHE = 'pixelrun-v8';
 const SHELL = ['./', './index.html', './icon.png', './apple-touch-icon.png'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
V12 on-device proved the bottom bar survives the CSS approach: on this iOS version, the **standalone layout viewport simply ends above the home indicator** — `100dvh`, `inset:0`, `innerHeight`, `visualViewport`, and the element rect all report the same short height, so no CSS unit or measurement loop can reach the screen bottom.

`screen.width/height` report the physical screen and don't lie. In standalone mode the canvas is now sized to the physical screen (orientation-mapped, max of screen and all viewport reports) via explicit JS sizing that overrides the CSS fallback. Fixed-position elements paint into the inset zone under `viewport-fit=cover`, so the dirt texture reaches the true bottom edge. The safe-area probe math handles the rest with no special cases: `extended height − probe bottom` = exactly the home-indicator gap, so buttons and title text stay clear of it.

Verified by simulating the failure headlessly (standalone + mocked screen taller than every viewport report): canvas extends past the viewport, pixel buffer matches (no stretch), bottom inset covers the extension, zero errors, top-inset floors from #249 untouched. Degradation path if some WebKit clips fixed elements at the short viewport: the strip falls back to the sky-tinted body — dim, not bright blue.

**VERSION 13** on the title screen, SW cache → v8. On device: relaunch twice, confirm V13, then check the bottom edge in a bright world (Green Hills makes the bar most visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fcibXj5NnHHSGBiSh51Et