### PR TITLE
Pixel Run v15: sky-colored status strip on Android

### DIFF
--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-<meta name="theme-color" content="#0b1030">
+<meta name="theme-color" content="#63b9ff">
 <link rel="manifest" href="manifest.webmanifest">
 <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
 <link rel="apple-touch-icon" href="apple-touch-icon.png">
@@ -68,7 +68,7 @@ const MAX_SPEED = 3.05;
 const PIT_Y = 11 * TILE;             // below this = pit death
 const WORLD_LEN = 500;               // tiles per world before the flag
 const SAVE = 'pixelrun_';
-const VERSION = 14;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
+const VERSION = 15;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
 
 // ---------- utils ----------
 const clamp = (v, a, b) => v < a ? a : v > b ? b : v;
@@ -174,9 +174,13 @@ resize();
 function tintPage() {
   // camouflage any strip the canvas can't reach: html gets the sky (top/side
   // strips), body gets the DIRT color — an exposed strip sits at the BOTTOM of
-  // the screen, where the game is showing ground, so dirt blends and sky glares
+  // the screen, where the game is showing ground, so dirt blends and sky glares.
+  // Android standalone can't draw under the status-bar/camera strip at all —
+  // Chrome live-updates it from the theme-color meta, so tint that to the sky too
   document.documentElement.style.background = THEMES[game.themeIdx].skyTop;
   document.body.style.background = THEMES[game.themeIdx].dirt;
+  const tc = document.querySelector('meta[name="theme-color"]');
+  if (tc) tc.content = THEMES[game.themeIdx].skyTop;
 }
 
 // ---------- 3x5 bitmap font ----------

--- a/apps/pixelrun/manifest.webmanifest
+++ b/apps/pixelrun/manifest.webmanifest
@@ -8,7 +8,7 @@
   "display_override": ["fullscreen", "standalone"],
   "orientation": "portrait",
   "background_color": "#63b9ff",
-  "theme_color": "#0b1030",
+  "theme_color": "#63b9ff",
   "icons": [
     { "src": "icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any maskable" },
     { "src": "icon.png", "sizes": "512x512", "type": "image/png", "purpose": "any maskable" }

--- a/apps/pixelrun/sw.js
+++ b/apps/pixelrun/sw.js
@@ -2,7 +2,7 @@
 // shell makes it fully playable offline. Strategy is stale-while-revalidate —
 // instant load from cache, silently refreshed from the network for next launch.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'pixelrun-v9';
+const CACHE = 'pixelrun-v10';
 const SHELL = ['./', './index.html', './icon.png', './apple-touch-icon.png', './icon-192.png', './manifest.webmanifest'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
From OnePlus 15 testing: the installed app stops below the camera cutout. That strip is Android's standalone status bar — unlike iOS, web content genuinely cannot draw under it in standalone display mode. The platform convention is to **color** it: Chrome live-updates the status bar from the `theme-color` meta tag.

- `tintPage()` now syncs `<meta name="theme-color">` to the current world's sky on every world change — Green Hills blue, Dunes sunset, Caves navy, etc. The strip becomes a seamless continuation of the game's sky, camera hole floating in it like the sun.
- Static meta + manifest `theme_color` changed from dark navy to hills sky so the first paint and the WebAPK splash already match.

Verified headless: the meta updates live per theme (checked against `THEMES[n].skyTop`), zero errors. VERSION **15**, SW cache **v10**.

(If OnePlus honored the `display_override: fullscreen` there'd be no strip at all — the fact that a status bar shows means it fell back to standalone, which is common; the color sync makes it look right either way.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fcibXj5NnHHSGBiSh51Et