### PR TITLE
Pixel Run v18: FROST PEAKS + HAUNTED HOLLOW — eight worlds, Magma Keep final

### DIFF
--- a/apps/pixelrun/CLAUDE.md
+++ b/apps/pixelrun/CLAUDE.md
@@ -27,5 +27,5 @@ caches + unregister the SW and reload once before evaluating a fresh edit.
 Physics and generator constants are coupled — the derivation comments at the
 constants block (`JUMP_V`/`GRAV`) list which pattern heights, gap widths, and
 enemy-train spacings must move together. Song data is arrays of 16-step bars
-validated at boot; keep new bars exactly 16 steps. Theme indices are
-load-bearing (water=3, sky=4, castle=5) across parallax, songs, and palettes.
+validated at boot; keep new bars exactly 16 steps. Theme indices are load-bearing across parallax, songs, and palettes:
+water=3, sky=4, frost=5, haunt=6, castle=7 (8 worlds total, magma final).

--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -2091,7 +2091,7 @@ function startRun() {
   for (let i = 0; i < 24; i++) C(0);             // opening runway
   player.x = 40; player.y = -player.h; player.vy = 0;
   player.onGround = true; player.coyote = 0; player.dj = true; player.slam = false;
-  player.mode = 'run'; player.runT = 0; player.inWater = false;
+  player.mode = 'run'; player.runT = 0; player.inWater = false; player.icyAir = false;
   cam.x = player.x - camOffX(); cam.y = camBaseY();
   announce('WORLD 1  ' + THEMES[0].name, 120);
   playSong('hills');

--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -2813,8 +2813,8 @@ function updateEnts() {
         burst(e.x + 8, e.y + 8, '#fff', 6, 1.4, 0.08);
         sfx.pop();
         e.pieces = null; e.reviveGrace = 22; e.t = 0;
-      } else if (player.slam && overlap(prect(), erect(e))) {
-        killEnemy(e, 150); sfx.brick();   // slamming the pile scatters it for good
+      } else if ((player.slam || game.star > 0 || game.giga > 0) && overlap(prect(), erect(e))) {
+        killEnemy(e, 150); sfx.brick();   // slam, star, or giga scatters the pile for good
       }
       continue;
     }

--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -68,7 +68,7 @@ const MAX_SPEED = 3.05;
 const PIT_Y = 11 * TILE;             // below this = pit death
 const WORLD_LEN = 500;               // tiles per world before the flag
 const SAVE = 'pixelrun_';
-const VERSION = 17;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
+const VERSION = 18;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
 
 // ---------- utils ----------
 const clamp = (v, a, b) => v < a ? a : v > b ? b : v;
@@ -927,6 +927,20 @@ const THEMES = [
     brick:'#e0b464', brickDk:'#ac7c3c', pipe:'#54b8e8', pipeDk:'#2c7fb0',
     plat:'#f0f4fc', platDk:'#b4c0d8',
     particle:'cloud', enemies:['bat','chomp','rollo'], deco:'flower' },
+  { name:'FROST PEAKS',
+    skyTop:'#9cc8e8', skyBot:'#eef8ff', sun:'#fffef0',
+    far:'#c8dcf0', far2:'#aac2e0', near:'#2c4a3c',
+    grass:'#f0f6ff', grassHi:'#ffffff', dirt:'#7a90b8', dirtDk:'#5c6f94',
+    brick:'#a8c4e0', brickDk:'#7490b4', pipe:'#4c9ce0', pipeDk:'#2c6ca8',
+    plat:'#cfe2f2', platDk:'#9cb4cc',
+    particle:'snow', enemies:['chomp','rollo','bat'], deco:'pine' },
+  { name:'HAUNTED HOLLOW',
+    skyTop:'#12081e', skyBot:'#2e1a42', sun:'#cabbe8',
+    far:'#241238', far2:'#1a0c2c', near:'#38204e',
+    grass:'#7a68a0', grassHi:'#a292c4', dirt:'#3c2c54', dirtDk:'#281c3c',
+    brick:'#54406c', brickDk:'#3a2c4e', pipe:'#7a5898', pipeDk:'#553a70',
+    plat:'#645080', platDk:'#463858',
+    particle:'fog', enemies:['wisp','bat','chomp'], deco:'grave' },
   { name:'MAGMA KEEP',
     skyTop:'#1c0f22', skyBot:'#54182c', sun:'#ff6a3c',
     far:'#3a1830', far2:'#2a1024', near:'#54223c',
@@ -1040,7 +1054,7 @@ function makeParallax(theme, idx) {
       const h = 80 + r2() * 70;
       c.beginPath(); c.moveTo(x, 0); c.lineTo(x + 10, h); c.lineTo(x + 20, 0); c.fill();
     }
-  } else if (idx === 5) { // castle: battlements + windows
+  } else if (idx === 7) { // castle: battlements + windows
     c.fillStyle = theme.far;
     c.fillRect(0, 90, 512, 130);
     for (let x = 0; x < 512; x += 16) if ((x / 16) % 2 === 0) c.fillRect(x, 78, 16, 12);
@@ -1048,6 +1062,33 @@ function makeParallax(theme, idx) {
     for (let x = 20; x < 512; x += 56) { c.fillRect(x, 110, 10, 22); c.fillRect(x + 2, 106, 6, 4); }
     c.fillStyle = '#ffb45c';
     for (let x = 20; x < 512; x += 112) c.fillRect(x + 3, 116, 4, 8);
+  } else if (idx === 5) { // frost: jagged snowy summits
+    c.fillStyle = theme.far;
+    for (let x = -30; x < 512; x += 88) {
+      const h = 90 + r2() * 70;
+      c.beginPath(); c.moveTo(x, 220); c.lineTo(x + 44, 220 - h); c.lineTo(x + 88, 220); c.fill();
+      c.fillStyle = '#ffffff';
+      c.beginPath(); c.moveTo(x + 30, 220 - h + h * 0.32); c.lineTo(x + 44, 220 - h); c.lineTo(x + 58, 220 - h + h * 0.32); c.fill();
+      c.fillStyle = theme.far;
+    }
+    c.fillStyle = theme.far2;
+    for (let x = 20; x < 512; x += 120) {
+      const h = 50 + r2() * 40;
+      c.beginPath(); c.moveTo(x, 220); c.lineTo(x + 34, 220 - h); c.lineTo(x + 68, 220); c.fill();
+    }
+  } else if (idx === 6) { // haunted hollow: dead hills and bare trees
+    c.fillStyle = theme.far;
+    for (let x = -40, i = 0; x < 512; x += 96, i++) {
+      const h = 40 + r2() * 40;
+      c.beginPath(); c.moveTo(x, 220); c.quadraticCurveTo(x + 48, 220 - h * 2, x + 96, 220); c.fill();
+    }
+    c.fillStyle = theme.far2;
+    for (let x = 30; x < 512; x += 110) {
+      const th2 = 40 + r2() * 26;
+      c.fillRect(x, 220 - th2 - 60, 3, th2 + 60);
+      c.fillRect(x - 8, 220 - th2 - 52, 10, 2); c.fillRect(x + 2, 220 - th2 - 40, 12, 2);
+      c.fillRect(x - 6, 220 - th2 - 28, 8, 2);
+    }
   } else if (idx === 4) { // sky: distant cloud banks
     c.fillStyle = theme.far;
     for (let x = 0; x < 512; x += 90) {
@@ -1091,7 +1132,7 @@ function makeParallax(theme, idx) {
       const y = 60 + r2() * 50, w2 = 40 + r2() * 30;
       c.fillRect(x, y, w2, 10); c.fillRect(x + 6, y - 6, w2 - 12, 6);
     }
-  } else if (idx === 5) {
+  } else if (idx === 7) {
     c.fillStyle = theme.near;
     for (let x = 0; x < 512; x += 34) {
       const h = 30 + r2() * 60;
@@ -1100,6 +1141,30 @@ function makeParallax(theme, idx) {
     }
     c.fillStyle = '#ff6a3c';
     for (let x = 10; x < 512; x += 68) c.fillRect(x, 132, 3, 8);
+  } else if (idx === 5) { // frost: pine treeline
+    for (let x = 4; x < 512; x += 44) {
+      const h = 46 + r2() * 34;
+      c.fillStyle = '#6a4a2e';
+      c.fillRect(x + 9, 140 - 10, 4, 10);
+      c.fillStyle = theme.near;
+      for (let l = 0; l < 3; l++) {
+        const lw = 22 - l * 6, ly = 140 - 10 - (h / 3) * (l + 1);
+        c.beginPath(); c.moveTo(x + 11 - lw / 2, ly + h / 3); c.lineTo(x + 11, ly); c.lineTo(x + 11 + lw / 2, ly + h / 3); c.fill();
+      }
+      c.fillStyle = 'rgba(255,255,255,0.75)';
+      c.fillRect(x + 5, 140 - 10 - h + 4, 12, 2);
+    }
+  } else if (idx === 6) { // hollow: gravestones and twisted trees
+    c.fillStyle = theme.near;
+    for (let x = -20; x < 512; x += 64) {
+      const h = 26 + r2() * 30;
+      c.beginPath(); c.moveTo(x, 140); c.quadraticCurveTo(x + 32, 140 - h * 2, x + 64, 140); c.fill();
+    }
+    for (let x = 16; x < 512; x += 78) {
+      c.fillStyle = '#4a3862';
+      c.fillRect(x, 116, 10, 24); c.fillRect(x + 2, 112, 6, 4);
+      if (r2() < 0.4) { c.fillStyle = '#ffe27a'; c.fillRect(x + 4, 122, 2, 3); }
+    }
   } else if (idx === 3) { // tidal cove: dune grass and beach palms
     c.fillStyle = theme.near;
     for (let x = -20; x < 512; x += 60) {
@@ -1351,6 +1416,57 @@ const SONGS = {};
     [t1, t2, t3, t4, t5, t6, t7, t8, t1, t2, t3, t4, t1, t2, t3, t4],
     [u1, u2, u3, u4, u5, u6, u7, u8, u1, u2, u3, u4, u1, u2, u3, u4],
     dr + dr + dr + 'k..h..s.h.ks.sks');
+}
+
+{ // FROST PEAKS — E-minor music box over a snowfield, crystalline plucks
+  const f1 = 'e5:1 g5:1 b5:2 e5:1 g5:1 b5:2 e5:1 g5:1 b5:2 g5:2 e5:2',
+        f2 = 'c5:1 e5:1 g5:2 c5:1 e5:1 g5:2 c5:1 e5:1 a5:2 g5:2 e5:2',
+        f3 = 'd5:1 f#5:1 a5:2 d5:1 f#5:1 a5:2 d5:1 f#5:1 b5:2 a5:2 f#5:2',
+        f4 = 'b4:2 d5:2 g5:2 f#5:2 e5:4 b4:2 e5:2',
+        f5 = 'g5:6 f#5:2 e5:4 b4:4',
+        f6 = 'a5:6 g5:2 f#5:8',
+        f7 = 'g5:4 b5:4 a5:4 g5:2 f#5:2',
+        f8 = 'e5:12 r:4',
+        f13 = 'b5:2 a5:2 g5:2 f#5:2 e5:2 f#5:2 g5:2 a5:2',
+        f14 = 'b5:4 g5:4 e5:4 g5:4',
+        f15 = 'a5:2 g5:2 f#5:2 e5:2 d5:2 e5:2 f#5:2 d5:2',
+        f16 = 'e5:2 b4:2 g4:2 b4:2 e5:8';
+  const pEm = 'r:4 b3:12', pC = 'r:4 c4:12', pD = 'r:4 a3:12', pG = 'r:4 g3:12';
+  const bEm = 'e2:4 b2:4 e3:4 b2:4', bC = 'c3:4 g2:4 c3:4 g2:4',
+        bD = 'd3:4 a2:4 d3:4 a2:4', bG = 'g2:4 d3:4 g3:4 d3:4',
+        bEnd = 'e2:4 b2:4 e2:8';
+  const dfr = 'k...h...s...h...';
+  SONGS.frost = song(132, { echo: 0.28 },
+    [f1, f2, f3, f4, f5, f6, f7, f8, f1, f2, f3, f4, f13, f14, f15, f16],
+    [pEm, pC, pD, pEm, pG, pD, pG, pEm, pEm, pC, pD, pEm, pG, pEm, pD, pEm],
+    [bEm, bC, bD, bEm, bG, bD, bG, bEm, bEm, bC, bD, bEm, bG, bEm, bD, bEnd],
+    [dfr, dfr, dfr, 'k...h...s..h.h.h', dfr, dfr, dfr, 'k...h...s..h.h.h',
+     dfr, dfr, dfr, 'k...h...s..h.h.h', dfr, dfr, dfr, 'k...h...ss.s.s.s']);
+}
+
+{ // HAUNTED HOLLOW — a creeping D-minor heartbeat with chromatic sighs
+  const g1 = 'd4:4 r:2 e4:2 f4:4 e4:2 d4:2',
+        g2 = 'c#4:4 r:2 d4:2 e4:4 d4:2 c#4:2',
+        g3 = 'd4:4 f4:4 g#4:4 g4:2 f4:2',
+        g4 = 'e4:2 f4:2 e4:2 c#4:2 d4:8',
+        g5 = 'a5:6 g#5:2 a5:4 f5:4',
+        g6 = 'g5:6 f5:2 e5:8',
+        g7 = 'f5:4 g#5:4 g5:4 e5:2 c#5:2',
+        g8 = 'd5:12 r:4',
+        g13 = 'd5:2 c#5:2 d5:2 f5:2 e5:2 d5:2 c#5:2 a4:2',
+        g14 = 'a#4:4 a4:4 g#4:4 a4:4',
+        g15 = 'd5:2 f5:2 g#5:2 g5:2 f5:2 e5:2 d5:2 c#5:2',
+        g16 = 'd4:2 a4:2 f4:2 e4:2 d4:8';
+  const hD = 'r:4 d3:12', hCs = 'r:4 c#3:12', hF = 'r:4 f3:12', hA = 'r:4 a3:12';
+  const wD = 'd2:8 a2:8', wCs = 'c#2:8 g#2:8', wF = 'd2:8 f2:8', wA = 'a2:8 d2:8',
+        wEnd = 'd2:16';
+  const dh = 'k......k........';
+  SONGS.haunt = song(96, { echo: 0.4 },
+    [g1, g2, g3, g4, g5, g6, g7, g8, g1, g2, g3, g4, g13, g14, g15, g16],
+    [hD, hCs, hF, hD, hA, hD, hF, hD, hD, hCs, hF, hD, hD, hA, hF, hD],
+    [wD, wCs, wF, wD, wA, wD, wF, wD, wD, wCs, wF, wD, wD, wA, wF, wEnd],
+    [dh, dh, dh, 'k......k....s...', dh, dh, dh, 'k......k....s...',
+     dh, dh, dh, 'k......k....s...', dh, dh, dh, 'k......k..s..s..']);
 }
 
 { // MAGMA KEEP — C-minor riff machine; B section climbs through Fm to G
@@ -1633,7 +1749,7 @@ const player = {
   onGround: false, coyote: 0, dj: true, slam: false,
   runT: 0, mode: 'run', bubbleT: 0, stompT: 0,
   flipT: 0, landT: 0, stretchT: 0, spinA: 0,   // juice: front-flip / squash / stretch / slam spin
-  pipeT: 0, inWater: false
+  pipeT: 0, inWater: false, icyAir: false
 };
 const cam = { x: 0, y: 0 };
 const gen = { x: 0, g: 0, nextFlag: WORLD_LEN, sinceEnemy: 0, sinceCoin: 0, totalTiles: 0 };
@@ -1700,7 +1816,7 @@ function spawnEnemy(type, tx, g) {
   else if (type === 'spiny') { e.vx = -0.3; e.h = 13; e.oy = 3; }
   else if (type === 'bat') {
     e.y = top - 16 - RI(28, 60); e.y0 = e.y; e.vx = -0.55; e.h = 9; e.oy = 2;
-    if (genThemeIdx() === 2) {   // cave bats roost way up high and wake with a swoop
+    if (genThemeIdx() === 2 || genThemeIdx() === 6) {   // cave/hollow bats roost high and wake with a swoop
       e.cruiseY = e.y0;
       e.y0 -= RI(70, 110); e.y = e.y0;
       e.sleep = 1;
@@ -1717,7 +1833,12 @@ function maybeEnemy(tx, g, d) {
   if (rng() < 0.6) {
     let type = pick(theme.enemies);
     if (type === 'snap') type = 'chomp';                      // snappers only live in pipes
-    if (type === 'wisp' && (d < 0.5 || ents.some(e => e.type === 'wisp'))) type = 'chomp';
+    if (type === 'wisp') {
+      // wisps headline HAUNTED HOLLOW: two at once, no difficulty gate there
+      const cap = genThemeIdx() === 6 ? 2 : 1;
+      const n = ents.filter(e => e.type === 'wisp' && !e.dead).length;
+      if ((genThemeIdx() !== 6 && d < 0.5) || n >= cap) type = 'chomp';
+    }
     spawnEnemy(type, tx, g);
     // trains of stompable critters spaced one bounce-arc apart: combo bait
     if (STOMPABLE.has(type) && d > 0.15 && rng() < 0.55) {
@@ -1994,7 +2115,7 @@ function addScore(n, x, y, label) {
 }
 
 // ---------- update ----------
-const THEME_SONGS = ['hills', 'dunes', 'caves', 'tide', 'sky', 'keep'];
+const THEME_SONGS = ['hills', 'dunes', 'caves', 'tide', 'sky', 'frost', 'haunt', 'keep'];
 const HOSTILE = new Set(['chomp', 'rollo', 'spiny', 'bat', 'snap', 'wisp', 'finn', 'puffer']);
 const STOMPABLE = new Set(['chomp', 'rollo', 'bat']);
 function genThemeIdx() { return Math.floor(Math.max(0, gen.x) / WORLD_LEN) % THEMES.length; }
@@ -2128,7 +2249,14 @@ function updatePlayer() {
   }
 
   // --- horizontal ---
-  const sp = game.speed * (player.slam ? 0.4 : player.inWater ? 0.72 : 1);
+  // FROST PEAKS: ice is slick — you run faster on it and carry that momentum
+  // through the air, so every jump overshoots a touch. Skid crystals sell it.
+  if (player.onGround) player.icyAir = game.themeIdx === 5;
+  const icy = game.themeIdx === 5 && (player.onGround || player.icyAir);
+  if (icy && player.onGround && game.frame % 6 === 0)
+    parts.push({ x: player.x - 1, y: player.y + player.h - 1, vx: R(-1, -0.5), vy: R(-0.3, 0),
+      life: RI(8, 16), color: '#dff0ff', size: 1, grav: 0.01 });
+  const sp = game.speed * (player.slam ? 0.4 : player.inWater ? 0.72 : 1) * (icy ? 1.12 : 1);
   player.x += sp;
   const rtx = Math.floor((player.x + player.w) / TILE);
   if (game.giga > 0) {   // giga plows straight through brickwork
@@ -2371,12 +2499,13 @@ function enterPipe(w) {
 const SPECIALS = ['star', 'wings', 'giga', 'moon', 'rain', 'wonder'];
 function startBonus() {
   // one hand-built design per world, each with its own palette and reward shape
-  const layout = (game.worldNum - 1) % 6;
+  const layout = (game.worldNum - 1) % 8;
   const b = BONUS_TX;
-  const LEN = [40, 40, 42, 42, 44, 42][layout];
-  const CEIL = [-7, -9, -8, -7, -11, -8][layout];
-  const PALETTE = [2, 5, 1, 2, 4, 5][layout];
-  const NAMES = ['OLD CELLAR!', 'PYRAMID VAULT!', 'GILDED HALL!', 'SUNKEN GROTTO!', 'CLOUD VAULT!', 'SPIKE VAULT!'];
+  const LEN = [40, 40, 42, 42, 44, 42, 42, 42][layout];
+  const CEIL = [-7, -9, -8, -7, -11, -8, -8, -8][layout];
+  const PALETTE = [2, 7, 1, 2, 4, 5, 6, 7][layout];
+  const NAMES = ['OLD CELLAR!', 'PYRAMID VAULT!', 'GILDED HALL!', 'SUNKEN GROTTO!',
+    'CLOUD VAULT!', 'GLACIER VAULT!', 'CRYPT VAULT!', 'SPIKE VAULT!'];
   // sealed box: floor, walls both ends, ceiling all the way across
   for (let i = 0; i < LEN; i++) ground.set(b + i, 0);
   for (let ty = -1; ty >= CEIL + 1; ty--) { put(b + 1, ty, T_STONE); put(b + LEN - 2, ty, T_STONE); }
@@ -2431,6 +2560,24 @@ function startBonus() {
     coinRow(b + 23, -6, 3);
     coinRow(b + 28, -4, 3);
     coinRow(b + 5, -1, 4);
+  } else if (layout === 5) {   // GLACIER VAULT — a slick sprint between ice shelves
+    for (let i = 9; i <= 14; i++) put(b + i, -4, T_PLAT);
+    for (let i = 21; i <= 26; i++) put(b + i, -5, T_PLAT);
+    qblock(b + 6, -4, 'heart');
+    qblock(b + 31, -4, pick(SPECIALS));
+    coinRow(b + 5, -1, 12);      // ice speed makes this a satisfying zoom
+    coinRow(b + 9, -5, 6);
+    coinRow(b + 21, -6, 6);
+    coinRow(b + 20, -1, 10);
+  } else if (layout === 6) {   // CRYPT VAULT — treasure in the dark (vignette active)
+    for (const m of [11, 20, 29]) { put(b + m, -1, T_STONE); put(b + m, -2, T_STONE); }
+    qblock(b + 8, -4, 'heart');
+    qblock(b + 16, -5, 'heart');           // the dark is generous to the brave
+    qblock(b + 25, -4, pick(SPECIALS));
+    coinRow(b + 5, -1, 5);
+    coinRow(b + 13, -4, 6);
+    coinRow(b + 22, -5, 6);
+    coinRow(b + 31, -1, 5);
   } else {                     // SPIKE VAULT — risk it for double treasure
     for (const s of [10, 11, 12, 13, 22, 23, 24, 25]) put(b + s, -1, T_SPIKE);
     for (let i = 10; i <= 13; i++) put(b + i, -4, T_PLAT);
@@ -2839,6 +2986,8 @@ function ambient() {
   }
   else if (th.particle === 'foam') { if (rng() < 0.5) parts.push({ x, y: yTop, vx: R(-0.5, -0.1), vy: R(0.2, 0.5), life: 180, color: 'rgba(255,255,255,0.6)', size: 1, grav: 0, sway: 1 }); }
   else if (th.particle === 'ember') parts.push({ x, y: cam.y + H + 5, vx: R(-0.4, 0.2), vy: R(-1.1, -0.5), life: 140, color: pick(['#ff6a3c', '#ffb45c']), size: rng() < 0.4 ? 2 : 1, grav: -0.004 });
+  else if (th.particle === 'snow') parts.push({ x, y: yTop, vx: R(-0.6, -0.1), vy: R(0.4, 0.9), life: 240, color: rng() < 0.3 ? '#ffffff' : '#e4f2ff', size: rng() < 0.25 ? 2 : 1, grav: 0, sway: 1 });
+  else if (th.particle === 'fog') { if (rng() < 0.6) parts.push({ x: cam.x + W + 10, y: cam.y + H * R(0.45, 0.9), vx: R(-0.5, -0.2), vy: R(-0.05, 0.05), life: 320, color: 'rgba(170,150,200,0.22)', size: 3, grav: 0 }); }
 }
 
 // ---------- UI / state entry ----------
@@ -2907,7 +3056,7 @@ function drawSkyAndParallax(camX, camY) {
   ctx.fillRect(sunX - 8, sunY - 8, 16, 16);
   ctx.fillRect(sunX - 10, sunY - 5, 20, 10); ctx.fillRect(sunX - 5, sunY - 10, 10, 20);
   // high-altitude dressing: stars in the dark worlds, drifting clouds elsewhere
-  if (game.themeIdx === 2 || game.themeIdx === 5) {
+  if (game.themeIdx === 2 || game.themeIdx === 6 || game.themeIdx === 7) {
     ctx.fillStyle = 'rgba(255,255,255,0.7)';
     for (let i = 0; i < 26; i++) {
       let xi = ((i * 199 + 31) - camX * 0.04) % (W + 20);
@@ -3427,6 +3576,15 @@ function renderWorld() {
     ctx.globalAlpha = Math.min(1, f.life / 14);
     drawTextC(ctx, f.txt, Math.round(f.x - camX + 6), Math.round(f.y - camY), 1, f.color, '#1a1c2c');
     ctx.globalAlpha = 1;
+  }
+  if (game.themeIdx === 6) {   // HAUNTED HOLLOW: darkness closes in, light follows you
+    const px2 = Math.round(player.x + 5 - camX), py2 = Math.round(player.y + 8 - camY);
+    const g3 = ctx.createRadialGradient(px2, py2, 34, px2, py2, Math.max(W, H) * 0.55);
+    g3.addColorStop(0, 'rgba(8,4,16,0)');
+    g3.addColorStop(0.45, 'rgba(8,4,16,0.12)');
+    g3.addColorStop(1, 'rgba(8,4,16,0.6)');
+    ctx.fillStyle = g3;
+    ctx.fillRect(0, 0, W, H);
   }
   drawHUD();
 }

--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -1731,6 +1731,7 @@ const sfx = {
   slam()   { if (audio.ctx) { noise(audio.sgain, audio.ctx.currentTime, 0.16, 0.22, 200); sq(90, 0.16, 0.14, 40); } },
   pop()    { sq(880, 0.05, 0.08, 1400); },
   pipe()   { sq(340, 0.32, 0.13, 90); sqAt(240, 0.1, 0.26, 0.10, 70); },
+  rattle() { if (audio.ctx) for (let i = 0; i < 3; i++) noise(audio.sgain, audio.ctx.currentTime + i * 0.05, 0.03, 0.09, 2400); },
   splash() { if (audio.ctx) { noise(audio.sgain, audio.ctx.currentTime, 0.22, 0.16, 900); sq(180, 0.12, 0.07, 90); } },
   swim()   { sq(300, 0.07, 0.05, 420); },
   combo(n) { sq(523 * Math.pow(1.122, Math.min(n, 12)), 0.09, 0.10); }
@@ -1746,6 +1747,7 @@ canvas.addEventListener('pointerdown', e => {
   input.pid = e.pointerId;
   try { canvas.setPointerCapture(e.pointerId); } catch (err) {}
   input.py = e.clientY; input.pt = performance.now();
+  input.kx = e.clientX; input.ky = e.clientY;
   onPress(e.clientX, e.clientY);
 });
 canvas.addEventListener('pointermove', e => {
@@ -1760,11 +1762,21 @@ function endPointer(e) {
   if (e.pointerId !== input.pid) return;
   input.pid = -1;
   releaseJump();
+  if (game.state === 'title' && e.type === 'pointerup') {
+    // title acts on release: taps start / hit buttons, swipes feed the secret code
+    const dx = e.clientX - input.kx, dy = e.clientY - input.ky;
+    if (Math.abs(dx) < 16 && Math.abs(dy) < 16) titleRelease(mkHit(e.clientX, e.clientY));
+    else konamiPush(Math.abs(dx) > Math.abs(dy) ? (dx > 0 ? 'R' : 'L') : (dy > 0 ? 'D' : 'U'));
+  }
 }
 canvas.addEventListener('pointerup', endPointer);
 canvas.addEventListener('pointercancel', endPointer);
 window.addEventListener('keydown', e => {
   if (e.repeat) return;
+  if (game.state === 'title') {
+    const km = { ArrowUp: 'U', ArrowDown: 'D', ArrowLeft: 'L', ArrowRight: 'R', KeyB: 'B', KeyA: 'A' };
+    if (km[e.code]) { konamiPush(km[e.code]); return; }   // arrows feed the code, not the run
+  }
   if (e.code === 'Space' || e.code === 'ArrowUp' || e.code === 'KeyW') { onPress(-1, -1); }
   if (e.code === 'ArrowDown' || e.code === 'KeyS') input.slamReq = true;
   if (e.code === 'KeyM') setMuted(!audio.muted);
@@ -1819,6 +1831,15 @@ function tileAt(tx, ty) {
 function solidAt(tx, ty) { return SOLID.has(tileAt(tx, ty)); }
 function groundTopPx(tx) { const g = ground.get(tx); return g === undefined ? Infinity : -g * TILE; }
 function waterSurfaceAt(px) { return water.get(Math.floor(px / TILE)); }
+function makeBonePieces(e) {
+  // skull pops, ribcage hops, legs crumple — sliced live from the sprite sheet
+  const floorY = e.y + 16;
+  return [
+    { sx: 2, sy: 0, sw: 12, sh: 7, ox: 2, oy: 0, vy: -2.6 },
+    { sx: 3, sy: 8, sw: 10, sh: 4, ox: 3, oy: 8, vy: -1.2 },
+    { sx: 3, sy: 12, sw: 10, sh: 4, ox: 3, oy: 12, vy: -0.4 }
+  ].map(d => ({ ...d, x: e.x + d.ox, y: e.y + d.oy, vx: R(-1.1, 1.1), rot: 0, vr: R(-0.28, 0.28), floorY }));
+}
 function warpUnderfoot() {
   // the warp pipe the player is standing on, if any (shared by swipe + slam entry)
   const pc = player.x + player.w / 2, feet = player.y + player.h;
@@ -2127,29 +2148,35 @@ function cleanup() {
 }
 
 // ---------- run / reset ----------
-function startRun() {
+function startRun(world) {
+  world = world || 1;
+  const offT = (world - 1) * WORLD_LEN;          // level-select starts mid-progression
   ground = new Map(); tiles = new Map(); qmeta = new Map(); bumps = new Map(); water = new Map();
   ents = []; coins = []; parts = []; floats = [];
   rng = mulberry32(urlSeed ? +urlSeed : (Math.random() * 1e9) | 0);
   game.state = 'play'; game.frame = 0; game.score = 0; game.coins = 0; game.dist = 0;
-  game.themeIdx = 0; game.worldNum = 1; game.speed = BASE_SPEED;
+  game.themeIdx = (world - 1) % THEMES.length; game.worldNum = world; game.speed = BASE_SPEED;
+  game.startWorld = world;
+  game.testRun = world > 1;                      // test runs never touch the records
   tintPage();
   game.hearts = 3; game.combo = 0; game.star = 0; game.magnet = 0; game.invuln = 0;
   game.wings = 0; game.giga = 0; game.moon = 0; game.rain = 0; game.wonder = 0;
-  game.shake = 0; game.newBest = false; game.themeFade = 0; game.recordFete = false;
+  game.shake = 0; game.newBest = false; game.themeFade = 0;
+  game.recordFete = game.testRun;                // suppress NEW RECORD! in tests
   game.hitstop = 0; game.heartFlash = 0; game.heartPop = 0;
   sfxState.coinStreak = 0; sfxState.coinFrame = -99;
   input.jumpBuf = 0; input.slamReq = false; input.held = false;
   game.inBonus = null;
-  gen.x = -6; gen.g = 0; gen.nextFlag = WORLD_LEN; gen.sinceEnemy = 0; gen.totalTiles = 0;
-  gen.lastWarp = -999;
+  gen.x = offT - 6; gen.g = 0; gen.nextFlag = world * WORLD_LEN; gen.sinceEnemy = 0;
+  gen.totalTiles = offT;                         // difficulty matches the real world
+  gen.lastWarp = offT - 999;
   for (let i = 0; i < 24; i++) C(0);             // opening runway
-  player.x = 40; player.y = -player.h; player.vy = 0;
+  player.x = offT * TILE + 40; player.y = -player.h; player.vy = 0;
   player.onGround = true; player.coyote = 0; player.dj = true; player.slam = false;
   player.mode = 'run'; player.runT = 0; player.inWater = false; player.icyAir = false;
   cam.x = player.x - camOffX(); cam.y = camBaseY();
-  announce('WORLD 1  ' + THEMES[0].name, 120);
-  playSong('hills');
+  announce('WORLD ' + world + '  ' + THEMES[game.themeIdx].name, 120);
+  playSong(THEME_SONGS[game.themeIdx]);
 }
 function announce(txt, t) { game.announce = txt; game.announceT = t; game.announceMax = t; }
 function camOffX() { return Math.round(W * (W > H ? 0.35 : 0.30)); }
@@ -2720,6 +2747,7 @@ function die() {
 }
 function gameOver() {
   game.state = 'over'; game.stateT = 0;
+  if (game.testRun) { game.newBest = false; return; }   // level-select runs don't count
   game.coinsAll += game.coins; store('coinsAll', game.coinsAll);
   game.newBest = game.score > game.best;
   if (game.newBest) { game.best = game.score; store('best', game.best); }
@@ -2755,11 +2783,36 @@ function updateEnts() {
       continue;
     }
     if (e.type === 'bones' && e.collapsed) {
-      // a pile of bones: harmless, patient, rattling back together
+      // the whole show: scatter -> settle -> rattle -> fly back together
       e.collapsed--;
+      if (!e.pieces) e.pieces = makeBonePieces(e);
+      if (e.collapsed > 168) {                     // pieces tumble and clatter down
+        for (const p of e.pieces) {
+          p.vy += 0.3; p.x += p.vx; p.y += p.vy; p.rot += p.vr;
+          const rest = p.floorY - p.sh;
+          if (p.y >= rest) { p.y = rest; p.vy = 0; p.vx *= 0.5; p.vr *= 0.5; }
+        }
+      } else if (e.collapsed <= 58 && e.collapsed > 18) {   // rattling awake
+        if (e.collapsed === 58) sfx.rattle();
+        if (e.collapsed % 14 === 0)
+          parts.push({ x: e.x + 4 + rng() * 8, y: e.y + 10, vx: R(-0.2, 0.2), vy: -0.5,
+            life: 20, color: '#cfd8ea', size: 1, grav: 0 });
+      } else if (e.collapsed <= 18) {              // reassembly: bones fly home
+        if (e.collapsed === 18) sfx.rattle();
+        const tt = 1 - e.collapsed / 18;
+        const c1 = 1.70158, c3 = c1 + 1;
+        const ez = 1 + c3 * Math.pow(tt - 1, 3) + c1 * Math.pow(tt - 1, 2);
+        for (const p of e.pieces) {
+          if (p.restX === undefined) { p.restX = p.x; p.restY = p.y; p.restRot = p.rot; }
+          p.x = p.restX + (e.x + p.ox - p.restX) * ez;
+          p.y = p.restY + (e.y + p.oy - p.restY) * ez;
+          p.rot = p.restRot * (1 - tt);
+        }
+      }
       if (e.collapsed === 0) {
         burst(e.x + 8, e.y + 8, '#fff', 6, 1.4, 0.08);
         sfx.pop();
+        e.pieces = null; e.reviveGrace = 22; e.t = 0;
       } else if (player.slam && overlap(prect(), erect(e))) {
         killEnemy(e, 150); sfx.brick();   // slamming the pile scatters it for good
       }
@@ -2767,6 +2820,7 @@ function updateEnts() {
     }
     if (e.type === 'chomp' || e.type === 'rollo' || e.type === 'spiny' || e.type === 'shell' || e.type === 'bones') {
       // walkers with gravity
+      if (e.type === 'bones' && e.reviveGrace) e.reviveGrace--;
       if (e.type === 'shell') {
         e.rot = (e.rot || 0) + 0.55;               // kicked shells spin
         if (e.t % 3 === 0)
@@ -2885,6 +2939,7 @@ function updateEnts() {
     // --- player vs enemy ---
     if (!HOSTILE.has(e.type)) continue;
     if (e.type === 'snap' && e.out < 0.35) continue;
+    if (e.type === 'bones' && e.reviveGrace) continue;   // fresh from the pile: brief truce
     const r = erect(e);
     if (!overlap(pr, r, 1)) continue;
     if (game.star > 0 || game.giga > 0) { killEnemy(e, 200); sfx.kick(); buzz(2); continue; }
@@ -2899,9 +2954,9 @@ function updateEnts() {
         e.type = 'shell'; e.vx = game.speed + 1.9; e.t = 0;
         sfx.kick();
       } else if (e.type === 'bones') {
-        e.collapsed = 190;                 // Dry-Bones style: down, not out
+        e.collapsed = 190; e.pieces = null;   // Dry-Bones style: down, not out
         burst(r.x + r.w / 2, r.y + r.h - 4, '#e8ecf4', 8, 1.8, 0.14);
-        sfx.brick();
+        sfx.rattle();
       } else killEnemy(e, 0, true);
       player.vy = input.held ? -6.3 : -4.5;
       player.dj = true; player.stompT = 8; player.stretchT = 6;
@@ -3067,15 +3122,22 @@ function settingsHit(hit) {
   if (hit(ui.buzz)) { hapticsOn = !hapticsOn; store('haptics', hapticsOn); buzz(1); sfx.ui(); return true; }
   return false;
 }
+function mkHit(cx, cy) {
+  const dpr = window.devicePixelRatio || 1;
+  const p = cx >= 0 ? { x: cx * dpr / SCALE, y: cy * dpr / SCALE } : null;
+  return r => p && r && p.x >= r.x && p.x <= r.x + r.w && p.y >= r.y && p.y <= r.y + r.h;
+}
 function onPress(cx, cy) {
   if (!audio.ctx) AC();
   if (audio.ctx && audio.ctx.state === 'suspended') audio.ctx.resume().catch(() => {});
-  const dpr = window.devicePixelRatio || 1;
-  const p = cx >= 0 ? { x: cx * dpr / SCALE, y: cy * dpr / SCALE } : null;
-  const hit = r => p && r && p.x >= r.x && p.x <= r.x + r.w && p.y >= r.y && p.y <= r.y + r.h;
+  const hit = mkHit(cx, cy);
   if (game.state === 'title') {
-    if (settingsHit(hit)) return;
-    startRun();
+    // handled on RELEASE so Konami swipes don't launch the game; keyboard = start now
+    if (cx < 0) titleRelease(hit);
+  } else if (game.state === 'levels') {
+    for (const b of ui.levelBtns || [])
+      if (hit(b.r)) { sfx.ui(); startRun(b.n); return; }
+    if (hit(ui.back)) { sfx.ui(); game.state = 'title'; game.stateT = 0; return; }
   } else if (game.state === 'play') {
     if (hit(ui.pause)) { togglePause(); sfx.ui(); return; }
     pressJump();
@@ -3084,8 +3146,24 @@ function onPress(cx, cy) {
     if (hit(ui.quit)) { game.state = 'title'; game.stateT = 0; playSong('title'); sfx.ui(); return; }
     togglePause(); sfx.ui();
   } else if (game.state === 'over') {
-    if (game.stateT > 45) startRun();
+    if (game.stateT > 45) startRun(game.startWorld || 1);   // retry the world you were testing
   }
+}
+function titleRelease(hit) {
+  if (settingsHit(hit)) return;
+  startRun();
+}
+// ↑↑↓↓←→←→ swiped on the title screen (plus B A on a keyboard) opens level select
+let konamiBuf = '';
+function konamiPush(ch) {
+  konamiBuf = (konamiBuf + ch).slice(-10);
+  if (konamiBuf.endsWith('UUDDLRLR')) openLevels();
+}
+function openLevels() {
+  konamiBuf = '';
+  game.state = 'levels'; game.stateT = 0;
+  ui.levelBtns = [];
+  sfx.power(); buzz(3);
 }
 function togglePause() {
   if (game.state === 'play') {
@@ -3219,18 +3297,52 @@ function drawEnt(e, camX, camY) {
   const f = (e.t >> 4) & 1;
   let img = null;
   // hop-bob walk with squash & stretch for the ground critters
-  if (e.type === 'bones' && e.collapsed && !e.dead) {
-    const jit = e.collapsed < 40 ? ((game.frame & 2) ? 1 : -1) : 0;   // rattling awake
-    ctx.drawImage(BONEPILE, sx + jit, sy);
+  if (e.type === 'bones' && !e.dead) {
+    if (e.collapsed) {
+      if ((e.collapsed > 168 || e.collapsed <= 18) && e.pieces) {
+        // scatter / reassembly: draw each tumbling bone piece
+        for (const p of e.pieces) {
+          ctx.save();
+          ctx.translate(Math.round(p.x - camX) + p.sw / 2, Math.round(p.y - camY) + p.sh / 2);
+          ctx.rotate(p.rot);
+          ctx.drawImage(BONES0, p.sx, p.sy, p.sw, p.sh, -p.sw / 2, -p.sh / 2, p.sw, p.sh);
+          ctx.restore();
+        }
+      } else {
+        const jit = e.collapsed <= 58 ? ((game.frame & 2) ? 1 : -1) : 0;   // rattling awake
+        ctx.drawImage(BONEPILE, sx + jit, sy);
+      }
+      return;
+    }
+    // walking: body bob + lagged skull bobble, glowing sockets, chatter shake
+    const ph = Math.abs(Math.sin(e.t * 0.11));
+    const hop = ph * 1.6;
+    const scl = 1 - 0.09 * (1 - ph);
+    const off = f ? 1 : 0, bodyH = f ? 8 : 9;
+    if (e.reviveGrace) ctx.globalAlpha = 0.65;
+    ctx.save();
+    ctx.translate(sx + 8, sy + 16 - hop);
+    ctx.scale(2 - scl, scl);
+    ctx.drawImage(BONES0, 0, 7 + off, 16, bodyH, -8, -9, 16, bodyH);   // ribs + legs
+    const shake = e.t % 170 < 10 ? (((e.t >> 1) & 1) ? 0.8 : -0.8) : 0;
+    ctx.save();
+    ctx.translate(shake, Math.sin(e.t * 0.11 - 0.9) * 1.2);            // skull lags the hop
+    ctx.rotate(Math.sin(e.t * 0.07) * 0.08);
+    ctx.drawImage(BONES0, 0, 0, 16, 7, -8, -16, 16, 7);
+    const glow = 0.35 + 0.45 * (0.5 + 0.5 * Math.sin(e.t * 0.15));     // haunted sockets
+    ctx.fillStyle = 'rgba(200,120,255,' + glow.toFixed(2) + ')';
+    ctx.fillRect(-4, -13, 1, 1); ctx.fillRect(0, -13, 1, 1);
+    ctx.restore();
+    ctx.restore();
+    ctx.globalAlpha = 1;
     return;
   }
-  if (!e.dead && (e.type === 'chomp' || e.type === 'rollo' || e.type === 'spiny' || e.type === 'bones')) {
+  if (!e.dead && (e.type === 'chomp' || e.type === 'rollo' || e.type === 'spiny')) {
     const ph = Math.abs(Math.sin(e.t * 0.11));
     const hop = ph * 1.6;
     const scl = 1 - 0.09 * (1 - ph);           // squash at the contact beat
     const wimg = e.type === 'chomp' ? (f ? CHOMP1 : CHOMP0)
                : e.type === 'rollo' ? (f ? ROLLO1 : ROLLO0)
-               : e.type === 'bones' ? (f ? BONES1 : BONES0)
                : (f ? SPINY1 : SPINY0);
     ctx.save();
     ctx.translate(sx + 8, sy + 16 - hop);
@@ -3239,7 +3351,8 @@ function drawEnt(e, camX, camY) {
     ctx.restore();
     return;
   }
-  if (e.type === 'chomp') img = f ? CHOMP1 : CHOMP0;
+  if (e.type === 'bones') img = BONES0;   // permanent kills tumble like the rest
+  else if (e.type === 'chomp') img = f ? CHOMP1 : CHOMP0;
   else if (e.type === 'rollo') img = f ? ROLLO1 : ROLLO0;
   else if (e.type === 'shell') {
     if (!e.dead) {                             // spinning as it slides
@@ -3491,6 +3604,8 @@ function drawHUD() {
   drawText(ctx, scoreStr, xr - 26 - textW(scoreStr, 2), y0, 2, '#fff', '#1a1c2c');
   const dStr = game.dist + 'M';
   drawText(ctx, dStr, xr - 26 - textW(dStr, 1), y0 + 14, 1, '#ffe97a', '#1a1c2c');
+  if (game.testRun)
+    drawText(ctx, 'TEST', xr - 26 - textW('TEST', 1), y0 + 24, 1, '#ff8a9a', '#1a1c2c');
   if (game.combo >= 2 && game.state === 'play') {
     const hot = ((game.frame >> 2) & 1) === 0;
     drawTextC(ctx, 'COMBO ×' + game.combo, W / 2, y0 + 26, 2, hot ? '#7dffb0' : '#d8ffe8', '#1a1c2c');
@@ -3698,8 +3813,25 @@ function renderOverlays() {
       drawTextC(ctx, 'TAP TO RUN AGAIN', px, box.y + box.h + 18, 2, '#ffe97a', '#1a1c2c');
   }
 }
+function renderLevels() {
+  const camX = game.frame * 0.6, camY = camBaseY();
+  drawSkyAndParallax(camX, camY);
+  ctx.fillStyle = 'rgba(10,12,28,0.74)';
+  ctx.fillRect(0, 0, W, H);
+  const y0 = safeTop + Math.max(24, H * 0.08);
+  drawTextC(ctx, 'LEVEL SELECT', W / 2, y0, 2, '#ffe97a', '#1a1c2c');
+  drawTextC(ctx, 'A TESTER\'S SECRET', W / 2, y0 + 14, 1, '#8a8ea0');
+  ui.levelBtns = [];
+  const rows0 = y0 + 32;
+  for (let i = 0; i < THEMES.length; i++) {
+    const r = drawBtn('W' + (i + 1) + '  ' + THEMES[i].name, W / 2, rows0 + i * 24, true);
+    ui.levelBtns.push({ r, n: i + 1 });
+  }
+  ui.back = drawBtn('BACK', W / 2, rows0 + THEMES.length * 24 + 8, false);
+}
 function render() {
   if (game.state === 'title') { renderTitle(); return; }
+  if (game.state === 'levels') { renderLevels(); return; }
   renderWorld();
   renderOverlays();
 }

--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -684,6 +684,60 @@ const PUFF0 = sprite([       // puffer: do not touch
 '................',
 '................'
 ]);
+const BONES0 = sprite([      // restless skeleton — collapses, never quits
+'....kkkkkk......',
+'...kwwwwwwk.....',
+'..kwwwwwwwwk....',
+'..kwekwwekwk....',
+'..kwwwwwwwwk....',
+'..kwkwkwkwwk....',
+'...kkwwwwkk.....',
+'.....kwwk.......',
+'...kkwwwwkk.....',
+'...kwkwwkwk.....',
+'...kkwwwwkk.....',
+'...kwkwwkwk.....',
+'.....kwwk.......',
+'....kwkkwk......',
+'...kwk..kwk.....',
+'...kk....kk.....'
+]);
+const BONES1 = sprite([
+'................',
+'....kkkkkk......',
+'...kwwwwwwk.....',
+'..kwwwwwwwwk....',
+'..kwekwwekwk....',
+'..kwwwwwwwwk....',
+'..kwkwkwkwwk....',
+'...kkwwwwkk.....',
+'.....kwwk.......',
+'...kkwwwwkk.....',
+'...kwkwwkwk.....',
+'...kkwwwwkk.....',
+'.....kwwk.......',
+'....kwwkwk......',
+'....kwk.kwk.....',
+'....kk...kk.....'
+]);
+const BONEPILE = sprite([    // temporarily inconvenienced
+'................',
+'................',
+'................',
+'................',
+'................',
+'................',
+'................',
+'................',
+'......kkkkk.....',
+'.....kwwwwwk....',
+'.....kwekwek....',
+'....kwwwwwwwk...',
+'...kwMwwkwwMwk..',
+'..kwwkwwwwkwwk..',
+'..kkkkkkkkkkkk..',
+'................'
+]);
 const WISP0 = sprite([       // castle ghost
 '.....kkkkkk.....',
 '...kkmmmmmmkk...',
@@ -940,7 +994,7 @@ const THEMES = [
     grass:'#7a68a0', grassHi:'#a292c4', dirt:'#3c2c54', dirtDk:'#281c3c',
     brick:'#54406c', brickDk:'#3a2c4e', pipe:'#7a5898', pipeDk:'#553a70',
     plat:'#645080', platDk:'#463858',
-    particle:'fog', enemies:['wisp','bat','chomp'], deco:'grave' },
+    particle:'fog', enemies:['wisp','bones','bat','chomp'], deco:'grave' },
   { name:'MAGMA KEEP',
     skyTop:'#1c0f22', skyBot:'#54182c', sun:'#ff6a3c',
     far:'#3a1830', far2:'#2a1024', near:'#54223c',
@@ -1812,6 +1866,7 @@ function spawnEnemy(type, tx, g) {
   const x = tx * TILE, top = -g * TILE;
   const e = { type, x, y: top - 16, vx: 0, vy: 0, w: 12, h: 12, ox: 2, oy: 4, dead: 0, t: RI(0, 100) };
   if (type === 'chomp') { e.vx = -0.35; }
+  else if (type === 'bones') { e.vx = -0.3; e.h = 14; e.oy = 1; }
   else if (type === 'rollo') { e.vx = -0.3; }
   else if (type === 'spiny') { e.vx = -0.3; e.h = 13; e.oy = 3; }
   else if (type === 'bat') {
@@ -2116,8 +2171,8 @@ function addScore(n, x, y, label) {
 
 // ---------- update ----------
 const THEME_SONGS = ['hills', 'dunes', 'caves', 'tide', 'sky', 'frost', 'haunt', 'keep'];
-const HOSTILE = new Set(['chomp', 'rollo', 'spiny', 'bat', 'snap', 'wisp', 'finn', 'puffer']);
-const STOMPABLE = new Set(['chomp', 'rollo', 'bat']);
+const HOSTILE = new Set(['chomp', 'rollo', 'spiny', 'bat', 'snap', 'wisp', 'finn', 'puffer', 'bones']);
+const STOMPABLE = new Set(['chomp', 'rollo', 'bat', 'bones']);
 function genThemeIdx() { return Math.floor(Math.max(0, gen.x) / WORLD_LEN) % THEMES.length; }
 
 function prect() { return { x: player.x, y: player.y, w: player.w, h: player.h }; }
@@ -2699,7 +2754,18 @@ function updateEnts() {
       if (e.t > 45) { e.dead = 2; e.deadT = 0; }
       continue;
     }
-    if (e.type === 'chomp' || e.type === 'rollo' || e.type === 'spiny' || e.type === 'shell') {
+    if (e.type === 'bones' && e.collapsed) {
+      // a pile of bones: harmless, patient, rattling back together
+      e.collapsed--;
+      if (e.collapsed === 0) {
+        burst(e.x + 8, e.y + 8, '#fff', 6, 1.4, 0.08);
+        sfx.pop();
+      } else if (player.slam && overlap(prect(), erect(e))) {
+        killEnemy(e, 150); sfx.brick();   // slamming the pile scatters it for good
+      }
+      continue;
+    }
+    if (e.type === 'chomp' || e.type === 'rollo' || e.type === 'spiny' || e.type === 'shell' || e.type === 'bones') {
       // walkers with gravity
       if (e.type === 'shell') {
         e.rot = (e.rot || 0) + 0.55;               // kicked shells spin
@@ -2832,6 +2898,10 @@ function updateEnts() {
       if (e.type === 'rollo') {
         e.type = 'shell'; e.vx = game.speed + 1.9; e.t = 0;
         sfx.kick();
+      } else if (e.type === 'bones') {
+        e.collapsed = 190;                 // Dry-Bones style: down, not out
+        burst(r.x + r.w / 2, r.y + r.h - 4, '#e8ecf4', 8, 1.8, 0.14);
+        sfx.brick();
       } else killEnemy(e, 0, true);
       player.vy = input.held ? -6.3 : -4.5;
       player.dj = true; player.stompT = 8; player.stretchT = 6;
@@ -3149,12 +3219,18 @@ function drawEnt(e, camX, camY) {
   const f = (e.t >> 4) & 1;
   let img = null;
   // hop-bob walk with squash & stretch for the ground critters
-  if (!e.dead && (e.type === 'chomp' || e.type === 'rollo' || e.type === 'spiny')) {
+  if (e.type === 'bones' && e.collapsed && !e.dead) {
+    const jit = e.collapsed < 40 ? ((game.frame & 2) ? 1 : -1) : 0;   // rattling awake
+    ctx.drawImage(BONEPILE, sx + jit, sy);
+    return;
+  }
+  if (!e.dead && (e.type === 'chomp' || e.type === 'rollo' || e.type === 'spiny' || e.type === 'bones')) {
     const ph = Math.abs(Math.sin(e.t * 0.11));
     const hop = ph * 1.6;
     const scl = 1 - 0.09 * (1 - ph);           // squash at the contact beat
     const wimg = e.type === 'chomp' ? (f ? CHOMP1 : CHOMP0)
                : e.type === 'rollo' ? (f ? ROLLO1 : ROLLO0)
+               : e.type === 'bones' ? (f ? BONES1 : BONES0)
                : (f ? SPINY1 : SPINY0);
     ctx.save();
     ctx.translate(sx + 8, sy + 16 - hop);

--- a/apps/pixelrun/sw.js
+++ b/apps/pixelrun/sw.js
@@ -2,7 +2,7 @@
 // shell makes it fully playable offline. Strategy is stale-while-revalidate —
 // instant load from cache, silently refreshed from the network for next launch.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'pixelrun-v12';
+const CACHE = 'pixelrun-v13';
 const SHELL = ['./', './index.html', './icon.png', './apple-touch-icon.png', './icon-192.png', './manifest.webmanifest'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
The two requested worlds, slotted in at 6 and 7 with **Magma Keep promoted to the world-8 finale**.

## ❄️ FROST PEAKS (world 6)
Icy pale palette, jagged snowcapped summits in the distance, a snow-dusted pine treeline, and constant drifting snowfall. The mechanic: **ice is genuinely slippery** — you run 12% faster on frozen ground and carry that momentum through the air, so every jump overshoots a touch and the whole world feels slick (skid crystals spray from your heels to sell it). Crystalline E-minor music-box track, 16 bars. Bonus room: **GLACIER VAULT** — a slick sprint between ice shelves where the speed boost makes coin lines feel amazing.

## 👻 HAUNTED HOLLOW (world 7)
Near-black violet night under a pale moon: dead hills, bare-branched trees, gravestones with the occasional glowing window, fog drifting at ground level — and a **darkness vignette that closes in from the edges with a pool of light following you**. The wisps get top billing: **two hunt you at once** with no difficulty gate, and bats roost here like in the caves. Creeping 96-BPM D-minor heartbeat track with heavy echo. Bonus room: **CRYPT VAULT** — the dark is generous: two heart blocks.

## Under the hood
Theme indices are load-bearing (per the app CLAUDE.md), so this was a full sweep: castle 5→7 across parallax branches, the dark-sky starfield check, and bonus-vault palettes; new parallax art for both worlds; `THEME_SONGS` gains `frost`/`haunt`; vault arrays extend to `%8`. Index map in CLAUDE.md updated (water=3, sky=4, frost=5, haunt=6, castle=7).

## Verified
Bot rode worlds 1→8 in order (Frost at 6, Hollow at 7, Magma at 8); both new tracks bar-validated at 256 steps; **2 wisps confirmed hunting simultaneously** in the Hollow; ice boost measured live at ~1.1×; zero errors across the ~90k-frame ride. Screenshots of both worlds in thread. VERSION **18**, SW cache **v13**.

A full loop is now 8 worlds ≈ 4km ≈ 8 minutes before NG+ wraps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fcibXj5NnHHSGBiSh51Et