### PR TITLE
Pixel Run v21: measured display-Hz readout

### DIFF
--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -68,7 +68,7 @@ const MAX_SPEED = 3.05;
 const PIT_Y = 11 * TILE;             // below this = pit death
 const WORLD_LEN = 500;               // tiles per world before the flag
 const SAVE = 'pixelrun_';
-const VERSION = 20;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
+const VERSION = 21;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
 
 // ---------- utils ----------
 const clamp = (v, a, b) => v < a ? a : v > b ? b : v;

--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -3902,7 +3902,7 @@ function renderTitle() {
   }
   ui.sound = drawBtn('SOUND ' + (audio.muted ? 'OFF' : 'ON'), W / 2 - 44, H - 22 - safeBot, !audio.muted);
   ui.buzz = drawBtn('BUZZ ' + (hapticsOn ? 'ON' : 'OFF'), W / 2 + 44, H - 22 - safeBot, hapticsOn);
-  const vs = 'V' + VERSION;
+  const vs = 'V' + VERSION + (hz.value ? '  ' + hz.value + 'HZ' : '');
   drawText(ctx, vs, W - textW(vs, 1) - 8 - safeR, H - 16 - safeBot, 1, 'rgba(255,255,255,0.6)', '#1a1c2c');
 }
 function drawWater(camX, camY) {
@@ -4070,9 +4070,16 @@ function step() {
   }
 }
 let last = 0, acc = 0, lastW = 0, lastH = 0;
+const hz = { ticks: 0, t0: 0, value: 0 };      // measured display rate (rAF cadence)
 function frame(ts) {
   requestAnimationFrame(frame);
   if (!last) last = ts;
+  hz.ticks++;
+  if (!hz.t0) hz.t0 = ts;
+  else if (ts - hz.t0 >= 1000) {
+    hz.value = Math.round(hz.ticks * 1000 / (ts - hz.t0));
+    hz.ticks = 0; hz.t0 = ts;
+  }
   let dt = ts - last; last = ts;
   if (dt > 250) dt = 250;
   acc += dt;
@@ -4166,7 +4173,7 @@ const DBG = window.__dbg = {
   bot: false, errors: [], stats: { hurts: [], deaths: [] },
   game, player, input, cam, gen,
   ents: () => ents, ground: () => ground, tiles: () => tiles, coins: () => coins,
-  qmeta: () => qmeta, K, openQBlock, ui, musicErrors: MUSIC_ERRORS, water: () => water,
+  qmeta: () => qmeta, K, openQBlock, ui, musicErrors: MUSIC_ERRORS, water: () => water, hz,
   toClient(r) { const dpr = window.devicePixelRatio || 1; return { x: (r.x + r.w / 2) * SCALE / dpr, y: (r.y + r.h / 2) * SCALE / dpr }; },
   startRun, step, botThink,
   stepN(n) { for (let i = 0; i < n; i++) { if (DBG.bot) botThink(); step(); } },

--- a/apps/pixelrun/sw.js
+++ b/apps/pixelrun/sw.js
@@ -2,7 +2,7 @@
 // shell makes it fully playable offline. Strategy is stale-while-revalidate —
 // instant load from cache, silently refreshed from the network for next launch.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'pixelrun-v15';
+const CACHE = 'pixelrun-v16';
 const SHELL = ['./', './index.html', './icon.png', './apple-touch-icon.png', './icon-192.png', './manifest.webmanifest'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
Adds a live refresh-rate readout beside the version on the title screen (e.g. `V21 120HZ`): it counts `requestAnimationFrame` ticks over rolling one-second windows, so it reports what the browser is *actually* delivering on any device — the honest answer to "is my 165 Hz screen being used?"

For context (unchanged by this PR): the simulation is a fixed 60 Hz timestep and rendering paints only when a sim step occurred, so high-refresh screens run the game correctly but at an effective 60 fps. The readout reveals the display cadence the loop is riding on. Also exposed as `__dbg.hz` for the harness.

Verified headless (readout renders and measures; low value there is SwiftShader's real speed). VERSION **21**, SW cache **v16**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fcibXj5NnHHSGBiSh51Et