### PR TITLE
Pixel Run v30: pet climbs at animal speed, not teleport speed

### DIFF
--- a/apps/pixelrun/CLAUDE.md
+++ b/apps/pixelrun/CLAUDE.md
@@ -7,6 +7,10 @@
 running build can be identified at a glance (the service worker makes staleness
 otherwise invisible). Started at 12 = the 12th Pixel Run PR (#238–#249).
 
+When bumping, ASSERT the old value is present (a search-and-replace bump
+against a stale base has silently no-opped twice — check open PRs for the
+true latest version before bumping).
+
 When a PR should reach installed players promptly, also bump `CACHE`
 (`pixelrun-vN`) in `sw.js` — the service worker serves stale-while-revalidate,
 so without a cache bump users get the previous build for one extra launch.

--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -2109,14 +2109,16 @@ function updatePet() {
     if (ws !== undefined && trail.w) {
       if (!gateAhead) ty2 = ws - 9;    // every land animal paddles at the surface
     } else if (!trail.w && ws === undefined) {               // real land only —
-      const gt2 = petFloor(tx2 + 8);                         // never perch on gate caps
+      // sample the floor a full tile ahead: climbs begin early and ramp up
+      // gently instead of snapping the pipe face at the last moment
+      const gt2 = petFloor(tx2 + 8 + 14) ?? petFloor(tx2 + 8);
       if (gt2 !== null) ty2 = gt2 - 13;   // paws on the ground; over a pit: sail the trail arc
     }
   }
   pet.x += (tx2 - pet.x) * 0.22;
-  // climbs and dives are brisk (clears stair risers and gate caps before the
-  // body drifts into them); everything else is a soft glide
-  pet.y += (ty2 - pet.y) * (ty2 < pet.y - 4 ? 0.5 : gateAhead ? 0.4 : 0.22);
+  // vertical speed is CAPPED so climbs, hops and dives read as movement,
+  // never teleports — dives get extra headroom to keep pace with the player
+  pet.y += clamp((ty2 - pet.y) * 0.3, -3, gateAhead ? 4 : 3.4);
   if (pet.celeb > 0) pet.celeb--;
   if (def.ember && pet.t % 110 === 0)                        // dragon: a proud little puff
     parts.push({ x: pet.x + 11, y: pet.y + 7, vx: 0.5, vy: R(-0.3, 0), life: RI(12, 20),

--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -68,7 +68,7 @@ const MAX_SPEED = 3.05;
 const PIT_Y = 11 * TILE;             // below this = pit death
 const WORLD_LEN = 500;               // tiles per world before the flag
 const SAVE = 'pixelrun_';
-const VERSION = 29;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
+const VERSION = 30;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
 
 // ---------- utils ----------
 const clamp = (v, a, b) => v < a ? a : v > b ? b : v;

--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -68,7 +68,7 @@ const MAX_SPEED = 3.05;
 const PIT_Y = 11 * TILE;             // below this = pit death
 const WORLD_LEN = 500;               // tiles per world before the flag
 const SAVE = 'pixelrun_';
-const VERSION = 28;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
+const VERSION = 29;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
 
 // ---------- utils ----------
 const clamp = (v, a, b) => v < a ? a : v > b ? b : v;
@@ -4425,10 +4425,9 @@ function drawBtn(label, cx, y, on) {
   drawText(ctx, label, x + 8, y + 5, 1, on === false ? '#8a8ea0' : '#fff');
   return { x: x - 4, y: y - 4, w: w + 8, h: h + 8 };
 }
-const LOGO_COLORS = ['#ff5a5a', '#ffb03c', '#ffe93c', '#7dff6a', '#59c8ff', '#c86bde'];
 function drawLogo(cx, y, s) {
   // readability first: solid fills with a chunky outline and soft drop shadow,
-  // one gentle group bob — the rainbow lives on as an underline accent
+  // bobbing gently as one unit
   const bob = Math.round(Math.sin(game.frame * 0.06) * 2);
   const word = (str, yy, sc, fill) => {
     const x0 = cx - textW(str, sc) / 2;
@@ -4439,13 +4438,6 @@ function drawLogo(cx, y, s) {
   };
   word('PIXEL', y + bob, s, '#ffffff');
   word('RUN', y + 6 * s + 4 + bob, s + 2, '#ffe93c');
-  const uw = textW('RUN', s + 2) + 8;
-  const ux = cx - uw / 2, uy = y + 6 * s + 4 + 5 * (s + 2) + 8 + bob;
-  const seg = Math.ceil(uw / 6);
-  for (let i = 0; i < 6; i++) {
-    ctx.fillStyle = LOGO_COLORS[i];
-    ctx.fillRect(Math.round(ux + i * seg), Math.round(uy), Math.min(seg, uw - i * seg), 3);
-  }
 }
 function drawTitleGround(camX) {
   // decorative ground strip shared by the title and level-select screens

--- a/apps/pixelrun/sw.js
+++ b/apps/pixelrun/sw.js
@@ -2,7 +2,7 @@
 // shell makes it fully playable offline. Strategy is stale-while-revalidate —
 // instant load from cache, silently refreshed from the network for next launch.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'pixelrun-v23';
+const CACHE = 'pixelrun-v24';
 const SHELL = ['./', './index.html', './icon.png', './apple-touch-icon.png', './icon-192.png', './manifest.webmanifest'];
 
 self.addEventListener('install', e => {

--- a/apps/pixelrun/sw.js
+++ b/apps/pixelrun/sw.js
@@ -2,7 +2,7 @@
 // shell makes it fully playable offline. Strategy is stale-while-revalidate —
 // instant load from cache, silently refreshed from the network for next launch.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'pixelrun-v24';
+const CACHE = 'pixelrun-v25';
 const SHELL = ['./', './index.html', './icon.png', './apple-touch-icon.png', './icon-192.png', './manifest.webmanifest'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
Playtest report: the pet's hops over pipes and gaps looked glitched — huge vertical snaps.

Cause: an exponential lerp with a "brisk climb" multiplier covered **half the remaining distance in one frame** (~20px vertical teleports over a pipe). 

Fix:
- **Hard cap on vertical speed** (~3px/frame climbing, 3.4 descending, slightly more during pillar-gate dives so it keeps pace with the player)
- **Climbs start a tile early** — the floor is sampled ~14px ahead, so rises ramp up gently before the obstacle arrives instead of snapping at its face

Measured: max per-frame vertical step fell from ~20px to **3.4px** across a 9k-frame run. Trade-off accepted and documented: a handful of brief overlap frames while scrambling over pipe lips (~0.5%, on a no-collision cosmetic entity) — it reads as a scramble, not a glitch.

VERSION **30**, SW cache **v25**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fcibXj5NnHHSGBiSh51Et