### PR TITLE
Pixel Run v31: pets never sink through a ledge on the way down

### DIFF
--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -68,7 +68,7 @@ const MAX_SPEED = 3.05;
 const PIT_Y = 11 * TILE;             // below this = pit death
 const WORLD_LEN = 500;               // tiles per world before the flag
 const SAVE = 'pixelrun_';
-const VERSION = 30;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
+const VERSION = 31;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
 
 // ---------- utils ----------
 const clamp = (v, a, b) => v < a ? a : v > b ? b : v;
@@ -2109,9 +2109,12 @@ function updatePet() {
     if (ws !== undefined && trail.w) {
       if (!gateAhead) ty2 = ws - 9;    // every land animal paddles at the surface
     } else if (!trail.w && ws === undefined) {               // real land only —
-      // sample the floor a full tile ahead: climbs begin early and ramp up
-      // gently instead of snapping the pipe face at the last moment
-      const gt2 = petFloor(tx2 + 8 + 14) ?? petFloor(tx2 + 8);
+      // asymmetric floor rule: RISE early for what's coming (look-ahead), but
+      // never DESCEND before the edge — falling starts only once the ground
+      // under the paws is actually gone, so drops never clip through the lip
+      const here = petFloor(tx2 + 8), ahead = petFloor(tx2 + 8 + 14);
+      const gt2 = here !== null && ahead !== null ? Math.min(here, ahead)
+        : here !== null ? here : ahead;
       if (gt2 !== null) ty2 = gt2 - 13;   // paws on the ground; over a pit: sail the trail arc
     }
   }

--- a/apps/pixelrun/sw.js
+++ b/apps/pixelrun/sw.js
@@ -2,7 +2,7 @@
 // shell makes it fully playable offline. Strategy is stale-while-revalidate —
 // instant load from cache, silently refreshed from the network for next launch.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'pixelrun-v25';
+const CACHE = 'pixelrun-v26';
 const SHELL = ['./', './index.html', './icon.png', './apple-touch-icon.png', './icon-192.png', './manifest.webmanifest'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
Playtest report: the pet clipped through the surface descending off pipes and ledges.

**Cause:** the climb look-ahead cut both ways. The pet samples the floor a tile ahead so climbs can begin early — but on a *drop*, that same look-ahead made it start sinking toward the lower ground **while still standing on the pipe**, straight through the lip.

**Fix — exactly the model suggested:** the floor rule is now asymmetric. The pet's target is the **higher** of (floor under it, floor ahead):
- Rising terrain ahead → starts climbing early, as before
- Falling terrain ahead → holds its level until the ground under its paws is actually gone, *then* runs off the edge and drops behind you, catching up

A pleasant side effect: small gaps are now glided across at lip height rather than dipped into.

Audited with per-frame solid checks at two body points across 25k consecutive frames of pipe-heavy worlds: **zero descending clips**. VERSION **31**, SW cache **v26** (bump assert-guarded per the new CLAUDE.md rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fcibXj5NnHHSGBiSh51Et