### PR TITLE
Pixel Run v39: the title always wears World 1's face

### DIFF
--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -68,7 +68,7 @@ const MAX_SPEED = 3.05;
 const PIT_Y = 11 * TILE;             // below this = pit death
 const WORLD_LEN = 500;               // tiles per world before the flag
 const SAVE = 'pixelrun_';
-const VERSION = 38;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
+const VERSION = 39;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
 
 // ---------- utils ----------
 const clamp = (v, a, b) => v < a ? a : v > b ? b : v;
@@ -4098,6 +4098,14 @@ function unlockAudio() {
   }
   if (!audio.song && game.state === 'title') playSong('title');
 }
+function goTitle() {
+  // the title always wears WORLD 1's face — a test run at world 8 used to
+  // leave its theme behind, showing Magma Keep over a start that plays hills
+  game.state = 'title'; game.stateT = 0;
+  game.themeIdx = 0; game.prevTheme = 0; game.themeFade = 0;
+  tintPage();
+  playSong('title');
+}
 function onPress(cx, cy) {
   unlockAudio();
   const hit = mkHit(cx, cy);
@@ -4107,18 +4115,18 @@ function onPress(cx, cy) {
   } else if (game.state === 'levels') {
     for (const b of ui.levelBtns || [])
       if (hit(b.r)) { sfx.ui(); startRun(b.n); return; }
-    if (hit(ui.back)) { sfx.ui(); game.state = 'title'; game.stateT = 0; return; }
+    if (hit(ui.back)) { sfx.ui(); goTitle(); return; }
   } else if (game.state === 'play') {
     if (hit(ui.pause)) { togglePause(); sfx.ui(); return; }
     pressJump();
   } else if (game.state === 'pause') {
     if (settingsHit(hit)) return;
-    if (hit(ui.quit)) { game.state = 'title'; game.stateT = 0; playSong('title'); sfx.ui(); return; }
+    if (hit(ui.quit)) { goTitle(); sfx.ui(); return; }
     togglePause(); sfx.ui();
   } else if (game.state === 'over') {
     if (game.stateT > 45) {
       if (game.testRun && hit(ui.overTitle)) {
-        game.state = 'title'; game.stateT = 0; playSong('title'); sfx.ui(); return;
+        goTitle(); sfx.ui(); return;
       }
       startRun(game.startWorld || 1);   // retry the world you were testing
     }

--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -2475,7 +2475,10 @@ const patterns = [
         w: 32, h: 16, ox: 0, oy: 0, dead: 0, t: 0 });
     }
     if (ph >= 4) coinAt(tx, -g - ph - 3);        // hint: this one needs a double jump
-    for (let i = 0; i < 3; i++) C(g);
+    // tall pipes need a LANDING RUNWAY: the double-jump arc carries ~8 tiles,
+    // and a short tail let the next pattern's ? blocks spawn inside it —
+    // you'd soar clean over them with no way back
+    for (let i = 0; i < (ph >= 4 ? 9 : 3); i++) C(g);
   } },
   { w: d => 1 + d * 2.2, f: d => {              // floating platforms over a wide gap
     const g = gen.g;

--- a/apps/pixelrun/sw.js
+++ b/apps/pixelrun/sw.js
@@ -2,7 +2,7 @@
 // shell makes it fully playable offline. Strategy is stale-while-revalidate —
 // instant load from cache, silently refreshed from the network for next launch.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'pixelrun-v33';
+const CACHE = 'pixelrun-v34';
 const SHELL = ['./', './index.html', './icon.png', './apple-touch-icon.png', './icon-192.png', './manifest.webmanifest'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
Playtest report: Konami to world 8 → quit to title → the title screen keeps rendering **Magma Keep's** night sky and battlements behind the logo, while tapping starts a **Green Hills** run. Misleading — the title should always look like what a tap delivers.

All three return-to-title paths (pause **QUIT TO TITLE**, level-select **BACK**, game-over **BACK TO TITLE**) now route through a single `goTitle()` helper that resets the theme state to world 1, retints the page chrome/status-bar color, and starts the title song — no path can leave a stale world theme behind again.

Verified headless on both quit paths: theme 7 in-run → theme 0 on the title, state correct, zero errors. VERSION **39**, SW cache **v34**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fcibXj5NnHHSGBiSh51Et