### PR TITLE
Pixel Run v42: TROPHIES gets equal button weight

### DIFF
--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -68,7 +68,7 @@ const MAX_SPEED = 3.05;
 const PIT_Y = 11 * TILE;             // below this = pit death
 const WORLD_LEN = 500;               // tiles per world before the flag
 const SAVE = 'pixelrun_';
-const VERSION = 41;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
+const VERSION = 42;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
 
 // ---------- utils ----------
 const clamp = (v, a, b) => v < a ? a : v > b ? b : v;
@@ -5126,7 +5126,7 @@ function renderTitle() {
   drawTextC(ctx, 'AN ENDLESS PLATFORM DASH', W / 2, safeTop + H * 0.12 + 62, 1, '#fff', '#1a1c2c');
   // daily + trophies live between the tagline and the start prompt
   ui.dailyBtn = drawBtn('DAILY RUN', W / 2 - 52, gy - 168, true);
-  ui.trophyBtn = drawBtn('TROPHIES', W / 2 + 52, gy - 168, false);
+  ui.trophyBtn = drawBtn('TROPHIES', W / 2 + 52, gy - 168, true);   // equal choices, equal weight
   {
     const bits = [];
     if (dailyBest) bits.push("TODAY'S BEST " + dailyBest.score);

--- a/apps/pixelrun/sw.js
+++ b/apps/pixelrun/sw.js
@@ -2,7 +2,7 @@
 // shell makes it fully playable offline. Strategy is stale-while-revalidate —
 // instant load from cache, silently refreshed from the network for next launch.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'pixelrun-v36';
+const CACHE = 'pixelrun-v37';
 const SHELL = ['./', './index.html', './icon.png', './apple-touch-icon.png', './icon-192.png', './manifest.webmanifest'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
Playtest question exposed a style inconsistency: DAILY RUN (white) beside TROPHIES (gray) read as *enabled next to disabled*, when they're equal navigation choices. TROPHIES is now white.

The gray button style now consistently means only: toggles that are OFF (SOUND/BUZZ), purchases you can't afford (NEED N MORE), and deliberately de-emphasized alternatives to a primary action (GIVE UP under SECOND WIND, BACK TO TITLE under RUN AGAIN).

VERSION **42**, SW cache **v37**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fcibXj5NnHHSGBiSh51Et