### PR TITLE
Pixel Run v43: guaranteed chest treasure actually arrives (was 1 of 12)

### DIFF
--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -3472,6 +3472,16 @@ function startBonus() {
 }
 function leaveBonus() {
   const b = game.inBonus;
+  // guaranteed treasure is GUARANTEED: any chest coin still homing when you
+  // step through the portal comes with you (they were being culled mid-flight —
+  // measured: 11 of 12 lost when running straight from chest to door)
+  let swept = 0;
+  for (const c of coins)
+    if (c.home !== undefined && !c.taken) { c.taken = 9; game.coins++; swept++; }
+  if (swept > 0) {
+    addScore(swept * 50, undefined);
+    sfx.coin(); buzz(1);
+  }
   player.mode = 'pipeout'; player.pipeT = 0; player.inWater = false;
   player.x = b.retX + 16 - player.w / 2;
   player.y = b.capY + 4;                          // rises out of the pipe you entered
@@ -3629,7 +3639,7 @@ function updateEnts() {
         e.opened = 1;
         for (let i = 0; i < 12; i++)
           coins.push({ x: e.x + 8, y: e.y + 4, vx: R(-1.5, 1.5), vy: 0, taken: 0,
-            fall: R(-3.6, -1.6), grav: 1, home: RI(24, 46) });   // then they fly to YOU
+            fall: R(-3.6, -1.6), grav: 1, home: RI(6, 20) });   // then they fly to YOU, fast
         burst(e.x + 8, e.y + 4, '#ffe97a', 12, 2.2, 0.1);
         addFloat(e.x - 4, e.y - 14, 'TREASURE!', '#ffd93c');
         sfx.power(); buzz(3); game.shake = Math.max(game.shake, 3);
@@ -4099,7 +4109,7 @@ function updateCoins() {
       if (c.home > 0) c.home--;
       else {
         const dx = pcx - c.x, dy = pcy - c.y, m2 = Math.hypot(dx, dy) || 1;
-        c.x += dx / m2 * 3.4; c.y += dy / m2 * 3.4;
+        c.x += dx / m2 * 5; c.y += dy / m2 * 5;
         c.fall = 0;
       }
     }

--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -68,7 +68,7 @@ const MAX_SPEED = 3.05;
 const PIT_Y = 11 * TILE;             // below this = pit death
 const WORLD_LEN = 500;               // tiles per world before the flag
 const SAVE = 'pixelrun_';
-const VERSION = 42;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
+const VERSION = 43;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
 
 // ---------- utils ----------
 const clamp = (v, a, b) => v < a ? a : v > b ? b : v;

--- a/apps/pixelrun/sw.js
+++ b/apps/pixelrun/sw.js
@@ -2,7 +2,7 @@
 // shell makes it fully playable offline. Strategy is stale-while-revalidate —
 // instant load from cache, silently refreshed from the network for next launch.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'pixelrun-v37';
+const CACHE = 'pixelrun-v38';
 const SHELL = ['./', './index.html', './icon.png', './apple-touch-icon.png', './icon-192.png', './manifest.webmanifest'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
Playtest observation, confirmed by measurement: **running straight from the vault chest to the exit portal collected 1 of its 12 coins.** The chest sits two tiles from the door, its coins fountain for ~25–45 frames before homing kicks in, and the exit teleports the player 64,000px back to the overworld — every coin still airborne was silently culled.

Two-layer fix:
- Coins **home sooner and faster** (6–20 frame stagger at 5px/frame, was 24–46 at 3.4) so the golden stream visibly pours into you before the door
- The exit portal **sweeps any still-homing coin** into your count with the coin chime — the treasure was guaranteed by design, and now in fact

Verified: **12 of 12** collected at a full chest-to-door rush (was 1 of 12).

Harness confession: the first verification falsely showed the fix absent — a reused headless Chrome profile's *service worker* was serving a cached same-version build. Diagnosed via `leaveBonus.toString()`, fixed by fresh-profile-per-run, and recorded in the app notes.

VERSION **43**, SW cache **v38**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fcibXj5NnHHSGBiSh51Et