### PR TITLE
Landscape mode for Pixel Run + controller support for both games

### DIFF
--- a/apps/fablekart/CLAUDE.md
+++ b/apps/fablekart/CLAUDE.md
@@ -427,6 +427,13 @@ work, and don't regress these four seams.
   hardwired geometric ("absolute"), but on a laptop that felt like being
   stuck in Reversed, so they follow the setting too (user request,
   2026-06-10). Do NOT "fix" the default back.
+- **Gamepad** (`padPoll()`, polled each frame before the paused early-out):
+  left stick steers, A/shoulders/triggers hold drift, B brakes, X/Y fire
+  (same `pendingFire` + `net.fireCount` path as touch), Start pauses /
+  confirms menus, A confirms menus outside the race. **The stick is ALWAYS
+  geometric** — `padSteer` is added AFTER the Standard/Reversed flip in
+  `computeSteer()`; the inverted default is a touch-slide preference and
+  must not apply to a physical stick.
 - Drift only engages while actually steering (|steer| > 0.28); hold DRIFT on
   GO! for a rocket start.
 - **Drift model (MKDS-style, tuned after playtest)**: engaging BLENDS from

--- a/apps/fablekart/index.html
+++ b/apps/fablekart/index.html
@@ -1080,6 +1080,7 @@
         let state = 'menu'; // menu, countdown, racing, finished, paused
         let steerInput = 0, keySteer = 0, touchSteer = 0;
         let driftHeld = false, pendingFire = false;
+        let padSteer = 0, padDrift = false, padBrake = false;   // gamepad (see padPoll)
         let steerReversed = false;           // touch-steer direction preference
         let mouseSteerOn = false, mouseSteerVal = 0;   // desktop pointer steering (settings opt-in)
         let steerRangePx = 64;               // thumb travel (px) for full lock
@@ -1156,7 +1157,7 @@
         // ⚠ APP_VER: increment ONCE PER PR (CLAUDE.md rule). Shown on the
         // title screen and folded into NET_VER, so any two different builds
         // refuse to share a room.
-        const APP_VER = 37;
+        const APP_VER = 38;
         function hash32(str) {
             let h = 2166136261 >>> 0;
             for (let i = 0; i < str.length; i++) { h ^= str.charCodeAt(i); h = Math.imul(h, 16777619); }
@@ -5397,8 +5398,8 @@
         // -------------------------------------------------------------------
         function localController(k) {
             k.ctrl.steer = steerInput;
-            k.ctrl.brake = false;
-            k.ctrl.drift = driftHeld;
+            k.ctrl.brake = padBrake;
+            k.ctrl.drift = driftHeld || padDrift;
             if (pendingFire) { k.ctrl.fire = true; pendingFire = false; }
         }
         function aiController(k, dt) {
@@ -6775,7 +6776,46 @@
             // screen-left), which on a laptop felt like being stuck in
             // Reversed if your muscle memory is the Standard scheme.
             const mouse = mouseSteerOn ? mouseSteerVal : 0;
-            steerInput = clamp((touchSteer + keySteer + mouse) * (steerReversed ? 1 : -1), -1, 1);
+            // padSteer joins AFTER the Standard/Reversed flip: a physical stick
+            // is geometric (stick right = kart right) no matter how the touch
+            // slide is configured — wheels don't slide, they point.
+            steerInput = clamp((touchSteer + keySteer + mouse) * (steerReversed ? 1 : -1) + padSteer, -1, 1);
+        }
+
+        // ---------------------------------------------------------------
+        // Gamepad (standard mapping — Backbone, DualSense, Xbox…): left
+        // stick steers, A / shoulders / triggers hold DRIFT, B brakes,
+        // X or Y fires the item, Start pauses (or confirms menus). Polled
+        // once per frame; everything flows through the same k.ctrl seam
+        // and pendingFire path the touch controls use.
+        // ---------------------------------------------------------------
+        const kpad = { prev: {} };
+        function padPoll() {
+            if (!navigator.getGamepads) return;
+            let gp = null;
+            for (const g of navigator.getGamepads()) if (g && g.connected && g.buttons.length) { gp = g; break; }
+            if (!gp) { padSteer = 0; padDrift = false; padBrake = false; return; }
+            const bt = (i) => !!(gp.buttons[i] && gp.buttons[i].pressed);
+            const raw = gp.axes.length ? gp.axes[0] : 0;
+            // deadzone + the same gentle curve the mouse steering uses
+            const dz = 0.12, m = Math.max(0, (Math.abs(raw) - dz) / (1 - dz));
+            padSteer = Math.sign(raw) * Math.min(1, m * m * 1.15);
+            padDrift = bt(0) || bt(4) || bt(5) || bt(6) || bt(7);
+            padBrake = bt(1);
+            const cur = { fire: bt(2) || bt(3), start: bt(9), a: bt(0) };
+            const was = kpad.prev; kpad.prev = cur;
+            if (cur.fire && !was.fire && state === 'racing') { pendingFire = true; net.fireCount++; }
+            if (cur.start && !was.start) {
+                if (state === 'racing') { if (!netActive()) pauseGame(); }
+                else if (state === 'paused') resumeGame();
+                else if (state === 'menu' && !dom.startScreen.classList.contains('hidden')) dom.startBtn.click();
+                else if (state === 'finished' && !dom.resultScreen.classList.contains('hidden')) dom.againBtn.click();
+            }
+            if (cur.a && !was.a) {   // A doubles as menu-confirm outside the race
+                if (state === 'paused') resumeGame();
+                else if (state === 'menu' && !dom.startScreen.classList.contains('hidden')) dom.startBtn.click();
+                else if (state === 'finished' && !dom.resultScreen.classList.contains('hidden')) dom.againBtn.click();
+            }
         }
         function sensToRange(v) { return Math.round(lerp(110, 36, clamp(v, 0, 100) / 100)); }
 
@@ -7128,6 +7168,8 @@
             requestAnimationFrame(animate);
             let dt = clock.getDelta();
             dt = Math.min(dt, 0.05);
+
+            padPoll();   // before the paused early-out — the controller must be able to resume
 
             if (state === 'paused') { renderer.render(scene, camera); return; }
 

--- a/apps/fablekart/sw.js
+++ b/apps/fablekart/sw.js
@@ -5,7 +5,7 @@
 // pinned CDN script. Everything else (worker API, websockets, cross-origin)
 // is deliberately NOT intercepted — multiplayer must never hit a stale cache.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'fablekart-v1';
+const CACHE = 'fablekart-v2';
 const THREE_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js';
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];

--- a/apps/pixelrun/CLAUDE.md
+++ b/apps/pixelrun/CLAUDE.md
@@ -28,6 +28,23 @@ caches + unregister the SW and reload once before evaluating a fresh edit.
 
 ## Tuning contracts
 
+## Landscape & gamepad
+
+The game plays in both orientations. Portrait sizing targets W≈250, landscape
+targets H≈240 (same sprite scale on a given phone). Screens with portrait
+vertical stacks have explicit `W > H` layout branches: title (compact centred
+menu column, hero+pet stage-right, stats card top-left), game-over (buttons
+side by side), level select and trophies (two columns). When adding UI, check
+it against a ~420×195 canvas, not just portrait.
+
+Gamepad (`padPoll()`, standard mapping, polled per rAF): A jump, B/X/dpad-down
+slam, Start pause; menus A confirm / B back / X daily / Y pet cycle; dpad
+feeds the Konami code; level select has a pad cursor (`ui.padSel`). All pad
+input drives the same primitives as touch (pressJump/releaseJump,
+input.slamReq, startRun…), never a parallel path.
+
+## Tuning contracts
+
 Physics and generator constants are coupled — the derivation comments at the
 constants block (`JUMP_V`/`GRAV`) list which pattern heights, gap widths, and
 enemy-train spacings must move together. Song data is arrays of 16-step bars

--- a/apps/pixelrun/CLAUDE.md
+++ b/apps/pixelrun/CLAUDE.md
@@ -26,8 +26,6 @@ headless with Chrome CDP (see the repo memory / scratchpad `drive.mjs` recipe).
 **The service worker serves stale builds to localhost tests** — always clear
 caches + unregister the SW and reload once before evaluating a fresh edit.
 
-## Tuning contracts
-
 ## Landscape & gamepad
 
 The game plays in both orientations. Portrait sizing targets W≈250, landscape

--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -5161,6 +5161,9 @@ function renderTitle() {
     // landscape: the pet leads the hero (to his right) — trailing him would
     // put it back under the centred menu text
     const ppx = land ? heroCX + 44 : Math.round(W / 2 - 76);
+    // one shared centre for the pet's labels + buy button, kept on-screen —
+    // clamping only some of them would detach the button from its caption
+    const petCX = clamp(ppx + 15, safeL + 70, W - safeR - 70);
     if (!def) {   // NO PET: a faint pawprint marks the empty spot (still tappable)
       const ppy0 = gy - 30;
       ctx.globalAlpha = 0.35;
@@ -5171,7 +5174,7 @@ function renderTitle() {
       ctx.globalAlpha = 1;
       ui.petRect = { x: ppx - 5, y: ppy0 - 7, w: 40, h: 44 };
       if (game.frame - (ui.petNameT || -999) < 110)
-        drawTextC(ctx, 'NO PET', ppx + 15, gy + 6, 1, '#8a8ea0', '#1a1c2c');
+        drawTextC(ctx, 'NO PET', petCX, gy + 6, 1, '#8a8ea0', '#1a1c2c');
     } else {
     const bob = def.mode === 'fly' ? Math.round(Math.sin(game.frame * 0.09) * 3) - 22 : 0;
     // ground pets: plant the paw row exactly on the ground line (they hovered)
@@ -5203,16 +5206,15 @@ function renderTitle() {
       ctx.fillRect(ppx + 12, ppy + 12, 8, 7);
       ctx.fillRect(ppx + 14, ppy + 9, 1, 3); ctx.fillRect(ppx + 17, ppy + 9, 1, 3);
       ctx.fillRect(ppx + 14, ppy + 8, 4, 1);
-      drawTextC(ctx, def.name + '  ×' + def.cost, ppx + 15, gy + 6, 1, '#ffe27a', '#1a1c2c');
+      drawTextC(ctx, def.name + '  ×' + def.cost, petCX, gy + 6, 1, '#ffe27a', '#1a1c2c');
       ui.petBuy = drawBtn(game.coinsAll >= def.cost ? 'UNLOCK' : 'NEED ' + (def.cost - game.coinsAll) + ' MORE',
-        clamp(ppx + 15, safeL + 70, W - safeR - 70),      // keep the wide label on-screen
-        ppy - 24, game.coinsAll >= def.cost);   // above the cage, clear of the help text
+        petCX, ppy - 24, game.coinsAll >= def.cost);   // above the cage, clear of the help text
       if (game.frame - (ui.petNeedT || -999) < 60 && game.coinsAll < def.cost)
-        drawTextC(ctx, 'KEEP RUNNING!', ppx + 15, ppy - 38, 1, '#ff8a9a', '#1a1c2c');
+        drawTextC(ctx, 'KEEP RUNNING!', petCX, ppy - 38, 1, '#ff8a9a', '#1a1c2c');
     } else {
       ui.petBuy = null;
       if (game.frame - (ui.petNameT || -999) < 110)
-        drawTextC(ctx, def.name, ppx + 15, gy + 6, 1, '#ffe97a', '#1a1c2c');
+        drawTextC(ctx, def.name, petCX, gy + 6, 1, '#ffe97a', '#1a1c2c');
       }
     }
     if (petIdx >= PETS.length) ui.petBuy = null;   // the NO PET slot sells nothing

--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -68,7 +68,7 @@ const MAX_SPEED = 3.05;
 const PIT_Y = 11 * TILE;             // below this = pit death
 const WORLD_LEN = 500;               // tiles per world before the flag
 const SAVE = 'pixelrun_';
-const VERSION = 43;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
+const VERSION = 44;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
 
 // ---------- utils ----------
 const clamp = (v, a, b) => v < a ? a : v > b ? b : v;
@@ -128,9 +128,11 @@ function resize() {
   if (sig === lastSize) return;
   lastSize = sig;
   const portrait = chh >= cw;
+  // landscape targets H≈240 so sprites keep the same on-screen size as
+  // portrait (which targets W≈250) — rotating must not zoom the world out
   SCALE = portrait
     ? Math.max(1, Math.round(cw * dpr / 250))
-    : Math.max(1, Math.round(chh * dpr / 270));
+    : Math.max(1, Math.round(chh * dpr / 240));
   W = Math.ceil(cw * dpr / SCALE);
   H = Math.ceil(chh * dpr / SCALE);
   canvas.width = W; canvas.height = H;
@@ -2133,6 +2135,82 @@ window.addEventListener('keydown', e => {
 window.addEventListener('keyup', e => {
   if (e.code === 'Space' || e.code === 'ArrowUp' || e.code === 'KeyW') releaseJump();
 });
+
+// ---------- gamepad (standard mapping — Backbone, DualSense, Xbox…) ----------
+// A = jump (hold for height), B/X/dpad-down/stick-down/R2 = slam/dive,
+// Start = pause. Menus: A confirm, B back, X daily run, Y cycle pet,
+// dpad swipes the secret code. Polled once per rAF; edges drive the same
+// primitives the touch layer uses, so behavior stays identical.
+const pad = { on: false, prev: {}, toastT: -9999 };
+window.addEventListener('gamepadconnected', () => { pad.on = true; pad.toastT = game.frame; sfx.ui(); });
+window.addEventListener('gamepaddisconnected', () => {
+  pad.on = false; pad.prev = {};
+  releaseJump();                       // never leave a jump latched by a dying pad
+});
+function padPoll() {
+  if (!navigator.getGamepads) return;
+  let gp = null;
+  for (const g of navigator.getGamepads()) if (g && g.connected && g.buttons.length) { gp = g; break; }
+  if (!gp) return;
+  if (!pad.on) { pad.on = true; pad.toastT = game.frame; }
+  const bt = i => !!(gp.buttons[i] && gp.buttons[i].pressed);
+  const ax = i => gp.axes.length > i ? gp.axes[i] : 0;
+  const cur = {
+    a: bt(0), b: bt(1), x: bt(2), y: bt(3), start: bt(9),
+    up: bt(12) || ax(1) < -0.6, down: bt(13) || ax(1) > 0.6,
+    left: bt(14) || ax(0) < -0.6, right: bt(15) || ax(0) > 0.6,
+    slam: bt(1) || bt(2) || bt(13) || bt(7) || ax(1) > 0.6
+  };
+  const was = pad.prev; pad.prev = cur;
+  const edge = k => cur[k] && !was[k];
+  const st = game.state;
+  if (st === 'play') {
+    if (edge('a')) pressJump();
+    if (!cur.a && was.a) releaseJump();
+    if (edge('slam')) input.slamReq = true;
+    if (edge('start')) { togglePause(); sfx.ui(); }
+  } else if (st === 'pause') {
+    if (edge('start') || edge('a')) { togglePause(); sfx.ui(); }
+  } else if (st === 'title') {
+    // the dpad feeds the secret code exactly like swipes do
+    for (const [k, ch] of [['up', 'U'], ['down', 'D'], ['left', 'L'], ['right', 'R']])
+      if (edge(k)) konamiPush(ch);
+    if (edge('y')) {                   // Y cycles your companion
+      petIdx = (petIdx + 1) % (PETS.length + 1);
+      store('pet', petIdx);
+      ui.petNameT = game.frame;
+      sfx.ui(); buzz(1);
+    }
+    if (edge('x')) { game.dailyPending = true; sfx.ui(); startRun(); return; }
+    if (edge('a') || edge('start')) startRun();
+  } else if (st === 'levels') {
+    const nOpts = THEMES.length + 1;   // the worlds + BACK
+    if (ui.padSel === undefined) ui.padSel = 0;
+    if (edge('up')) { ui.padSel = (ui.padSel + nOpts - 1) % nOpts; sfx.ui(); }
+    if (edge('down')) { ui.padSel = (ui.padSel + 1) % nOpts; sfx.ui(); }
+    if (edge('b')) { sfx.ui(); goTitle(); return; }
+    if (edge('a') || edge('start')) {
+      sfx.ui();
+      if (ui.padSel < THEMES.length) startRun(ui.padSel + 1);
+      else goTitle();
+    }
+  } else if (st === 'trophies') {
+    if (edge('a') || edge('b') || edge('start')) { goTitle(); sfx.ui(); }
+  } else if (st === 'downed') {
+    if (game.stateT > 20) {
+      if (edge('a')) { secondWind(); return; }
+      if (edge('b')) { gameOver(); sfx.ui(); }
+    }
+  } else if (st === 'over') {
+    if (game.stateT > 45) {
+      if (edge('b')) { goTitle(); sfx.ui(); return; }
+      if (edge('a') || edge('start')) {
+        if (game.daily) game.dailyPending = true;
+        startRun(game.startWorld || 1);
+      }
+    }
+  }
+}
 
 // ---------- world state ----------
 const game = {
@@ -4321,7 +4399,7 @@ function konamiPush(ch) {
 function openLevels() {
   konamiBuf = '';
   game.state = 'levels'; game.stateT = 0;
-  ui.levelBtns = [];
+  ui.levelBtns = []; ui.padSel = 0;
   sfx.power(); buzz(3);
 }
 function togglePause() {
@@ -5064,19 +5142,25 @@ function renderTitle() {
   drawSkyAndParallax(camX, camY);
   drawTitleGround(camX);
   const gy = -camBaseY();       // baseline ground on screen (layout anchor below)
+  // landscape: the vertical stack doesn't fit above the ground band, so the
+  // menu column compacts and centres while hero+pet run stage-right of it
+  const land = W > H;
+  const heroCX = land ? Math.round(W * 0.78) : Math.round(W / 2);
   // hero running in place, with an excited hop every few seconds
   player.runT += 0.28;
   const hopT = game.frame % 200;
   const hop = hopT < 26 ? Math.round(Math.sin(hopT / 26 * Math.PI) * 20) : 0;
   const img = hop > 0 ? HERO_JUMP : HERO_CYCLE[Math.floor(player.runT) % 4];
-  ctx.save(); ctx.translate(Math.round(W / 2 - 24), gy - 48 - hop); ctx.scale(3, 3);
+  ctx.save(); ctx.translate(heroCX - 24, gy - 48 - hop); ctx.scale(3, 3);
   ctx.drawImage(img, 0, 0);
   if (!hop && game.frame % 173 < 5) { ctx.fillStyle = PAL.S; ctx.fillRect(9, 5, 1, 2); }
   ctx.restore();
   // your companion waits beside you — tap it to meet the next one
   {
     const def = petIdx < PETS.length ? PETS[petIdx] : null;
-    const ppx = Math.round(W / 2 - 76);
+    // landscape: the pet leads the hero (to his right) — trailing him would
+    // put it back under the centred menu text
+    const ppx = land ? heroCX + 44 : Math.round(W / 2 - 76);
     if (!def) {   // NO PET: a faint pawprint marks the empty spot (still tappable)
       const ppy0 = gy - 30;
       ctx.globalAlpha = 0.35;
@@ -5121,7 +5205,8 @@ function renderTitle() {
       ctx.fillRect(ppx + 14, ppy + 8, 4, 1);
       drawTextC(ctx, def.name + '  ×' + def.cost, ppx + 15, gy + 6, 1, '#ffe27a', '#1a1c2c');
       ui.petBuy = drawBtn(game.coinsAll >= def.cost ? 'UNLOCK' : 'NEED ' + (def.cost - game.coinsAll) + ' MORE',
-        ppx + 15, ppy - 24, game.coinsAll >= def.cost);   // above the cage, clear of the help text
+        clamp(ppx + 15, safeL + 70, W - safeR - 70),      // keep the wide label on-screen
+        ppy - 24, game.coinsAll >= def.cost);   // above the cage, clear of the help text
       if (game.frame - (ui.petNeedT || -999) < 60 && game.coinsAll < def.cost)
         drawTextC(ctx, 'KEEP RUNNING!', ppx + 15, ppy - 38, 1, '#ff8a9a', '#1a1c2c');
     } else {
@@ -5132,20 +5217,33 @@ function renderTitle() {
     }
     if (petIdx >= PETS.length) ui.petBuy = null;   // the NO PET slot sells nothing
   }
-  drawLogo(W / 2, safeTop + H * 0.12, 4);
-  drawTextC(ctx, 'AN ENDLESS PLATFORM DASH', W / 2, safeTop + H * 0.12 + 62, 1, '#fff', '#1a1c2c');
+  let btnY, tapY;
+  if (land) {   // compact column, vertically centred in the sky above the ground band
+    const stackTop = safeTop + Math.max(6, Math.round((gy - safeTop - 118) / 2));
+    drawLogo(W / 2, stackTop, 3);
+    drawTextC(ctx, 'AN ENDLESS PLATFORM DASH', W / 2, stackTop + 58, 1, '#fff', '#1a1c2c');
+    btnY = stackTop + 72;
+    tapY = btnY + 34;
+  } else {
+    drawLogo(W / 2, safeTop + H * 0.12, 4);
+    drawTextC(ctx, 'AN ENDLESS PLATFORM DASH', W / 2, safeTop + H * 0.12 + 62, 1, '#fff', '#1a1c2c');
+    btnY = gy - 168;
+    tapY = gy - 124;
+  }
   // daily + trophies live between the tagline and the start prompt
-  ui.dailyBtn = drawBtn('DAILY RUN', W / 2 - 52, gy - 168, true);
-  ui.trophyBtn = drawBtn('TROPHIES', W / 2 + 52, gy - 168, true);   // equal choices, equal weight
+  ui.dailyBtn = drawBtn('DAILY RUN', W / 2 - 52, btnY, true);
+  ui.trophyBtn = drawBtn('TROPHIES', W / 2 + 52, btnY, true);   // equal choices, equal weight
   {
     const bits = [];
     if (dailyBest) bits.push("TODAY'S BEST " + dailyBest.score);
     if (dailyStreak.count > 1 && dailyStreak.last === todayKey()) bits.push(dailyStreak.count + ' DAY STREAK');
     if (bits.length)
-      drawTextC(ctx, bits.join('  ·  '), W / 2, gy - 146, 1, '#bfe8ff', '#1a1c2c');
+      drawTextC(ctx, bits.join('  ·  '), W / 2, btnY + 22, 1, '#bfe8ff', '#1a1c2c');
   }
   if ((game.frame >> 5) & 1)
-    drawTextC(ctx, 'TAP TO START', W / 2, gy - 124, 2, '#ffe97a', '#1a1c2c');
+    drawTextC(ctx, 'TAP TO START', W / 2, tapY, 2, '#ffe97a', '#1a1c2c');
+  if (game.frame - pad.toastT < 160)
+    drawTextC(ctx, 'CONTROLLER CONNECTED', W / 2, tapY + 18, 1, '#7dffb0', '#1a1c2c');
   drawTextC(ctx, 'TAP: JUMP   AIR TAP: DOUBLE JUMP', W / 2, H - 68 - safeBot, 1, '#fff', '#1a1c2c');
   drawTextC(ctx, 'SWIPE DOWN: SLAM / DIVE', W / 2, H - 58 - safeBot, 1, '#fff', '#1a1c2c');
   drawTextC(ctx, 'SLAM A ↓ PIPE TO EXPLORE', W / 2, H - 48 - safeBot, 1, '#ffe97a', '#1a1c2c');
@@ -5156,12 +5254,15 @@ function renderTitle() {
   if (stats.length) {
     const bw = Math.max(...stats.map(s => textW(s[0], 1))) + 18;
     const bh = stats.length * 11 + 9;
-    const bx = Math.round(W / 2 - bw / 2), by = gy - 78 - bh;
+    // landscape: the card moves to the top-left corner — its portrait slot
+    // (above the start prompt) is where the compact menu column now sits
+    const bx = land ? safeL + 8 : Math.round(W / 2 - bw / 2);
+    const by = land ? safeTop + 6 : gy - 78 - bh;
     ctx.fillStyle = 'rgba(20,22,40,0.75)';
     ctx.fillRect(bx, by, bw, bh);
     ctx.fillStyle = 'rgba(255,255,255,0.3)';
     ctx.fillRect(bx, by, bw, 1); ctx.fillRect(bx, by + bh - 1, bw, 1);
-    stats.forEach((s, i) => drawTextC(ctx, s[0], W / 2, by + 7 + i * 11, 1, s[1]));
+    stats.forEach((s, i) => drawTextC(ctx, s[0], bx + bw / 2, by + 7 + i * 11, 1, s[1]));
   }
   ui.sound = drawBtn('SOUND ' + (audio.muted ? 'OFF' : 'ON'), W / 2 - 44, H - 22 - safeBot, !audio.muted);
   ui.buzz = drawBtn('BUZZ ' + (hapticsOn ? 'ON' : 'OFF'), W / 2 + 44, H - 22 - safeBot, hapticsOn);
@@ -5404,12 +5505,25 @@ function renderOverlays() {
     drawText(ctx, 'WORLD ' + game.worldNum + ' ' + THEMES[game.themeIdx].name, box.x + 8, box.y + 64, 1, '#fff');
     drawText(ctx, 'BEST DIST ' + game.bestDist + 'M', box.x + 8, box.y + 78, 1, '#8a8ea0');
     if (game.stateT > 45) {
-      // two explicit choices; tapping anywhere else still means "again"
-      ui.overAgain = drawBtn(game.testRun ? 'RETRY WORLD ' + game.startWorld : 'RUN AGAIN',
-        px, box.y + box.h + 14, true);
-      ui.overTitle = drawBtn('BACK TO TITLE', px, box.y + box.h + 38, false);
+      // two explicit choices; tapping anywhere else still means "again".
+      // landscape: side by side — stacked they run off the short screen
+      const again = game.testRun ? 'RETRY WORLD ' + game.startWorld : 'RUN AGAIN';
+      if (W > H) {
+        ui.overAgain = drawBtn(again, px - 70, box.y + box.h + 14, true);
+        ui.overTitle = drawBtn('BACK TO TITLE', px + 70, box.y + box.h + 14, false);
+      } else {
+        ui.overAgain = drawBtn(again, px, box.y + box.h + 14, true);
+        ui.overTitle = drawBtn('BACK TO TITLE', px, box.y + box.h + 38, false);
+      }
     } else ui.overAgain = ui.overTitle = null;
   }
+}
+function padCursor(r) {   // controller selection marker: a small triangle by the button
+  ctx.fillStyle = '#ffe97a';
+  const cy = r.y + Math.round(r.h / 2);
+  ctx.fillRect(r.x - 9, cy - 3, 2, 7);
+  ctx.fillRect(r.x - 7, cy - 1, 2, 3);
+  ctx.fillRect(r.x - 5, cy, 2, 1);
 }
 function renderLevels() {
   const camX = game.frame * 0.6, camY = camBaseY();
@@ -5422,11 +5536,16 @@ function renderLevels() {
   drawTextC(ctx, 'A TESTER\'S SECRET', W / 2, y0 + 14, 1, '#8a8ea0');
   ui.levelBtns = [];
   const rows0 = y0 + 32;
+  // landscape: 8 stacked rows overflow the short screen — two columns of 4
+  const land = W > H, perCol = land ? 4 : THEMES.length;
   for (let i = 0; i < THEMES.length; i++) {
-    const r = drawBtn('W' + (i + 1) + '  ' + THEMES[i].name, W / 2, rows0 + i * 24, true);
+    const cx = land ? W / 2 + (i < perCol ? -80 : 80) : W / 2;
+    const r = drawBtn('W' + (i + 1) + '  ' + THEMES[i].name, cx, rows0 + (i % perCol) * 24, true);
     ui.levelBtns.push({ r, n: i + 1 });
+    if (pad.on && ui.padSel === i) padCursor(r);
   }
-  ui.back = drawBtn('BACK', W / 2, rows0 + THEMES.length * 24 + 8, false);
+  ui.back = drawBtn('BACK', W / 2, rows0 + perCol * 24 + 8, false);
+  if (pad.on && ui.padSel === THEMES.length) padCursor(ui.back);
 }
 function renderTrophies() {
   const camX = game.frame * 0.6, camY = camBaseY();
@@ -5437,14 +5556,18 @@ function renderTrophies() {
   const y0 = safeTop + Math.max(22, H * 0.06);
   drawTextC(ctx, 'TROPHIES', W / 2, y0, 2, '#ffe97a', '#1a1c2c');
   drawTextC(ctx, achOwned.size + ' / ' + ACH.length, W / 2, y0 + 14, 1, '#8a8ea0');
-  const rows0 = y0 + 30, rh = Math.min(24, (H - rows0 - 40) / ACH.length);
+  // landscape: 12 rows can't fit the short screen at a readable size — split
+  // the wall into two columns of 6
+  const perCol = W > H ? Math.ceil(ACH.length / 2) : ACH.length;
+  const rows0 = y0 + 30, rh = Math.min(24, (H - rows0 - 40) / perCol);
   ACH.forEach((a, i) => {
-    const yy = rows0 + i * rh;
+    const x0 = i < perCol ? 24 : Math.round(W / 2) + 12;
+    const yy = rows0 + (i % perCol) * rh;
     const got = achOwned.has(a.id);
     ctx.fillStyle = got ? '#ffd93c' : 'rgba(255,255,255,0.15)';   // the cup
-    ctx.fillRect(24, yy + 1, 8, 6); ctx.fillRect(26, yy + 7, 4, 2); ctx.fillRect(25, yy + 9, 6, 1);
-    drawText(ctx, a.name, 40, yy, 1, got ? '#fff' : '#5a5e70');
-    drawText(ctx, a.desc, 40, yy + 9, 1, got ? '#9adfff' : 'rgba(90,94,112,0.8)');
+    ctx.fillRect(x0, yy + 1, 8, 6); ctx.fillRect(x0 + 2, yy + 7, 4, 2); ctx.fillRect(x0 + 1, yy + 9, 6, 1);
+    drawText(ctx, a.name, x0 + 16, yy, 1, got ? '#fff' : '#5a5e70');
+    drawText(ctx, a.desc, x0 + 16, yy + 9, 1, got ? '#9adfff' : 'rgba(90,94,112,0.8)');
   });
   drawTextC(ctx, 'TAP TO GO BACK', W / 2, H - 24 - safeBot, 1, '#8a8ea0', '#1a1c2c');
 }
@@ -5489,6 +5612,7 @@ function frame(ts) {
   }
   let dt = ts - last; last = ts;
   if (dt > 250) dt = 250;
+  padPoll();                    // controller state is fresh for the sim steps below
   acc += dt;
   let n = 0;
   while (acc >= STEP && n < 5) { if (DBG.bot) botThink(); step(); acc -= STEP; n++; }

--- a/apps/pixelrun/manifest.webmanifest
+++ b/apps/pixelrun/manifest.webmanifest
@@ -6,7 +6,7 @@
   "scope": "./",
   "display": "standalone",
   "display_override": ["fullscreen", "standalone"],
-  "orientation": "portrait",
+  "orientation": "any",
   "background_color": "#63b9ff",
   "theme_color": "#63b9ff",
   "icons": [

--- a/apps/pixelrun/sw.js
+++ b/apps/pixelrun/sw.js
@@ -2,7 +2,7 @@
 // shell makes it fully playable offline. Strategy is stale-while-revalidate —
 // instant load from cache, silently refreshed from the network for next launch.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'pixelrun-v38';
+const CACHE = 'pixelrun-v39';
 const SHELL = ['./', './index.html', './icon.png', './apple-touch-icon.png', './icon-192.png', './manifest.webmanifest'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
## Pixel Run: landscape mode (V44, sw v39)

Rotating the phone used to wreck the layout: the title's menu stack is anchored to the ground line, and on a short-wide screen it landed on top of the logo; several overlay screens ran off the bottom; the landscape scale formula over-zoomed the world.

- **Scale**: landscape now targets H≈240 (portrait targets W≈250), so sprites render at the same size in both orientations on a given phone — rotating no longer zooms the world out.
- **Title**: landscape gets a compact, vertically centred menu column (logo → tagline → DAILY RUN/TROPHIES → streak → TAP TO START); hero + pet run stage-right of it (pet leads), stats card moves to the top-left corner. Pet UNLOCK button is clamped on-screen.
- **Game over**: RUN AGAIN / BACK TO TITLE go side by side in landscape (stacked they overflowed).
- **Level select / trophies**: two columns in landscape.
- **Manifest**: `orientation` portrait → `any` (Android honored the lock; iOS ignores it either way).

## Controller support (Backbone, Xbox, DualSense — standard mapping)

Polled once per rAF; edges drive the exact same primitives as touch (no parallel input path).

**Pixel Run**: A = jump (hold for height), B / X / dpad-down / stick-down / R2 = slam/dive, Start = pause. Menus: A confirm, B back, X = daily run, Y = cycle pet, dpad feeds the Konami code (which now works on a controller), and level select gets a pad cursor.

**Fable Kart** (APP_VER 38, sw v2): left stick steers with deadzone + soft curve, A / shoulders / triggers hold DRIFT, B brakes, X/Y fire the item (same `pendingFire`/`net.fireCount` path, online-safe), Start pauses/resumes/starts the race/races again. **The stick is always geometric** (stick right = kart right): `padSteer` joins after the Standard/Reversed flip in `computeSteer()` — the inverted default is a touch-slide preference and doesn't apply to a physical stick.

## Verification (headless CDP)

- Landscape 844×390: title, gameplay, game over, level select, trophies all screenshot-verified; portrait 390×844 re-verified unchanged.
- Gamepad stubbed via `navigator.getGamepads`: Pixel Run title→run→jump→slam→pause→resume, Konami by dpad → level select → cursor → launch W3 all pass; Fable Kart start race / pause / resume by Start and A pass, stick-right visually veers the kart right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fcibXj5NnHHSGBiSh51Et