### PR TITLE
Fix iOS landscape rotation + kart stick follows the steering setting

### DIFF
--- a/apps/fablekart/CLAUDE.md
+++ b/apps/fablekart/CLAUDE.md
@@ -430,10 +430,12 @@ work, and don't regress these four seams.
 - **Gamepad** (`padPoll()`, polled each frame before the paused early-out):
   left stick steers, A/shoulders/triggers hold drift, B brakes, X/Y fire
   (same `pendingFire` + `net.fireCount` path as touch), Start pauses /
-  confirms menus, A confirms menus outside the race. **The stick is ALWAYS
-  geometric** — `padSteer` is added AFTER the Standard/Reversed flip in
-  `computeSteer()`; the inverted default is a touch-slide preference and
-  must not apply to a physical stick.
+  confirms menus, A confirms menus outside the race. **The stick follows the
+  Standard/Reversed setting exactly like touch and keys** — `padSteer` sits
+  INSIDE the flip in `computeSteer()`. A geometric-always stick was tried
+  first (PR #287) and the user immediately reported it as inverted
+  (2026-07-11); the Standard scheme is the muscle memory on every input
+  device. Do NOT move the stick outside the flip.
 - Drift only engages while actually steering (|steer| > 0.28); hold DRIFT on
   GO! for a rocket start.
 - **Drift model (MKDS-style, tuned after playtest)**: engaging BLENDS from

--- a/apps/fablekart/index.html
+++ b/apps/fablekart/index.html
@@ -1157,7 +1157,7 @@
         // ⚠ APP_VER: increment ONCE PER PR (CLAUDE.md rule). Shown on the
         // title screen and folded into NET_VER, so any two different builds
         // refuse to share a room.
-        const APP_VER = 38;
+        const APP_VER = 39;
         function hash32(str) {
             let h = 2166136261 >>> 0;
             for (let i = 0; i < str.length; i++) { h ^= str.charCodeAt(i); h = Math.imul(h, 16777619); }
@@ -6776,10 +6776,11 @@
             // screen-left), which on a laptop felt like being stuck in
             // Reversed if your muscle memory is the Standard scheme.
             const mouse = mouseSteerOn ? mouseSteerVal : 0;
-            // padSteer joins AFTER the Standard/Reversed flip: a physical stick
-            // is geometric (stick right = kart right) no matter how the touch
-            // slide is configured — wheels don't slide, they point.
-            steerInput = clamp((touchSteer + keySteer + mouse) * (steerReversed ? 1 : -1) + padSteer, -1, 1);
+            // the gamepad stick follows the Standard/Reversed setting exactly
+            // like keys do — a geometric stick was shipped first and the user
+            // immediately reported it as inverted (2026-07-11): the Standard
+            // scheme IS the muscle memory here, whatever the input device.
+            steerInput = clamp((touchSteer + keySteer + mouse + padSteer) * (steerReversed ? 1 : -1), -1, 1);
         }
 
         // ---------------------------------------------------------------

--- a/apps/fablekart/sw.js
+++ b/apps/fablekart/sw.js
@@ -5,7 +5,7 @@
 // pinned CDN script. Everything else (worker API, websockets, cross-origin)
 // is deliberately NOT intercepted — multiplayer must never hit a stale cache.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'fablekart-v2';
+const CACHE = 'fablekart-v3';
 const THREE_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js';
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];

--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -173,7 +173,7 @@ function readInsets(cw, chh) {
   if (navigator.standalone) {
     const notched = Math.max(screen.width, screen.height) >= 780;
     if (cw > chh) {   // landscape
-      if (notched && botCss < 8) botCss = 21;
+      if (notched && botCss < 10) botCss = 21;
       if (notched && leftCss < 10 && rightCss < 10) leftCss = rightCss = 44;
     } else {
       if (topCss < 20) topCss = notched ? 47 : 20;

--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -68,7 +68,7 @@ const MAX_SPEED = 3.05;
 const PIT_Y = 11 * TILE;             // below this = pit death
 const WORLD_LEN = 500;               // tiles per world before the flag
 const SAVE = 'pixelrun_';
-const VERSION = 44;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
+const VERSION = 45;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
 
 // ---------- utils ----------
 const clamp = (v, a, b) => v < a ? a : v > b ? b : v;
@@ -104,12 +104,23 @@ let W = 240, H = 420, SCALE = 2;
 let lastSize = '';
 function resize() {
   const dpr = window.devicePixelRatio || 1;
-  // measure the element and every viewport report, take the largest —
-  // iOS standalone lags these at launch/rotation
+  // CSS media orientation is the one report iOS keeps truthful through a
+  // standalone rotation — innerWidth/Height and screen.* can sit in the OLD
+  // orientation for a while, and our own canvas style feeds back through the
+  // element rect. Maxing raw axes let a stale portrait height (844) win in
+  // landscape → an 844×844 canvas on a 390-tall screen, bottom half cut off.
+  // So: orient every (w,h) source to the CSS orientation, THEN take the
+  // per-axis max (which still covers the launch-lag case max() was for).
+  const landscape = window.matchMedia('(orientation: landscape)').matches;
   const vv = window.visualViewport;
   const rect = canvas.getBoundingClientRect();
-  let cw = Math.round(Math.max(window.innerWidth, vv ? vv.width : 0, rect.width));
-  let chh = Math.round(Math.max(window.innerHeight, vv ? vv.height : 0, rect.height));
+  let cw = 0, chh = 0;
+  for (const [pw, ph] of [[window.innerWidth, window.innerHeight],
+                          [vv ? vv.width : 0, vv ? vv.height : 0],
+                          [rect.width, rect.height]]) {
+    cw = Math.max(cw, Math.round(landscape ? Math.max(pw, ph) : Math.min(pw, ph)));
+    chh = Math.max(chh, Math.round(landscape ? Math.min(pw, ph) : Math.max(pw, ph)));
+  }
   // Some iOS versions size the standalone layout viewport SHORT of the home
   // indicator, so 100dvh / inset:0 / innerHeight all agree on a height that ends
   // above the screen bottom (the bar). The physical screen doesn't lie: extend the
@@ -117,8 +128,8 @@ function resize() {
   // and the inset math below then measures the home-indicator gap naturally.
   if (navigator.standalone && screen && screen.width) {
     const sMin = Math.min(screen.width, screen.height), sMax = Math.max(screen.width, screen.height);
-    if (chh >= cw) { cw = Math.max(cw, sMin); chh = Math.max(chh, sMax); }
-    else { cw = Math.max(cw, sMax); chh = Math.max(chh, sMin); }
+    cw = Math.max(cw, landscape ? sMax : sMin);
+    chh = Math.max(chh, landscape ? sMin : sMax);
   }
   // insets are cheap — refresh them on EVERY call. env() resolves late on iOS,
   // and if the first size measurement is already correct no further resize fires,
@@ -127,7 +138,7 @@ function resize() {
   const sig = cw + 'x' + chh + '@' + dpr;
   if (sig === lastSize) return;
   lastSize = sig;
-  const portrait = chh >= cw;
+  const portrait = !landscape;
   // landscape targets H≈240 so sprites keep the same on-screen size as
   // portrait (which targets W≈250) — rotating must not zoom the world out
   SCALE = portrait
@@ -153,23 +164,34 @@ function readInsets(cw, chh) {
   probe.remove();
   let topCss = r.top;
   let botCss = Math.max(0, chh - r.bottom);
+  let leftCss = r.left, rightCss = Math.max(0, cw - r.right);
   // env() can report 0 before iOS settles; in a standalone app that is never true —
-  // fall back to device-class status-bar / home-indicator heights until it resolves
+  // fall back to device-class geometry until it resolves. The floors are
+  // ORIENTATION-SPECIFIC: landscape hides the status bar entirely (forcing the
+  // portrait 47px top floor there wasted a fifth of the short screen), moves
+  // the notch to the sides, and slims the home indicator to 21px.
   if (navigator.standalone) {
     const notched = Math.max(screen.width, screen.height) >= 780;
-    if (topCss < 20) topCss = notched ? 47 : 20;
-    if (notched && botCss < 10) botCss = 34;
+    if (cw > chh) {   // landscape
+      if (notched && botCss < 8) botCss = 21;
+      if (notched && leftCss < 10 && rightCss < 10) leftCss = rightCss = 44;
+    } else {
+      if (topCss < 20) topCss = notched ? 47 : 20;
+      if (notched && botCss < 10) botCss = 34;
+    }
   }
   const s = (window.devicePixelRatio || 1) / SCALE;
   safeTop = Math.ceil(topCss * s);
   safeBot = Math.ceil(botCss * s);
-  safeL = Math.ceil(r.left * s);
-  safeR = Math.ceil(Math.max(0, cw - r.right) * s);
+  safeL = Math.ceil(leftCss * s);
+  safeR = Math.ceil(rightCss * s);
 }
 window.addEventListener('resize', resize);
-window.addEventListener('orientationchange', () => setTimeout(resize, 250));
+window.addEventListener('orientationchange', () => { setTimeout(resize, 250); setTimeout(resize, 700); });
 window.addEventListener('pageshow', () => setTimeout(resize, 60));
 if (window.visualViewport) window.visualViewport.addEventListener('resize', resize);
+// the CSS orientation flip is the signal the whole sizing keys on — listen to it directly
+try { window.matchMedia('(orientation: landscape)').addEventListener('change', () => { resize(); setTimeout(resize, 250); }); } catch (e) {}
 setTimeout(resize, 350);        // iOS standalone reports the real viewport late
 setTimeout(resize, 1200);       // …and sometimes very late
 resize();
@@ -5246,9 +5268,13 @@ function renderTitle() {
     drawTextC(ctx, 'TAP TO START', W / 2, tapY, 2, '#ffe97a', '#1a1c2c');
   if (game.frame - pad.toastT < 160)
     drawTextC(ctx, 'CONTROLLER CONNECTED', W / 2, tapY + 18, 1, '#7dffb0', '#1a1c2c');
-  drawTextC(ctx, 'TAP: JUMP   AIR TAP: DOUBLE JUMP', W / 2, H - 68 - safeBot, 1, '#fff', '#1a1c2c');
-  drawTextC(ctx, 'SWIPE DOWN: SLAM / DIVE', W / 2, H - 58 - safeBot, 1, '#fff', '#1a1c2c');
-  drawTextC(ctx, 'SLAM A ↓ PIPE TO EXPLORE', W / 2, H - 48 - safeBot, 1, '#ffe97a', '#1a1c2c');
+  if (land)   // one line — three stacked rows collide with the menu column on short screens
+    drawTextC(ctx, 'TAP: JUMP   SWIPE DOWN: SLAM   SLAM A ↓ PIPE', W / 2, H - 44 - safeBot, 1, '#fff', '#1a1c2c');
+  else {
+    drawTextC(ctx, 'TAP: JUMP   AIR TAP: DOUBLE JUMP', W / 2, H - 68 - safeBot, 1, '#fff', '#1a1c2c');
+    drawTextC(ctx, 'SWIPE DOWN: SLAM / DIVE', W / 2, H - 58 - safeBot, 1, '#fff', '#1a1c2c');
+    drawTextC(ctx, 'SLAM A ↓ PIPE TO EXPLORE', W / 2, H - 48 - safeBot, 1, '#ffe97a', '#1a1c2c');
+  }
   // stats on a dark card — tiny colored text straight on the sky was unreadable
   const stats = [];
   if (game.best > 0) stats.push(['BEST ' + game.best + '   ' + game.bestDist + 'M', '#bfe8ff']);

--- a/apps/pixelrun/sw.js
+++ b/apps/pixelrun/sw.js
@@ -2,7 +2,7 @@
 // shell makes it fully playable offline. Strategy is stale-while-revalidate —
 // instant load from cache, silently refreshed from the network for next launch.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'pixelrun-v39';
+const CACHE = 'pixelrun-v40';
 const SHELL = ['./', './index.html', './icon.png', './apple-touch-icon.png', './icon-192.png', './manifest.webmanifest'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
## Pixel Run V45 (sw v40): the real iPhone landscape bug

V44's landscape looked right headless but broke on-device because of how iOS standalone reports sizes after rotation: the CSS viewport rotates, but `innerWidth`/`innerHeight` and `screen.*` keep the OLD orientation for a while (and `screen.*` never rotates at all on iOS). `resize()` took the per-axis **max of all reports**, so the stale portrait height (844) won in landscape → an **844×844 canvas on a 390pt-tall screen** — the bottom half of every screen was simply off-canvas. The canvas's own inline style then fed the wrong size back through `getBoundingClientRect()` on every subsequent resize.

- `resize()` now orients every (w,h) source pair to the **CSS media orientation** (the one report iOS keeps truthful) before taking the per-axis max — the max still covers the launch-lag case it existed for.
- Listens to the `(orientation: landscape)` MediaQueryList directly, plus a second delayed `orientationchange` pass at 700ms.
- `readInsets()` fallback floors are now orientation-specific: landscape has **no status bar** (the forced 47px top floor was wasting a fifth of the short screen), the notch moves to the side insets (44px floor), and the home indicator slims to 21px.
- Landscape title instructions compress to one line — three stacked rows collide with the menu column on short screens.
- Rotation reflows live in **both directions**, including mid-run.

## Fable Kart APP_VER 39 (sw v3): stick joins the Standard/Reversed setting

The geometric-always stick shipped in #287 was immediately reported as inverted. `padSteer` now sits **inside** the Standard/Reversed flip in `computeSteer()`, exactly like touch/keys/mouse — the Standard scheme is the muscle memory on every input device. CLAUDE.md updated so this doesn't get "fixed" back.

## Verification (headless CDP)

- Live window rotation portrait→landscape→portrait: correct W/H/SCALE each step, identical portrait layout after the round trip, mid-game rotation keeps playing at the new size.
- Spoofed the exact iPhone failure (stale portrait `innerWidth/innerHeight`, portrait-locked `screen.*`, `navigator.standalone`, CSS orientation landscape): v45 sizes the canvas 844×390 with safeTop 0 + side notch insets (v44 produced the 844×844 cut-off).
- Kart: stick-right held from the start line now veers the kart left (Standard), screenshot-verified — previously verified veering right (geometric).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fcibXj5NnHHSGBiSh51Et