### PR TITLE
Pixel Run v46: bonus-vault death restores the surface world + sandbar coin fix

### DIFF
--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -68,7 +68,7 @@ const MAX_SPEED = 3.05;
 const PIT_Y = 11 * TILE;             // below this = pit death
 const WORLD_LEN = 500;               // tiles per world before the flag
 const SAVE = 'pixelrun_';
-const VERSION = 45;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
+const VERSION = 46;                  // shown on the title screen — bump once per PR (see CLAUDE.md)
 
 // ---------- utils ----------
 const clamp = (v, a, b) => v < a ? a : v > b ? b : v;
@@ -2307,6 +2307,7 @@ function canSecondWind() {
   return !game.secondWindUsed && !game.testRun && game.coinsAll >= secondWindCost();
 }
 function secondWind() {
+  endBonus();   // downed in a vault: revive on the main track, exit check disarmed
   game.coinsAll -= secondWindCost(); store('coinsAll', game.coinsAll);
   game.secondWindUsed = true;
   player.x = game.lastSafeX - 8;
@@ -3593,6 +3594,17 @@ function leaveBonus() {
   sfx.pipe(); buzz(2);
 }
 
+function endBonus() {
+  // leaving a vault by dying or quitting, not through the portal: the pipe-out
+  // ride never runs, so restore the surface world's theme and disarm the exit
+  // check here — a revived/next run in the main world (x > exitX) would
+  // otherwise trigger leaveBonus and teleport back onto the warp pipe
+  if (!game.inBonus) return;
+  game.themeIdx = game.inBonus.theme; game.themeFade = 0;
+  game.inBonus = null;
+  tintPage();
+}
+
 function startBubble() {
   player.mode = 'bubble'; player.bubbleT = 0; player.vy = 0; player.slam = false;
   player.targetX = null;
@@ -3641,6 +3653,7 @@ function die() {
   playSong('over'); buzz(4); game.shake = 7;
 }
 function gameOver() {
+  endBonus();   // died in a vault: the card and backdrop show the real world
   game.state = 'over'; game.stateT = 0;
   if (game.testRun) { game.newBest = false; return; }   // level-select runs don't count
   game.coinsAll += game.coins; store('coinsAll', game.coinsAll);
@@ -4339,6 +4352,7 @@ function unlockAudio() {
   if (!audio.song && game.state === 'title') playSong('title');
 }
 function goTitle() {
+  endBonus();   // quit from inside a vault: the sky must come back with you
   // the title always wears WORLD 1's face — a test run at world 8 used to
   // leave its theme behind, showing Magma Keep over a start that plays hills
   game.state = 'title'; game.stateT = 0;

--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -2793,7 +2793,6 @@ const patterns = [
     AQCOL(-1); AQCOL(1); AQCOL(3); AQCOL(5);    // quick shoal — you swim over it
     const len = RI(6, 12), x0 = gen.x;
     for (let i = 0; i < len; i++) C(SAND_G);    // a thin bar of dry sand
-    coinRow(x0 + 1, -SAND_G - 2, Math.min(5, len - 1));
     if (len >= 9 && gen.totalTiles - gen.lastWarp > 220 && rng() < 0.5) {
       // the cove's warp pipe lives on its islands — grotto access restored
       gen.lastWarp = gen.totalTiles;
@@ -2805,6 +2804,9 @@ const patterns = [
     } else if (rng() < 0.5) {
       qblock(x0 + Math.floor(len / 2), -SAND_G - 4, qContents());
     }
+    // coins AFTER the pipe: at len 9 the left cap lands on the row's last cell
+    // (-SAND_G - 2), and coinAt can only skip occupied cells it can see
+    coinRow(x0 + 1, -SAND_G - 2, Math.min(5, len - 1));
     if (len > 8 && rng() < 0.4) {
       spawnEnemy('chomp', x0 + 2, SAND_G);
       ents[ents.length - 1].ledge = 1;          // beach chompers stay on the beach

--- a/apps/pixelrun/index.html
+++ b/apps/pixelrun/index.html
@@ -3597,10 +3597,11 @@ function leaveBonus() {
 }
 
 function endBonus() {
-  // leaving a vault by dying or quitting, not through the portal: the pipe-out
-  // ride never runs, so restore the surface world's theme and disarm the exit
-  // check here — a revived/next run in the main world (x > exitX) would
-  // otherwise trigger leaveBonus and teleport back onto the warp pipe
+  // leaving a vault by dying (gameOver / secondWind), not through the portal:
+  // the pipe-out ride never runs, so restore the surface world's theme and
+  // disarm the exit check here — a revived/next run in the main world
+  // (x > exitX) would otherwise trigger leaveBonus and teleport back onto
+  // the warp pipe. (goTitle disarms inline; it resets the theme itself.)
   if (!game.inBonus) return;
   game.themeIdx = game.inBonus.theme; game.themeFade = 0;
   game.inBonus = null;
@@ -4354,7 +4355,9 @@ function unlockAudio() {
   if (!audio.song && game.state === 'title') playSong('title');
 }
 function goTitle() {
-  endBonus();   // quit from inside a vault: the sky must come back with you
+  // quit from inside a vault: disarm the bonus exit state — no endBonus() theme
+  // restore here, the lines below reset the theme and tint to WORLD 1 anyway
+  game.inBonus = null;
   // the title always wears WORLD 1's face — a test run at world 8 used to
   // leave its theme behind, showing Magma Keep over a start that plays hills
   game.state = 'title'; game.stateT = 0;

--- a/apps/pixelrun/sw.js
+++ b/apps/pixelrun/sw.js
@@ -2,7 +2,7 @@
 // shell makes it fully playable offline. Strategy is stale-while-revalidate —
 // instant load from cache, silently refreshed from the network for next launch.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'pixelrun-v40';
+const CACHE = 'pixelrun-v41';
 const SHELL = ['./', './index.html', './icon.png', './apple-touch-icon.png', './icon-192.png', './manifest.webmanifest'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
Two bug fixes.

**1. Dying or quitting in a bonus vault restores the surface world.**
Dying inside a bonus room (vault spikes / grotto fish on the last heart)
left `game.inBonus` set and `themeIdx` stuck on the vault's palette. That
made the game-over card name the wrong world theme, drew the underground
cave-wall backdrop on the title screen after BACK TO TITLE or a pause
QUIT TO TITLE from inside a vault, and armed a stale exit check: a
SECOND WIND revival at the main-world `lastSafeX` satisfied
`x > inBonus.exitX` immediately, so `leaveBonus()` yanked the revived
player back onto the warp pipe one frame later.

New `endBonus()` restores the theme and disarms the exit state in
`gameOver()` and `secondWind()`; `goTitle()` disarms inline since it
resets the theme to WORLD 1 itself (review feedback: avoids a wasted
theme-restore + double `tintPage()`). The normal portal exit is
untouched.

**2. Sandbar coin row no longer buried inside the warp pipe cap.**
On Tidal Cove sandbar islands the coin row was laid before the warp
pipe, and at island length 9 the pipe's left cap (`put` at
`-SAND_G - 2`) landed exactly on the row's last cell — a coin embedded
in the cap, visible but uncollectable. The row now goes in after the
pipe/qblock so `coinAt`'s occupied-cell guard can skip that cell,
matching the "blocks and terrain first, coins second" rule used
everywhere else. Neither call consumes rng, so seeded layouts are
otherwise unchanged.

**Verification** (headless via the `__dbg` harness): all three vault
escape paths plus the portal round-trip, bot free-runs, the boss
gauntlet (win, 0 errors), and a sweep of all 8 worlds × 5 seeds
asserting no resting coin occupies a solid tile or ground cell
(3 embeds found before the coin fix, 0 after).

Cache bumped to v41 so installed players get the fix promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXZG8G6ZYgrQxeH1ACSQEk