### PR TITLE
Wreck & Ruin V2: unbury the wrecking ball — rig geometry, camera, iOS fixes

### DIFF
--- a/apps/wreck/CLAUDE.md
+++ b/apps/wreck/CLAUDE.md
@@ -33,8 +33,23 @@ must reach installed players promptly.
   failsafe rebuilds the rig if the ball ever ends up > 2.5× chain length
   from the anchor (`rig.resets` counts this; expect 0 in normal play, ~1 per
   1600-step slew-reversal torture run — more than that means a regression).
-- Winch = the anchor sliding down a virtual rail from boom tip to near
-  ground; the visual hoist cable stretches tip→anchor. Boom pitch is fixed.
+- Winch = the anchor sliding down a virtual rail (`anchorRailY`): the top is
+  just under the boom sheave (ball hangs FREE and can swing), the bottom
+  leaves ~1.2m of chain slack so the ball rests and ploughs — the anchor must
+  never press-fit a taut chain into the terrain (that press-fit read as an
+  endless solver buzz, mean link vel ~2.5 m/s at "rest"). The visual hoist
+  cable stretches tip→anchor. Boom pitch is fixed (15m boom @ 1.18 rad).
+- **LAW: every chain + ball hang must stay ~2m shorter than the anchor top
+  (~16.2m over flat ground)** or the winch can never lift the ball. The
+  original 8–15m chains under a 10m boom left every loadout dragging in the
+  dirt with a 4cm total winch range (verified) — that's why chains are now
+  5/7/9 links.
+- `buildRig()` spawns every link and the ball clamped ABOVE `terrainH`: the
+  old straight drop from the tip buried the ball ~2m inside the paper-thin
+  heightfield, which depenetrated it DOWNWARD — the ball then lived under the
+  map, invisible and useless, for the whole session. The failsafe also
+  rebuilds the rig if the ball center is ever a full radius below terrainH
+  (tunnel recovery).
 - Collision groups: world/blocks 0x0001 (filter 7), chain+ball 0x0002
   (filter 1 — no self-collision, no truck), truck kinematic 0x0004 (filter 1).
 - **Truck is kinematic**, driven by an arcade model on the terrain *function*
@@ -60,6 +75,16 @@ with the chunk. Impact shards: `burst()` pool, purely visual.
 `world.numSolverIterations` was verified to be a real accessor on
 rapier3d-compat 0.19.3 (prototype getter/setter — not a silent expando).
 
+**Camera is a POLAR chase**: `cam.yaw` eases toward truck yaw but the position
+is rigidly `truck − dir(cam.yaw)·19` — the vehicle physically cannot leave the
+frame; only the shot angle lags in turns. (A positional lerp here trailed
+turning trucks by ~25° of arc and parked the vehicle at the screen edge.) It
+must track the INTERPOLATED truck pose (`ix/iyaw` in `syncVisuals`) — raw
+60Hz poses strobe on 120Hz phones. `resize()` orients `innerWidth/Height` to
+the CSS media orientation and listens on the orientation MediaQueryList —
+iOS standalone keeps stale JS viewport numbers after rotation (same bug
+PR #288 fixed for Pixel Run).
+
 ## World generation
 
 Deterministic from lot index: `lotAt(k)` at x≈30k, alternating road sides,
@@ -80,7 +105,10 @@ rebuild the rig (`buildRig()`).
 
 `window.__dbg`: `snapshot()`, `stepN(n)` (sync fast-forward), `auto`
 (bot ctrl override `{throttle, steer, slew, winch}`), `terrainProbe()`,
-`lotAt`, `rig`, `errors`. Drive headless via the scratchpad `drive.mjs` CDP
+`equip(slot, id)` (swap gear + rebuild rig), `camera` (project world points
+to NDC for framing asserts), `lotAt`, `rig`, `errors`. NOTE: `stepN` batches
+call `syncVisuals` only once — camera-convergence checks must interleave
+small `stepN` calls or run on the live RAF loop. Drive headless via the scratchpad `drive.mjs` CDP
 harness (`--url http://localhost:8765/apps/wreck/index.html`). Gamepad is
 testable by stubbing `navigator.getGamepads` (leave ≥2 frames between
 press/release so edges are sampled). Icons regenerate from `gen-icon.html`

--- a/apps/wreck/index.html
+++ b/apps/wreck/index.html
@@ -1137,12 +1137,13 @@ function buildRig() {
     const y = tp.y - 1 - (i + 0.5) * L;
     const rb = world.createRigidBody(RAPIER.RigidBodyDesc.dynamic()
       .setTranslation(tp.x, y, tp.z).setCcdEnabled(true)
-      .setAngularDamping(0.7).setLinearDamping(0.06));
+      .setAngularDamping(1.2).setLinearDamping(0.25));   // high damping: slack chain must lie calm, not buzz
     // links are absurdly dense on purpose: the solver can only hold a joint
     // chain together when the ball outweighs a link by ~10x, not ~100x —
     // so link mass scales with whatever ball is equipped
     world.createCollider(RAPIER.ColliderDesc.capsule(L / 2 - rig.linkR, rig.linkR)
-      .setDensity(linkDensity).setCollisionGroups(G_CHAIN), rb);
+      .setDensity(linkDensity).setFriction(0.15).setRestitution(0)
+      .setCollisionGroups(G_CHAIN), rb);
     rig.joints.push(world.createImpulseJoint(
       RAPIER.JointData.spherical(prevAnchor, { x: 0, y: L / 2, z: 0 }), prev, rb, true));
     prev = rb; prevAnchor = { x: 0, y: -L / 2, z: 0 };
@@ -1153,7 +1154,7 @@ function buildRig() {
   const R = rig.ballDef.r;
   rig.ball = world.createRigidBody(RAPIER.RigidBodyDesc.dynamic()
     .setTranslation(tp.x, tp.y - 1 - LINKS * L - R, tp.z).setCcdEnabled(true)
-    .setAngularDamping(0.5).setLinearDamping(0.03));
+    .setAngularDamping(0.7).setLinearDamping(0.05));
   const bc = world.createCollider(RAPIER.ColliderDesc.ball(R)
     .setDensity(rig.ballDef.density).setCollisionGroups(G_CHAIN)
     .setActiveEvents(RAPIER.ActiveEvents.CONTACT_FORCE_EVENTS)
@@ -1181,6 +1182,21 @@ function buildRig() {
   const cable = new THREE.Mesh(new THREE.CylinderGeometry(0.06, 0.06, 1, 6),
     new THREE.MeshBasicMaterial({ color: 0x30343c }));
   scene.add(cable); rig.cable = cable;
+  // previous-step transforms for render interpolation (the sim is 60Hz; on a
+  // 120Hz phone, rendering raw physics poses made the chain look like it was
+  // vibrating — every other frame showed no movement)
+  rig.prev = [...rig.links, rig.ball].map(b => {
+    const p = b.translation(), r = b.rotation();
+    return { p: new THREE.Vector3(p.x, p.y, p.z), q: new THREE.Quaternion(r.x, r.y, r.z, r.w) };
+  });
+}
+function snapshotRig() {
+  const bodies = [...rig.links, rig.ball];
+  for (let i = 0; i < bodies.length; i++) {
+    const p = bodies[i].translation(), r = bodies[i].rotation();
+    rig.prev[i].p.set(p.x, p.y, p.z);
+    rig.prev[i].q.set(r.x, r.y, r.z, r.w);
+  }
 }
 
 // ===================================================================
@@ -1336,6 +1352,7 @@ function step(dt) {
   readInput();
   if (state !== 'play') { ctrl.throttle = ctrl.steer = ctrl.slew = ctrl.winch = 0; }
   if (window.__dbg && window.__dbg.auto) Object.assign(ctrl, window.__dbg.auto);   // headless bot override
+  truck.px = truck.x; truck.pz = truck.z; truck.pyaw = truck.yaw; truck.pcab = truck.cabYaw;   // for render interpolation
   const eng = equipped('engine'), win = equipped('winch');
   // ---- drive (arcade kinematics on the height function) ----
   const target = ctrl.throttle * eng.speed;
@@ -1373,14 +1390,23 @@ function step(dt) {
   if (tl > MAXSTEP) v3b.multiplyScalar(MAXSTEP / tl);
   rig.tipPos.add(v3b);
   rig.tip.setNextKinematicTranslation({ x: rig.tipPos.x, y: rig.tipPos.y, z: rig.tipPos.z });
-  // ball speed ceiling: collision ejections can inject huge energy in one
-  // step, and it compounds through the joints — clamp before it cascades
+  // speed ceilings: collision ejections (a link pinched between falling
+  // blocks, the ball wedged under a slab) inject huge energy in one step and
+  // it compounds through the joints — clamp everything before it cascades
   {
     const bv = rig.ball.linvel();
     const sp2 = bv.x * bv.x + bv.y * bv.y + bv.z * bv.z;
     if (sp2 > 55 * 55) {
       const s = 55 / Math.sqrt(sp2);
       rig.ball.setLinvel({ x: bv.x * s, y: bv.y * s, z: bv.z * s }, true);
+    }
+    for (const l of rig.links) {
+      const lv = l.linvel();
+      const l2 = lv.x * lv.x + lv.y * lv.y + lv.z * lv.z;
+      if (l2 > 70 * 70) {
+        const s = 70 / Math.sqrt(l2);
+        l.setLinvel({ x: lv.x * s, y: lv.y * s, z: lv.z * s }, true);
+      }
     }
   }
   // failsafe: if the solver ever loses the chain anyway, quietly rebuild it
@@ -1404,6 +1430,7 @@ function step(dt) {
   }
 
   // ---- physics ----
+  snapshotRig();   // remember pre-step poses for render interpolation
   world.step(eventQueue);
   eventQueue.drainContactForceEvents(ev => {
     const c1 = ev.collider1(), c2 = ev.collider2();
@@ -1448,16 +1475,40 @@ function step(dt) {
 // ===================================================================
 //  render sync
 // ===================================================================
-function syncVisuals(dt) {
-  // chain + ball meshes track bodies
+const lerpQ = new THREE.Quaternion();
+function syncVisuals(dt, alpha) {
+  // chain + ball meshes: interpolate between the last two physics poses —
+  // rendering raw 60Hz poses on a 120Hz screen reads as violent jitter
+  const a = alpha === undefined ? 1 : alpha;
   for (let i = 0; i < rig.links.length; i++) {
     const p = rig.links[i].translation(), r = rig.links[i].rotation();
-    rig.linkMeshes[i].position.set(p.x, p.y, p.z);
-    rig.linkMeshes[i].quaternion.set(r.x, r.y, r.z, r.w);
+    const pv = rig.prev[i];
+    rig.linkMeshes[i].position.set(lerp(pv.p.x, p.x, a), lerp(pv.p.y, p.y, a), lerp(pv.p.z, p.z, a));
+    rig.linkMeshes[i].quaternion.copy(pv.q).slerp(lerpQ.set(r.x, r.y, r.z, r.w), a);
   }
-  const bp = rig.ball.translation(), br = rig.ball.rotation();
+  const bp0 = rig.prev[rig.prev.length - 1];
+  const bpc = rig.ball.translation(), br = rig.ball.rotation();
+  const bp = { x: lerp(bp0.p.x, bpc.x, a), y: lerp(bp0.p.y, bpc.y, a), z: lerp(bp0.p.z, bpc.z, a) };
   rig.ballMesh.position.set(bp.x, bp.y, bp.z);
-  rig.ballMesh.quaternion.set(br.x, br.y, br.z, br.w);
+  rig.ballMesh.quaternion.copy(bp0.q).slerp(lerpQ.set(br.x, br.y, br.z, br.w), a);
+  // the truck's VISUAL pose interpolates too (physics/anchor math in step()
+  // uses the exact 60Hz pose; this overwrite is render-only)
+  {
+    const ix = lerp(truck.px !== undefined ? truck.px : truck.x, truck.x, a);
+    const iz = lerp(truck.pz !== undefined ? truck.pz : truck.z, truck.z, a);
+    let dyaw = truck.yaw - (truck.pyaw !== undefined ? truck.pyaw : truck.yaw);
+    while (dyaw > Math.PI) dyaw -= 2 * Math.PI;
+    while (dyaw < -Math.PI) dyaw += 2 * Math.PI;
+    const iyaw = (truck.pyaw !== undefined ? truck.pyaw : truck.yaw) + dyaw * a;
+    const hI = terrainH(ix, iz);
+    const hF = terrainH(ix + Math.cos(iyaw) * 2.6, iz - Math.sin(iyaw) * 2.6);
+    const hS = terrainH(ix + Math.sin(iyaw) * 1.4, iz + Math.cos(iyaw) * 1.4);
+    truck.group.position.set(ix, hI, iz);
+    truck.group.rotation.set(0, iyaw, 0, 'YXZ');
+    truck.group.rotateZ(Math.atan2(hF - hI, 2.6));
+    truck.group.rotateX(-Math.atan2(hS - hI, 1.4));
+    crane.group.rotation.y = lerp(truck.pcab !== undefined ? truck.pcab : truck.cabYaw, truck.cabYaw, a);
+  }
   // beacon blink (faster while moving)
   beacon.t += dt * (2 + Math.abs(truck.speed) * 0.4);
   beacon.mesh.material.color.setHex((beacon.t | 0) % 2 === 0 ? 0xff7a00 : 0x6b3200);
@@ -1481,9 +1532,14 @@ function syncVisuals(dt) {
     d.material.opacity = Math.max(0, d.userData.life * 0.5);
     if (d.userData.life <= 0) d.visible = false;
   }
-  // camera: chase the truck, peek toward the ball
-  const back = 19.5, up = 11;
-  v3b.set(truck.x - Math.cos(truck.yaw) * back, terrainH(truck.x, truck.z) + up, truck.z + Math.sin(truck.yaw) * back);
+  // camera: locked chase behind the truck, TRUCK-CENTERED. The old look-at
+  // blended 40% toward the ball, so after any slewing the whole vehicle
+  // drifted off-frame ("my boom is off to the right side of the screen").
+  // Ball influence is now a small CLAMPED nudge — the truck always anchors
+  // the shot and the full rig stays in view.
+  const back = 18, up = 10;
+  const hT = terrainH(truck.x, truck.z);
+  v3b.set(truck.x - Math.cos(truck.yaw) * back, hT + up, truck.z + Math.sin(truck.yaw) * back);
   camPos.lerp(v3b, 1 - Math.exp(-dt * 3.2));
   const sh = game.shake;
   if (sh > 0.01) {
@@ -1491,8 +1547,14 @@ function syncVisuals(dt) {
     game.shake *= Math.pow(0.02, dt);
   }
   camera.position.copy(camPos);
-  camLook.lerp(v3b.set(truck.x * 0.6 + bp.x * 0.4, (terrainH(truck.x, truck.z) + 3) * 0.65 + bp.y * 0.35,
-    truck.z * 0.6 + bp.z * 0.4), 1 - Math.exp(-dt * 4));
+  let nx = bp.x - truck.x, nz = bp.z - truck.z;             // ball nudge, capped at 3.5m
+  const nl = Math.hypot(nx, nz);
+  if (nl > 3.5) { nx *= 3.5 / nl; nz *= 3.5 / nl; }
+  const ny = clamp((bp.y - hT) * 0.15, 0, 2.5);
+  camLook.lerp(v3b.set(
+    truck.x + Math.cos(truck.yaw) * 3 + nx * 0.6,
+    hT + 3 + ny,
+    truck.z - Math.sin(truck.yaw) * 3 + nz * 0.6), 1 - Math.exp(-dt * 4));
   camera.lookAt(camLook);
   // sun + shadow box follow; sky dome and mountains ride along (infinitely far)
   sun.position.set(truck.x + 30, 60, truck.z + 18);
@@ -1604,7 +1666,7 @@ function frame(ts) {
     readInput();   // paused/garage: the sim is stopped but the controller must still navigate
   }
   fragTick(dt);
-  syncVisuals(dt);
+  syncVisuals(dt, clamp(acc / STEP, 0, 1));   // interpolation fraction between physics steps
   renderer.render(scene, camera);
 }
 requestAnimationFrame(frame);

--- a/apps/wreck/index.html
+++ b/apps/wreck/index.html
@@ -166,7 +166,7 @@ import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
 import { RoundedBoxGeometry } from 'three/addons/geometries/RoundedBoxGeometry.js';
 import RAPIER from 'rapier';
 
-const VERSION = 1;   // bump once per PR (see CLAUDE.md)
+const VERSION = 2;   // bump once per PR (see CLAUDE.md)
 try {
 
 // ===================================================================
@@ -194,12 +194,15 @@ const BALLS = [
   { id: 'iron',  nm: 'CAST IRON',      ds: 'The classic. Reliable, round, angry.', cost: 0,    r: 1.5, density: 4,  color: 0x3a4048, coinMul: 1 },
   { id: 'big',   nm: 'BIG BERTHA',     ds: 'Half a ton of extra persuasion.',      cost: 600,  r: 2.1, density: 5,  color: 0x51322a, coinMul: 1 },
   { id: 'spike', nm: 'SPIKE STAR',     ds: 'Bites into walls. Shatters on impact.', cost: 1400, r: 1.6, density: 4.5, color: 0x6e6e78, coinMul: 1, spike: true },
-  { id: 'gold',  nm: 'GOLD GOLIATH',   ds: 'Heaviest. Shiniest. +50% coins.',      cost: 3200, r: 2.3, density: 6,  color: 0xffc24a, coinMul: 1.5 },
+  { id: 'gold',  nm: 'GOLD GOLIATH',   ds: 'Heaviest. Shiniest. +50% coins.',      cost: 3200, r: 2.0, density: 6.5, color: 0xffc24a, coinMul: 1.5 },
 ];
+// chain length + ball hang must stay comfortably SHORTER than the boom tip
+// height (~16.2m anchor) or the winch can never lift the ball off the ground
+// — even the gold+CRANE KING combo needs ~2m of flat-ground clearance
 const CHAINS = [
-  { id: 'chain1', nm: 'WORKS CHAIN',   ds: '8m of honest steel.',   cost: 0,   links: 7 },
-  { id: 'chain2', nm: 'LONG CHAIN',    ds: '11m. Wider arcs, bigger swings.', cost: 500, links: 10 },
-  { id: 'chain3', nm: 'CRANE KING',    ds: '14m. Wrecking-ball artillery.',   cost: 1100, links: 13 },
+  { id: 'chain1', nm: 'WORKS CHAIN',   ds: '6m of honest steel. High, fast swings.', cost: 0,   links: 5 },
+  { id: 'chain2', nm: 'LONG CHAIN',    ds: '8m. Wider arcs, bigger swings.', cost: 500, links: 7 },
+  { id: 'chain3', nm: 'CRANE KING',    ds: '10m. Wrecking-ball artillery.',   cost: 1100, links: 9 },
 ];
 const ENGINES = [
   { id: 'eng1', nm: 'DIESEL 4',  ds: 'Gets you there. Eventually.', cost: 0,   speed: 11, accel: 14 },
@@ -459,12 +462,19 @@ const mountains = new THREE.Group();
   }
 }
 
+// iOS standalone can keep innerWidth/innerHeight in the OLD orientation after
+// rotating (the CSS viewport rotates, the JS numbers don't — same bug PR #288
+// fixed for Pixel Run). Orient the reported pair to the CSS media orientation
+// so the buffer/aspect never end up portrait-sized on a landscape screen.
+const landscapeMQ = matchMedia('(orientation: landscape)');
 function resize() {
-  const w = innerWidth, h = innerHeight;
+  let w = innerWidth, h = innerHeight;
+  if (landscapeMQ.matches === (h > w)) { const t = w; w = h; h = t; }
   renderer.setSize(w, h, false);
   camera.aspect = w / h; camera.updateProjectionMatrix();
 }
 window.addEventListener('resize', resize);
+landscapeMQ.addEventListener('change', () => { resize(); setTimeout(resize, 250); });
 window.addEventListener('orientationchange', () => { setTimeout(resize, 250); setTimeout(resize, 700); });
 resize();
 
@@ -947,7 +957,7 @@ function syncBlock(b) {
 //  the truck — kinematic arcade body carrying a crane
 // ===================================================================
 const truck = {
-  x: 0, z: 0, yaw: 0, speed: 0, cabYaw: 0, winchT: 0.12,   // winchT: 0=high, 1=low
+  x: 0, z: 0, yaw: 0, speed: 0, cabYaw: 0, winchT: 0.25,   // winchT: 0=high, 1=low
   body: null, group: new THREE.Group(),
 };
 truck.z = roadZ(0);
@@ -1016,7 +1026,10 @@ const beacon = { mesh: null, t: 0 };
   scene.add(g);
 }
 // crane assembly (child of truck group so it inherits truck pose)
-const crane = { group: new THREE.Group(), boomLen: 9.5, boomPitch: 0.86, piston: null, pistonRod: null };
+// tall boom: the tip must clear (longest chain + biggest ball + margin) so a
+// raised winch means a free-hanging, swingable ball — 9.5m/0.86 left every
+// loadout dragging in (or under) the dirt
+const crane = { group: new THREE.Group(), boomLen: 15, boomPitch: 1.18, piston: null, pistonRod: null };
 {
   const mat = c => new THREE.MeshStandardMaterial({ color: c, roughness: 0.62, metalness: 0.12, envMapIntensity: 0.5 });
   const g = crane.group;
@@ -1113,6 +1126,16 @@ function boomTipWorld(out) {   // where the hoist cable leaves the boom
   crane.boom.localToWorld(t);
   return t;
 }
+// winch rail: anchor height for a given winchT. High end sits just under the
+// boom sheave (ball hangs free and can SWING); low end leaves ~1.2m of chain
+// slack so the ball rests and ploughs — but the anchor never presses a taut
+// chain into the terrain (that press-fit was the endless solver buzz)
+function anchorRailY(tip, winchT) {
+  const hang = rig.chainDef.links * rig.linkL + rig.ballDef.r * 0.92;
+  const high = tip.y - 0.6;
+  const low = Math.min(high, terrainH(tip.x, tip.z) + hang + rig.ballDef.r - 1.2);
+  return lerp(high, low, winchT);
+}
 function buildRig() {
   // tear down
   for (const j of rig.joints) world.removeImpulseJoint(j, true);
@@ -1129,12 +1152,18 @@ function buildRig() {
   const linkVol = Math.PI * rig.linkR ** 2 * (L - rig.linkR * 2) + (4 / 3) * Math.PI * rig.linkR ** 3;
   const linkDensity = ballMass / 10 / linkVol;
   const tp = boomTipWorld(tmpV);
-  rig.tipPos.set(tp.x, tp.y - 1, tp.z);
+  // spawn hanging from the winch rail, and NEVER below ground: the old
+  // straight-drop spawn buried the ball ~2m inside the (paper-thin)
+  // heightfield, which ejected it DOWNWARD — the ball then lived under the
+  // map, invisible and useless, for the whole session
+  const aY = anchorRailY(tp, truck.winchT);
+  const gy = terrainH(tp.x, tp.z);
+  rig.tipPos.set(tp.x, aY, tp.z);
   rig.tip = world.createRigidBody(RAPIER.RigidBodyDesc.kinematicPositionBased()
-    .setTranslation(tp.x, tp.y - 1, tp.z));
+    .setTranslation(tp.x, aY, tp.z));
   let prev = rig.tip, prevAnchor = { x: 0, y: 0, z: 0 };
   for (let i = 0; i < LINKS; i++) {
-    const y = tp.y - 1 - (i + 0.5) * L;
+    const y = Math.max(aY - (i + 0.5) * L, gy + 0.3);
     const rb = world.createRigidBody(RAPIER.RigidBodyDesc.dynamic()
       .setTranslation(tp.x, y, tp.z).setCcdEnabled(true)
       .setAngularDamping(1.2).setLinearDamping(0.25));   // high damping: slack chain must lie calm, not buzz
@@ -1153,7 +1182,7 @@ function buildRig() {
   }
   const R = rig.ballDef.r;
   rig.ball = world.createRigidBody(RAPIER.RigidBodyDesc.dynamic()
-    .setTranslation(tp.x, tp.y - 1 - LINKS * L - R, tp.z).setCcdEnabled(true)
+    .setTranslation(tp.x, Math.max(aY - LINKS * L - R * 0.92, gy + R + 0.1), tp.z).setCcdEnabled(true)
     .setAngularDamping(0.7).setLinearDamping(0.05));
   const bc = world.createCollider(RAPIER.ColliderDesc.ball(R)
     .setDensity(rig.ballDef.density).setCollisionGroups(G_CHAIN)
@@ -1346,7 +1375,8 @@ function debrisTick() {
 // ===================================================================
 //  main sim step
 // ===================================================================
-const camPos = new THREE.Vector3(-14, 10, 0), camLook = new THREE.Vector3();
+const cam = { yaw: 0, y: 12 };   // polar-follow state (see syncVisuals)
+const camLook = new THREE.Vector3();
 const v3a = new THREE.Vector3(), v3b = new THREE.Vector3(), qa = new THREE.Quaternion();
 function step(dt) {
   readInput();
@@ -1371,7 +1401,7 @@ function step(dt) {
   truck.group.rotateZ(pitch); truck.group.rotateX(-roll);
   // crane slew + winch — slew ACCELERATES rather than snapping to full rate:
   // instant reversals whip-crack the chain (the failsafe caught one in testing)
-  truck.slewV = lerp(truck.slewV || 0, ctrl.slew * 1.5, 1 - Math.exp(-dt * 5));
+  truck.slewV = lerp(truck.slewV || 0, ctrl.slew * 2.0, 1 - Math.exp(-dt * 8));
   truck.cabYaw += truck.slewV * dt;
   crane.group.rotation.y = truck.cabYaw;
   truck.winchT = clamp(truck.winchT + ctrl.winch * dt * win.speed * -0.12, 0, 1);
@@ -1380,9 +1410,9 @@ function step(dt) {
   qa.setFromEuler(new THREE.Euler(0, truck.yaw, 0));
   truck.body.setNextKinematicRotation({ x: qa.x, y: qa.y, z: qa.z, w: qa.w });
   const tip = boomTipWorld(v3a);
-  // winch: the anchor rides a virtual rail from just under the boom tip down
-  // to near the ground (letting the ball drag and plough is deliberate fun)
-  const anchorY = lerp(tip.y - 0.6, terrainH(tip.x, tip.z) + 1.4, truck.winchT);
+  // winch: the anchor rides the rail — free-hanging swings at the top,
+  // deliberate ground-ploughing at the bottom (see anchorRailY)
+  const anchorY = anchorRailY(tip, truck.winchT);
   // the anchor CHASES its target with a speed cap — teleporting it across the
   // boom's arc in one step is what detonated the joint chain
   v3b.set(tip.x, anchorY, tip.z).sub(rig.tipPos);
@@ -1409,12 +1439,15 @@ function step(dt) {
       }
     }
   }
-  // failsafe: if the solver ever loses the chain anyway, quietly rebuild it
+  // failsafe: if the solver ever loses the chain — flung out of range, NaN,
+  // or the ball tunnels through the thin heightfield and ends up UNDER the
+  // map (it then hangs there invisibly forever) — quietly rebuild the rig
   {
     const bp = rig.ball.translation();
     const maxLen = (rig.chainDef.links * rig.linkL + rig.ballDef.r * 2 + 4) * 2.5;
     const dx = bp.x - rig.tipPos.x, dy = bp.y - rig.tipPos.y, dz = bp.z - rig.tipPos.z;
-    if (!isFinite(dx + dy + dz) || dx * dx + dy * dy + dz * dz > maxLen * maxLen) {
+    if (!isFinite(dx + dy + dz) || dx * dx + dy * dy + dz * dz > maxLen * maxLen ||
+        bp.y < terrainH(bp.x, bp.z) - rig.ballDef.r) {
       rig.resets++;
       buildRig();
     }
@@ -1492,15 +1525,16 @@ function syncVisuals(dt, alpha) {
   rig.ballMesh.position.set(bp.x, bp.y, bp.z);
   rig.ballMesh.quaternion.copy(bp0.q).slerp(lerpQ.set(br.x, br.y, br.z, br.w), a);
   // the truck's VISUAL pose interpolates too (physics/anchor math in step()
-  // uses the exact 60Hz pose; this overwrite is render-only)
+  // uses the exact 60Hz pose; this overwrite is render-only). ix/iyaw/hI are
+  // reused below by the camera so it tracks the SMOOTH pose on 120Hz screens.
+  const ix = lerp(truck.px !== undefined ? truck.px : truck.x, truck.x, a);
+  const iz = lerp(truck.pz !== undefined ? truck.pz : truck.z, truck.z, a);
+  let dyaw = truck.yaw - (truck.pyaw !== undefined ? truck.pyaw : truck.yaw);
+  while (dyaw > Math.PI) dyaw -= 2 * Math.PI;
+  while (dyaw < -Math.PI) dyaw += 2 * Math.PI;
+  const iyaw = (truck.pyaw !== undefined ? truck.pyaw : truck.yaw) + dyaw * a;
+  const hI = terrainH(ix, iz);
   {
-    const ix = lerp(truck.px !== undefined ? truck.px : truck.x, truck.x, a);
-    const iz = lerp(truck.pz !== undefined ? truck.pz : truck.z, truck.z, a);
-    let dyaw = truck.yaw - (truck.pyaw !== undefined ? truck.pyaw : truck.yaw);
-    while (dyaw > Math.PI) dyaw -= 2 * Math.PI;
-    while (dyaw < -Math.PI) dyaw += 2 * Math.PI;
-    const iyaw = (truck.pyaw !== undefined ? truck.pyaw : truck.yaw) + dyaw * a;
-    const hI = terrainH(ix, iz);
     const hF = terrainH(ix + Math.cos(iyaw) * 2.6, iz - Math.sin(iyaw) * 2.6);
     const hS = terrainH(ix + Math.sin(iyaw) * 1.4, iz + Math.cos(iyaw) * 1.4);
     truck.group.position.set(ix, hI, iz);
@@ -1532,29 +1566,32 @@ function syncVisuals(dt, alpha) {
     d.material.opacity = Math.max(0, d.userData.life * 0.5);
     if (d.userData.life <= 0) d.visible = false;
   }
-  // camera: locked chase behind the truck, TRUCK-CENTERED. The old look-at
-  // blended 40% toward the ball, so after any slewing the whole vehicle
-  // drifted off-frame ("my boom is off to the right side of the screen").
-  // Ball influence is now a small CLAMPED nudge — the truck always anchors
-  // the shot and the full rig stays in view.
-  const back = 18, up = 10;
-  const hT = terrainH(truck.x, truck.z);
-  v3b.set(truck.x - Math.cos(truck.yaw) * back, hT + up, truck.z + Math.sin(truck.yaw) * back);
-  camPos.lerp(v3b, 1 - Math.exp(-dt * 3.2));
+  // camera: POLAR chase. The follow yaw eases toward the truck's yaw, but the
+  // position is rigidly (truck − dir(camYaw)·back) — the vehicle physically
+  // cannot leave the frame; only the shot ANGLE lags in a turn. (The old
+  // positional lerp trailed a turning truck by ~25° of arc, parking the whole
+  // vehicle at the screen edge — "it's always off to the right".)
+  const back = 19, up = 11;
+  let dyc = iyaw - cam.yaw;
+  while (dyc > Math.PI) dyc -= 2 * Math.PI;
+  while (dyc < -Math.PI) dyc += 2 * Math.PI;
+  cam.yaw += dyc * (1 - Math.exp(-dt * 6));
+  cam.y = lerp(cam.y, hI + up, 1 - Math.exp(-dt * 4));
+  camera.position.set(ix - Math.cos(cam.yaw) * back, cam.y, iz + Math.sin(cam.yaw) * back);
   const sh = game.shake;
   if (sh > 0.01) {
-    camPos.x += (Math.random() - 0.5) * sh; camPos.y += (Math.random() - 0.5) * sh * 0.7;
+    camera.position.x += (Math.random() - 0.5) * sh;
+    camera.position.y += (Math.random() - 0.5) * sh * 0.7;
     game.shake *= Math.pow(0.02, dt);
   }
-  camera.position.copy(camPos);
-  let nx = bp.x - truck.x, nz = bp.z - truck.z;             // ball nudge, capped at 3.5m
+  let nx = bp.x - ix, nz = bp.z - iz;             // ball nudge, capped at 3.5m
   const nl = Math.hypot(nx, nz);
   if (nl > 3.5) { nx *= 3.5 / nl; nz *= 3.5 / nl; }
-  const ny = clamp((bp.y - hT) * 0.15, 0, 2.5);
+  const ny = clamp((bp.y - hI) * 0.2, 0, 4);      // taller boom: let the shot tilt up more
   camLook.lerp(v3b.set(
-    truck.x + Math.cos(truck.yaw) * 3 + nx * 0.6,
-    hT + 3 + ny,
-    truck.z - Math.sin(truck.yaw) * 3 + nz * 0.6), 1 - Math.exp(-dt * 4));
+    ix + Math.cos(iyaw) * 3 + nx * 0.6,
+    hI + 3.2 + ny,
+    iz - Math.sin(iyaw) * 3 + nz * 0.6), 1 - Math.exp(-dt * 6));
   camera.lookAt(camLook);
   // sun + shadow box follow; sky dome and mountains ride along (infinitely far)
   sun.position.set(truck.x + 30, 60, truck.z + 18);
@@ -1679,9 +1716,10 @@ window.__dbg = {
   get score() { return game.score; },
   get coins() { return eco.coins; },
   get truck() { return truck; },
-  ctrl, world, blocks, rig, errors: dbgErrors, lotAt, terrainH,
+  ctrl, world, blocks, rig, camera, errors: dbgErrors, lotAt, terrainH,
   start: startGame,
   stepN(n) { for (let i = 0; i < n; i++) step(STEP); syncVisuals(STEP); },
+  equip(slot, id) { eco.owned.add(id); eco.equip[slot] = id; buildRig(); },   // test hook: swap gear + rebuild
   terrainProbe() {   // heightfield vs function agreement — only chunk colliders count
     const chunkBodies = new Set([...chunks.values()].map(c => c.body.handle));
     let worst = 0, hits = 0;

--- a/apps/wreck/sw.js
+++ b/apps/wreck/sw.js
@@ -2,7 +2,7 @@
 // CDN files (Three.js module, Rapier physics with inlined WASM, es-module-shims)
 // — all versioned upstream, safe to treat as immutable: cache-first.
 // Same-origin shell is stale-while-revalidate. Bump CACHE to force-invalidate.
-const CACHE = 'wreck-v1';
+const CACHE = 'wreck-v2';
 const PINNED = [
   'https://cdn.jsdelivr.net/npm/es-module-shims@1.10.0/dist/es-module-shims.js',
   'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js',


### PR DESCRIPTION
## What was wrong (all reproduced + measured headless)

The on-device complaints — invisible ball, violently vibrating chain, useless winch, vehicle drifting off-frame — all trace to four root causes:

1. **The ball lived under the map.** `buildRig()` dropped the chain straight down from the boom tip, spawning the ball ~2 m *inside* the paper-thin heightfield; depenetration ejected it downward, so it hung beneath the terrain — invisible and unable to hit anything — from the first frame of every session.
2. **Chains longer than the boom is tall.** 8–15 m of chain under a ~10 m boom: the winch's entire travel changed ball height by **4 cm** (measured), and the kinematic anchor press-fit the taut chain into the ground — the solver expressed that contradiction as permanent chain buzz (idle link velocity 2.5 m/s mean at "rest").
3. **Camera positional lerp** trailed a full-lock turn by ~25° of arc, parking the truck at the screen edge.
4. **iOS stale viewport after rotation** (the Pixel Run PR #288 bug) was never applied to wreck.

## Fixes

- Links + ball spawn clamped above terrain; failsafe also rebuilds the rig if the ball is ever a full radius below `terrainH` (tunnel recovery).
- Boom 15 m @ 1.18 rad; chains 5/7/9 links; `anchorRailY` runs from a true free-hang at the sheave down to ~1.2 m of deliberate slack for ground-ploughing. New law documented in CLAUDE.md: hang must stay ~2 m shorter than the anchor top.
- Polar chase camera: yaw eases, position rigidly `truck − dir·19` — the vehicle physically cannot leave the frame; tracks the interpolated pose for 120 Hz phones.
- `resize()` orients viewport dims to the CSS media orientation + MediaQueryList listener.
- Slew 1.5→2.0 rad/s with snappier ramp; gold ball r 2.0 / density 6.5; `__dbg.equip()` + `__dbg.camera` test hooks. VERSION 2, sw cache `wreck-v2` (installed PWAs pick it up promptly).

## Verification (CDP + SwiftShader headless)

| Metric | Before | After |
|---|---|---|
| Ball at boot | 2.65 m under the map | hangs 4.9 m up |
| Winch full-up → full-down | −2.51 → −2.55 m (4 cm) | 5.77 → 1.54 m |
| Idle link velocity (mean) | 2.48 m/s | 0.67 m/s |
| Hard slew swing | ball buried | peaks 16.9 m @ 39 m/s, 0 rig resets |
| Truck screen-x, full-lock turn | off-frame | \|NDC x\| ≤ 0.11 |
| One slew pass through a lot | ~0 | +1,684 points |

terrainProbe 0.16 m, zero JS errors, zero rig resets across all runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aELZuW9PmgVGUk6XtbZQo