### PR TITLE
Wreck sw.js: shell-only install — iOS players pinned to V1 forever

### DIFF
--- a/apps/wreck/CLAUDE.md
+++ b/apps/wreck/CLAUDE.md
@@ -11,6 +11,15 @@ title screen). ASSERT the old value when bumping (repo-wide rule — silent
 no-op bumps have shipped). Bump `CACHE` in `sw.js` (`wreck-vN`) when a deploy
 must reach installed players promptly.
 
+**sw.js install must stay SHELL-ONLY and fast.** V1 gated install on
+`Promise.all` of the multi-MB pinned CDN downloads; on iOS standalone every
+quick launch/force-quit aborted the in-flight update install, so players were
+pinned to the old worker's stale shell forever ("still see V1"). CDN files
+cache lazily via the fetch handler and are copied forward across CACHE bumps
+in activate. Shell revalidation must fetch by URL with `cache: 'no-cache'` —
+WebKit rejects refetching a navigation-mode Request, which silently disabled
+stale-while-revalidate for `./` on iOS.
+
 ## Stack
 
 - **Three.js 0.160** (ES modules via jsdelivr importmap) + **Rapier 3D 0.19.3**

--- a/apps/wreck/index.html
+++ b/apps/wreck/index.html
@@ -166,7 +166,7 @@ import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
 import { RoundedBoxGeometry } from 'three/addons/geometries/RoundedBoxGeometry.js';
 import RAPIER from 'rapier';
 
-const VERSION = 3;   // bump once per PR (see CLAUDE.md)
+const VERSION = 4;   // bump once per PR (see CLAUDE.md)
 try {
 
 // ===================================================================

--- a/apps/wreck/sw.js
+++ b/apps/wreck/sw.js
@@ -1,8 +1,18 @@
-// Wreck & Ruin service worker: full offline play. The game needs three pinned
-// CDN files (Three.js module, Rapier physics with inlined WASM, es-module-shims)
-// — all versioned upstream, safe to treat as immutable: cache-first.
-// Same-origin shell is stale-while-revalidate. Bump CACHE to force-invalidate.
-const CACHE = 'wreck-v3';
+// Wreck & Ruin service worker: full offline play. The game needs five pinned
+// CDN files (Three.js module + addons, Rapier physics with inlined WASM,
+// es-module-shims) — all versioned upstream, immutable: cache-first, cached
+// LAZILY by the fetch handler and copied forward across CACHE bumps.
+//
+// INSTALL MUST STAY SHELL-ONLY AND FAST. V1 gated install on Promise.all of
+// the multi-MB CDN downloads: on iOS standalone every quick launch/force-quit
+// aborted the in-flight update install, so the old worker (and its stale
+// shell) survived indefinitely — players were stuck on V1 no matter how many
+// times they relaunched. Pixel Run's tiny install never had this problem.
+//
+// Same-origin shell is stale-while-revalidate. The revalidation fetches by
+// URL with cache:'no-cache' — WebKit rejects fetch() of a navigation-mode
+// Request, which silently killed the V1 refresh of './' on iOS.
+const CACHE = 'wreck-v4';
 const PINNED = [
   'https://cdn.jsdelivr.net/npm/es-module-shims@1.10.0/dist/es-module-shims.js',
   'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js',
@@ -15,20 +25,27 @@ const SHELL = ['./', './index.html', './manifest.webmanifest',
 
 self.addEventListener('install', e => {
   e.waitUntil(
-    caches.open(CACHE)
-      .then(c => Promise.all([c.addAll(SHELL), ...PINNED.map(u => c.add(u))]))
-      .then(() => self.skipWaiting())
+    caches.open(CACHE).then(c => c.addAll(SHELL)).then(() => self.skipWaiting())
   );
 });
 
 self.addEventListener('activate', e => {
-  e.waitUntil(
-    caches.keys()
-      .then(keys => Promise.all(
-        keys.filter(k => k.startsWith('wreck-') && k !== CACHE).map(k => caches.delete(k))
-      ))
-      .then(() => self.clients.claim())
-  );
+  e.waitUntil((async () => {
+    const keys = await caches.keys();
+    const olds = keys.filter(k => k.startsWith('wreck-') && k !== CACHE);
+    // carry the immutable CDN files over from any old cache so a version bump
+    // never forces a multi-MB re-download (or breaks offline play)
+    const c = await caches.open(CACHE);
+    for (const url of PINNED) {
+      if (await c.match(url)) continue;
+      for (const old of olds) {
+        const hit = await (await caches.open(old)).match(url);
+        if (hit) { await c.put(url, hit); break; }
+      }
+    }
+    await Promise.all(olds.map(k => caches.delete(k)));
+    await self.clients.claim();
+  })());
 });
 
 self.addEventListener('fetch', e => {
@@ -49,8 +66,11 @@ self.addEventListener('fetch', e => {
   }
   if (new URL(url).origin !== self.location.origin) return;
   const cached = caches.match(e.request, { ignoreSearch: true });
+  // revalidate by URL, not by Request: WebKit rejects refetching a
+  // navigation-mode Request, and cache:'no-cache' skips the 10-minute
+  // GitHub Pages heuristic so the next launch really is fresh
   const refresh = cached.then(hit =>
-    fetch(e.request).then(res => {
+    fetch(url, { cache: 'no-cache' }).then(res => {
       if (res && res.ok) {
         const copy = res.clone();
         return caches.open(CACHE).then(c => c.put(e.request, copy)).then(() => res);


### PR DESCRIPTION
This is the fix for "force quit a million times and still see V1."

**Root cause**: the service worker's install step gated on `Promise.all` of the multi-MB pinned CDN downloads (Rapier with inlined WASM). On iOS standalone the update-install only runs while the app is foreground, so every quick launch → check version → force-quit cycle **aborted the in-flight install** — the old `wreck-v1` worker never got replaced and kept serving its cached V1 shell indefinitely. Pixel Run's shell-only install (~6 tiny files) is exactly why it never exhibits this.

Second, independent blocker: WebKit rejects `fetch()` of a navigation-mode `Request`, so the stale-while-revalidate background refresh of `./` silently no-oped on iOS — the self-healing path was dead too.

**Changes**
- install: shell-only (fast, atomic) — CDN files cache lazily via the existing fetch handler
- activate: immutable pinned CDN files are copied forward from old caches, so cache bumps neither re-download megabytes nor break offline play
- revalidation fetches by URL with `cache: 'no-cache'` (works on WebKit, skips the 10-min Pages heuristic)
- VERSION 4, cache `wreck-v4`; CLAUDE.md documents the shell-only-install contract

(Note: this commit was originally pushed to the #292 branch minutes after that PR merged, so it never landed — this PR carries it.)

**Verified headless**: worker installs, activates, claims, shell cached, zero errors.

**On-device rescue path**: after this deploys, open the app and leave it in the foreground ~15 seconds (let the update install), then relaunch twice. If it's somehow still stuck, delete the home-screen app and re-add it — that nukes the old registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aELZuW9PmgVGUk6XtbZQo