### PR TITLE
Fix the day-one bug: canvas was 2x the viewport on every DPR>1 phone

### DIFF
--- a/apps/ruin/CLAUDE.md
+++ b/apps/ruin/CLAUDE.md
@@ -95,6 +95,16 @@ with the chunk. Impact shards: `burst()` pool, purely visual.
 `world.numSolverIterations` was verified to be a real accessor on
 rapier3d-compat 0.19.3 (prototype getter/setter — not a silent expando).
 
+**The canvas MUST have explicit CSS `width:100%; height:100%`** — it's a
+replaced element, so `position:fixed; inset:0` does NOT stretch it; it lays
+out at its attribute size, which is buffer × pixelRatio because
+`renderer.setSize(w, h, false)` skips the style update. On every DPR>1 phone
+the canvas was 2× the viewport with only the top-left quarter on screen, so
+the camera-centered truck sat exactly on the right screen edge — this, not
+the camera, was the original "vehicle is always off to the right" bug.
+Desktop/headless DPR 1 masked it completely: **always verify with
+`Emulation.setDeviceMetricsOverride` at `deviceScaleFactor: 3`.**
+
 **Camera is a POLAR chase**: `cam.yaw` eases toward truck yaw but the position
 is rigidly `truck − dir(cam.yaw)·19` — the vehicle physically cannot leave the
 frame; only the shot angle lags in turns. (A positional lerp here trailed

--- a/apps/ruin/index.html
+++ b/apps/ruin/index.html
@@ -14,7 +14,13 @@
   html, body { width: 100%; height: 100%; overflow: hidden; background: #8ed4f7;
     font-family: "Avenir Next", "Trebuchet MS", system-ui, -apple-system, sans-serif;
     color: #fff; -webkit-user-select: none; user-select: none; touch-action: none; }
-  canvas#gl { position: fixed; inset: 0; display: block; touch-action: none; }
+  /* width/height 100% is LOAD-BEARING: canvas is a replaced element, so
+     inset:0 alone does NOT stretch it — it lays out at its attribute size
+     (buffer × pixelRatio). On every DPR>1 phone that made the canvas 2× the
+     viewport with only the top-left quarter visible: the camera-centered
+     truck sat exactly on the right screen edge ("vehicle is always off to
+     the right hand side, I can't see it"). Desktop DPR 1 masked it. */
+  canvas#gl { position: fixed; inset: 0; width: 100%; height: 100%; display: block; touch-action: none; }
 
   /* ---------- HUD ---------- */
   #hud { position: fixed; inset: 0; pointer-events: none; display: none; z-index: 20; }
@@ -166,7 +172,7 @@ import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
 import { RoundedBoxGeometry } from 'three/addons/geometries/RoundedBoxGeometry.js';
 import RAPIER from 'rapier';
 
-const VERSION = 5;   // bump once per PR (see CLAUDE.md)
+const VERSION = 6;   // bump once per PR (see CLAUDE.md)
 try {
 
 // ===================================================================

--- a/apps/ruin/sw.js
+++ b/apps/ruin/sw.js
@@ -12,7 +12,7 @@
 // Same-origin shell is stale-while-revalidate. The revalidation fetches by
 // URL with cache:'no-cache' — WebKit rejects fetch() of a navigation-mode
 // Request, which silently killed the V1 refresh of './' on iOS.
-const CACHE = 'ruin-v1';
+const CACHE = 'ruin-v2';
 const PINNED = [
   'https://cdn.jsdelivr.net/npm/es-module-shims@1.10.0/dist/es-module-shims.js',
   'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js',


### PR DESCRIPTION
## The actual root cause of "the vehicle is always off to the right"

`renderer.setSize(w, h, false)` skips the canvas style update, and `position:fixed; inset:0` does **not** stretch a `<canvas>` — replaced elements lay out at their **attribute size**, which is buffer × pixelRatio. On every DPR>1 phone the canvas was **2× the viewport**, with only its top-left quarter on screen. The camera has been correctly centering the truck all along — in an image whose center sits exactly at the right edge of the screen.

- Explains the original day-one complaint verbatim ("vehicle always off to the right hand side, I can't see it")
- Explains why every camera rework changed nothing on-device
- Explains why desktop + headless verification always looked perfect: DPR 1 makes buffer, attribute, and viewport sizes coincide

Caught by finally emulating real iPhone 17 Pro metrics (`Emulation.setDeviceMetricsOverride`, 874×402 CSS @ deviceScaleFactor 3) — the broken composition reproduced immediately, and the camera-state numbers (truck NDC 0.07, dead center) disagreed with the pixels, which pinned it to the canvas layer.

**Fix**: explicit `width:100%; height:100%` on `canvas#gl`, marked load-bearing with a comment. CLAUDE.md now requires DPR-3 emulation in runtime verification.

**Verified** at emulated iPhone metrics: canvas CSS 874×402 = viewport, truck dead center, full boom and free-swinging ball in frame, zero errors. Before/after screenshots in the session.

VERSION 6, sw cache `ruin-v2`. After merge + a relaunch-twice cycle: title reads **V6** and the truck should finally be in the middle of your screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aELZuW9PmgVGUk6XtbZQo