### PR TITLE
Breakout V2: one-hit bricks + post-merge review fixes

### DIFF
--- a/apps/breakout/CLAUDE.md
+++ b/apps/breakout/CLAUDE.md
@@ -18,8 +18,12 @@ in `sw.js`.
   never covers the ball. Tap = launch stuck ball(s).
 - Playfield is a fixed 250px logical width (`PF`) centered in the canvas —
   brick geometry never depends on device width.
-- Levels are `PATTERNS` (rows of `COLS` chars, '1'-'4' = brick hp/color tier,
-  '.' = empty). All patterns loop forever with `game.loop` speeding balls up.
+- Levels are `PATTERNS` (rows of `COLS` chars, '1'-'4' = brick point/color
+  tier, '.' = empty). **Every brick breaks in ONE hit** — color means points
+  (tier×10), never durability. Multi-hit bricks were shipped in V1 and read
+  as "bricks recolor instead of breaking" (user report); don't reintroduce
+  them without a visually distinct armored-brick treatment. All patterns loop
+  forever with `game.loop` speeding balls up.
 - Power-ups drop from destroyed bricks (12%): W = wide paddle 12s, M = +2 balls.
   Life is lost only when the LAST ball falls.
 - Ball sim runs 2 substeps/frame and clamps `|vy|` ≥ 0.22·speed so the ball can

--- a/apps/breakout/index.html
+++ b/apps/breakout/index.html
@@ -50,7 +50,7 @@ const PAD_H = 8, PAD_W = 44, PAD_WIDE = 68;
 const SPEED0 = 3.4, SPEED_MAX = 6.0, SPEED_UP = 0.08;   // per paddle hit
 const DRAG_GAIN = 1.5;
 const SAVE = 'breakout_';
-const VERSION = 1;                    // shown on the title screen — bump once per PR (see CLAUDE.md)
+const VERSION = 2;                    // shown on the title screen — bump once per PR (see CLAUDE.md)
 
 const clamp = (v, a, b) => v < a ? a : v > b ? b : v;
 function hash2(x, y) { let h = (x * 374761393 + y * 668265263) | 0; h = (h ^ h >> 13) * 1274126177 | 0; return ((h ^ h >> 16) >>> 0) / 4294967296; }
@@ -233,7 +233,9 @@ const sfx = {
 };
 
 // ---------- levels ----------
-// rows of COLS chars: '.' empty, '1'-'4' brick hp (score/color tier)
+// rows of COLS chars: '.' empty, '1'-'4' brick point/color tier.
+// EVERY brick breaks in ONE hit — classic breakout. Color means points
+// (tier×10), never durability; recoloring-on-hit reads as broken (user report).
 const PATTERNS = [
   ['1111111111',
    '1111111111',
@@ -432,10 +434,8 @@ function stepBall(b) {
         const penY = Math.min(b.y + BALL_R - br.y, br.y + br.h - (b.y - BALL_R));
         if (penX < penY) { b.vx = b.x < br.x + br.w / 2 ? -Math.abs(b.vx) : Math.abs(b.vx); }
         else { b.vy = b.y < br.y + br.h / 2 ? -Math.abs(b.vy) : Math.abs(b.vy); }
-        const hp = grid[r][c];
-        sfx.brick(hp); buzz(1);
-        if (hp > 1) { grid[r][c] = hp - 1; game.score += 5; burst(b.x, b.y, BRICK_COLS[hp][0], 3); }
-        else killBrick(r, c);
+        sfx.brick(grid[r][c]); buzz(1);
+        killBrick(r, c);
         hit = true;
       }
     }

--- a/apps/breakout/index.html
+++ b/apps/breakout/index.html
@@ -90,6 +90,9 @@ function resize() {
   if (sig === lastSize) return;
   lastSize = sig;
   const portrait = !landscape;
+  // landscape targets H≈250 so brick/ball/paddle pixels keep the same on-screen
+  // size as portrait (W≈270) — rotating must not zoom the game out. Unrelated
+  // to PF; the playfield just recenters/reclamps via layout().
   SCALE = portrait
     ? Math.max(1, Math.round(cw * dpr / 270))
     : Math.max(1, Math.round(chh * dpr / 250));
@@ -296,7 +299,7 @@ let gridRows = 0;
 let balls = [];          // {x,y,vx,vy,stuck}
 let drops = [];          // falling power-ups {x,y,type}
 let fx = [];
-const pad = { x: 0, w: PAD_W, wideT: 0 };
+const pad = { x: 0, w: PAD_W, wideT: 0, hits: 0 };
 const input = { down: false, id: -1, lastX: 0, x0: 0, t0: 0, moved: 0 };
 const ui = { btns: [] };
 
@@ -463,7 +466,8 @@ function update() {
       sfx.over();
       return;
     }
-    serve();
+    drops = [];          // falling power-ups die with the ball — no stale
+    serve();             // MULTI catches while the fresh ball is still stuck
   }
   // falling power-ups
   for (const d of drops) d.y += 1.4;

--- a/apps/breakout/sw.js
+++ b/apps/breakout/sw.js
@@ -1,7 +1,7 @@
 // Breakout service worker: one self-contained file, so caching the shell makes
 // it fully playable offline. Stale-while-revalidate; bump CACHE when a deploy
 // must invalidate old copies immediately.
-const CACHE = 'breakout-v1';
+const CACHE = 'breakout-v2';
 const SHELL = ['./', './index.html', './icon.png', './apple-touch-icon.png', './icon-192.png', './manifest.webmanifest'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
PR #298 was merged just before its review-fix commit was pushed, so these three small changes from the automated review missed the merge:

- **Clear `drops` on the life-loss path** — falling power-ups now die with the ball, so you can't catch a stale MULTI while the fresh ball is still stuck to the paddle (the reviewer's one "double check before shipping" item).
- **`hits: 0` in the `pad` literal** — removes the latent NaN footgun if init ordering ever changes.
- **Comment on the landscape scaling constant** (pixelrun-style) explaining the 250 target is about keeping sprite size constant across rotation, not derived from `PF`.

Re-verified headless after the changes: zero JS errors, bot plays normally, `drops` confirmed empty after a life loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MsRHTcxT4uFSqvX6R6tH9E