### PR TITLE
Spider-Man 3D V6: fix east-west world mirror (the "inverted tilt") + physical sidewalk curbs

### DIFF
--- a/apps/spiderman3d/CLAUDE.md
+++ b/apps/spiderman3d/CLAUDE.md
@@ -111,13 +111,22 @@ Other V3 playtest laws:
   Camera near plane is 0.5 for the same reason — near distance dominates
   depth precision; don't drop it back to 0.1. Sidewalk plinth padding skips
   park-facing sides (a padded plinth under a lawn is back inside z-fight
-  range), and parks are physically 0.2 m raised terraces (`supportAt`), so
-  the runner stands ON the lawn decal rather than shin-deep in it.
+  range). Parks are physically 0.2 m raised terraces and sidewalks are
+  physically 0.3 m curbs (`supportAt` knows both, plinth rects are hashed in
+  `pHash`) — the runner stands ON lawns and sidewalks, never shin-deep in
+  visual-only geometry. Any new raised ground visual must get a `supportAt`
+  entry.
 
 ## Manhattan geography (V4)
 
 The island is rough real Manhattan: 21.6 km Battery (z = Z0, south) → Inwood,
-+z uptown, +x east. Layout is data-driven — `W_PTS`/`C_PTS` are piecewise
++z uptown. **AXIS LAW (V6): +x is WEST** — in a y-up right-handed world with
++z = north, a body facing north has its right hand (east) at -x. V5 shipped
+the island east-west mirrored because "west" was placed at low x; every
+east/west feature (centerline drift, Hudson Yards, Riverside, Broadway's
+curve, square parks) now follows the axis law, and the minimap draws -x
+(east) on the RIGHT so it reads as a normal north-up map AND the dot moves
+the same direction you steer. If you add geography, check it against this. Layout is data-driven — `W_PTS`/`C_PTS` are piecewise
 width/centerline profiles in km-from-Battery (widest ~3.7 km at 14th St,
 spine drifting east going north); the shoreline slab, `insideIsland()`, bot
 recentering, and respawn all derive from them. The real grid: avenues `AV` =

--- a/apps/spiderman3d/index.html
+++ b/apps/spiderman3d/index.html
@@ -123,7 +123,8 @@ const rand = mulberry32(seed);
 
 // ---------------------------------------------------------------------------
 // CITY — rough real Manhattan. Battery at the south (z = Z0), Inwood at the
-// north; +z is uptown, +x is east. Real scale: ~21.6 km long, ~3.7 km at the
+// north; +z is uptown, +x is WEST (see the AXIS LAW below — east is -x).
+// Real scale: ~21.6 km long, ~3.7 km at the
 // widest (14th St). Real grid: avenues (N-S corridors) every ~272 m, streets
 // (E-W) every ~80 m. Neighborhood skylines via nbhHeight(). Individual
 // buildings are invented; scale and layout follow the real island.
@@ -190,8 +191,8 @@ function inPark(x, z) {
   return false;
 }
 
-// Neighborhood skyline band: t = km north of the Battery, e = east-west
-// position in [-1 west, +1 east] across the island at that latitude. The band
+// Neighborhood skyline band: t = km north of the Battery, e = cross-island
+// position in [-1 east, +1 west] (axis law: +x is west). The band
 // also decides the BLOCK FABRIC: base ≤ 26 → rowhouse street walls,
 // base ≤ 55 (no supertall chance) → mid-rise frontages, else office slabs.
 function nbhBand(t, e) {
@@ -287,8 +288,8 @@ function placeBuilding(x0, x1, z0, z1, h, small) {
     const sz0 = z0 + (i / N) * (z1 - z0), sz1 = z0 + ((i + 1) / N) * (z1 - z0);
     const bw = bwayXAt((sz0 + sz1) / 2);
     const L1 = Math.min(x1, bw - BWAY_HALF), R0 = Math.max(x0, bw + BWAY_HALF);
-    if (L1 - x0 >= 4) slices.push([x0, L1, sz0, sz1]);   // west-of-Broadway slice
-    if (x1 - R0 >= 4) slices.push([R0, x1, sz0, sz1]);   // east-of-Broadway slice
+    if (L1 - x0 >= 4) slices.push([x0, L1, sz0, sz1]);   // east-of-Broadway slice (-x)
+    if (x1 - R0 >= 4) slices.push([R0, x1, sz0, sz1]);   // west-of-Broadway slice (+x)
   }
   // exactly ONE face-ring set per crossing building: the widest slice keeps
   // it (preserves the 55 m street-reach guarantee at the corridor without
@@ -515,12 +516,12 @@ scene.add(sun);
 {
   const shape = new THREE.Shape();
   const N = 160;
-  for (let i = 0; i <= N; i++) {        // east shore, south → north
+  for (let i = 0; i <= N; i++) {        // west shore (+x), south → north
     const z = Z0 + (i / N) * ISLAND_L;
     i ? shape.lineTo(centerAt(z) + widthAt(z) / 2, z)
       : shape.moveTo(centerAt(z) + widthAt(z) / 2, z);
   }
-  for (let i = N; i >= 0; i--) {        // west shore, north → south
+  for (let i = N; i >= 0; i--) {        // east shore (-x), north → south
     const z = Z0 + (i / N) * ISLAND_L;
     shape.lineTo(centerAt(z) - widthAt(z) / 2, z);
   }

--- a/apps/spiderman3d/index.html
+++ b/apps/spiderman3d/index.html
@@ -81,7 +81,7 @@ import * as THREE from 'three';
 
 const BOOT_T0 = performance.now();   // city gen + scene build cost, exposed as __dbg.bootMs
 
-const VERSION = 5;
+const VERSION = 6;
 // the version badge lives ONLY on the title screen (user decision, V5)
 document.getElementById('tver').textContent = 'V' + VERSION;
 
@@ -139,10 +139,14 @@ const zk  = t => Z0 + t * 1000;       // inverse
 
 // width & centerline profiles (piecewise-linear over km-from-Battery).
 // The island widens to 14th St, tapers uptown, and drifts east going north.
+// AXIS LAW: this world is y-up right-handed with +z = north, which makes
+// +x = WEST (east = -x — a body facing north has its right hand at -x).
+// All east/west geography below follows that; the V5 world shipped mirrored
+// because "west" was placed at low x.
 const W_PTS = [[0, 500], [0.5, 1400], [1, 2200], [2, 3100], [3, 3700], [5, 3500],
   [6, 3400], [8, 2900], [10, 2700], [12, 2400], [14, 2100], [15.5, 1800],
   [17, 1600], [19, 1400], [20.5, 900], [21.3, 400], [21.6, 120]];
-const C_PTS = [[0, 0], [4, 50], [6, 200], [9, 450], [12, 700], [15, 900], [18, 1050], [21.6, 1200]];
+const C_PTS = [[0, 0], [4, -50], [6, -200], [9, -450], [12, -700], [15, -900], [18, -1050], [21.6, -1200]];
 function pw(pts, t) {
   if (t <= pts[0][0]) return pts[0][1];
   for (let i = 1; i < pts.length; i++) if (t <= pts[i][0]) {
@@ -173,16 +177,16 @@ const CENTRAL_PARK = addPark(8.7, 12.8, -420, 420);   // 59th → 110th
 // generic rectangle renderer must skip this entry.
 const BATTERY = addPark(0, 0.35, -2000, 2000);
 BATTERY.noLawn = true;
-addPark(3.55, 3.78, -140, 120);                       // Washington Square
-addPark(3.05, 3.25, 560, 780);                        // Tompkins Square
-addPark(4.15, 4.32, -40, 150);                        // Union Square
-addPark(4.7, 4.92, -60, 160);                         // Madison Square
-addPark(7.3, 7.48, -260, -40);                        // Bryant Park
+addPark(3.55, 3.78, -120, 140);                       // Washington Square
+addPark(3.05, 3.25, -780, -560);                      // Tompkins Square (east side = -x)
+addPark(4.15, 4.32, -150, 40);                        // Union Square
+addPark(4.7, 4.92, -160, 60);                         // Madison Square
+addPark(7.3, 7.48, 40, 260);                          // Bryant Park (west of the spine = +x)
 function inPark(x, z) {
   for (const p of PARKS) if (x > p.x0 && x < p.x1 && z > p.z0 && z < p.z1) return true;
   const t = kmN(z), c = centerAt(z), w = widthAt(z);
-  if (t > 9.5 && t < 14.5 && x < c - w / 2 + 170) return true;   // Riverside Park (west shore)
-  if (t > 2.6 && t < 4.2 && x > c + w / 2 - 140) return true;    // East River Park
+  if (t > 9.5 && t < 14.5 && x > c + w / 2 - 170) return true;   // Riverside Park (west shore = +x)
+  if (t > 2.6 && t < 4.2 && x < c - w / 2 + 140) return true;    // East River Park (east = -x)
   return false;
 }
 
@@ -196,7 +200,7 @@ function nbhBand(t, e) {
   else if (t < 2.3)  { base = 28; varr = 55; }                                   // Tribeca / Civic Center
   else if (t < 4.0)  { base = 15; varr = 32; }                                   // SoHo / Village / LES
   else if (t < 5.1)  { base = 35; varr = 85;
-    if (e < -0.5 && t > 4.5) { base = 110; varr = 220; } }                       // Flatiron; Hudson Yards to the west
+    if (e > 0.5 && t > 4.5) { base = 110; varr = 220; } }                        // Flatiron; Hudson Yards to the west (+x)
   else if (t < 6.5)  { base = 45; varr = 100; }                                  // Chelsea / Gramercy / Murray Hill
   else if (t < 8.8)  { base = 70; varr = 210;                                    // Midtown canyon
     superChance = t > 7.0 ? 0.05 : 0.02; superMin = 300; superVar = 220;
@@ -220,8 +224,8 @@ function nbhHeight(band) {
 // famous diagonal cutting west past Union/Madison/Herald/Times Squares to
 // Columbus Circle, up the west side, and back to the spine in Inwood.
 // Buildings are never placed within its corridor.
-const BWAY_PTS = [[0.3, 0], [2, -0.03], [3.9, 0.03], [4.8, 0.05], [5.6, 0], [7, -0.08],
-  [8.75, -0.2], [10, -0.5], [12.8, -0.5], [15, -0.35], [17, -0.2], [19, -0.08], [21.3, 0]];
+const BWAY_PTS = [[0.3, 0], [2, 0.03], [3.9, -0.03], [4.8, -0.05], [5.6, 0], [7, 0.08],
+  [8.75, 0.2], [10, 0.5], [12.8, 0.5], [15, 0.35], [17, 0.2], [19, 0.08], [21.3, 0]];
 const BWAY_HALF = 14;   // corridor half-width, m
 function bwayXAt(z) {
   const t = kmN(z);
@@ -450,15 +454,37 @@ function findBend(p, piv) {
   return bend;
 }
 
+// sidewalk plinth rects — physical curbs (0.3 m), one per block, padding
+// skipped on park-facing sides (a padded plinth bleeding under a lawn would
+// sit 0.1 m below it, inside z-fight range). Rendered by the scene section.
+const plinths = [], pHash = new Map();
+for (const b of blocks) {
+  const cx = (b.x0 + b.x1) / 2, cz = (b.z0 + b.z1) / 2;
+  const x0 = b.x0 - (inPark(b.x0 - 6, cz) ? 0 : 4), x1 = b.x1 + (inPark(b.x1 + 6, cz) ? 0 : 4);
+  const z0 = b.z0 - (inPark(cx, b.z0 - 6) ? 0 : 4), z1 = b.z1 + (inPark(cx, b.z1 + 6) ? 0 : 4);
+  const idx = plinths.push({ x0, x1, z0, z1 }) - 1;
+  for (let ccx = Math.floor(x0 / CELL); ccx <= Math.floor(x1 / CELL); ccx++)
+    for (let ccz = Math.floor(z0 / CELL); ccz <= Math.floor(z1 / CELL); ccz++)
+      bucket(pHash, hk(ccx, ccz)).push(idx);
+}
+
 // support height (feet level) at a point: roof if inside a footprint, else
-// lawn (parks are 0.2 m raised terraces — matches the decal height so the
-// runner stands ON the grass, not shin-deep in it), else street
+// sidewalk (0.3 m curb — the runner steps ONTO plinths instead of sinking
+// shin-deep through them), else lawn (parks are 0.2 m raised terraces),
+// else street
 function supportAt(x, z) {
   let s = 0;
   const arr = bHash.get(hk(Math.floor(x / CELL), Math.floor(z / CELL)));
   if (arr) for (const i of arr) {
     const b = buildings[i];
     if (x >= b.x0 && x <= b.x1 && z >= b.z0 && z <= b.z1 && b.h > s) s = b.h;
+  }
+  if (s === 0) {
+    const pa = pHash.get(hk(Math.floor(x / CELL), Math.floor(z / CELL)));
+    if (pa) for (const i of pa) {
+      const p = plinths[i];
+      if (x >= p.x0 && x <= p.x1 && z >= p.z0 && z <= p.z1) { s = 0.3; break; }
+    }
   }
   if (s === 0 && inPark(x, z)) s = 0.2;
   return s;
@@ -530,13 +556,13 @@ scene.add(sun);
     addLawn(centerAt(zm) - widthAt(zm) / 2, centerAt(zm) + widthAt(zm) / 2, zk(t0), zk(t0 + 0.07));
   }
   // shore strips, segmented so they hug the shoreline profiles
-  for (let i = 0; i < 10; i++) {        // Riverside Park
+  for (let i = 0; i < 10; i++) {        // Riverside Park (west shore = +x)
     const t0 = 9.5 + i * 0.5, zm = zk(t0 + 0.25);
-    addLawn(centerAt(zm) - widthAt(zm) / 2, centerAt(zm) - widthAt(zm) / 2 + 170, zk(t0), zk(t0 + 0.5));
+    addLawn(centerAt(zm) + widthAt(zm) / 2 - 170, centerAt(zm) + widthAt(zm) / 2, zk(t0), zk(t0 + 0.5));
   }
-  for (let i = 0; i < 4; i++) {         // East River Park
+  for (let i = 0; i < 4; i++) {         // East River Park (east = -x)
     const t0 = 2.6 + i * 0.4, zm = zk(t0 + 0.2);
-    addLawn(centerAt(zm) + widthAt(zm) / 2 - 140, centerAt(zm) + widthAt(zm) / 2, zk(t0), zk(t0 + 0.4));
+    addLawn(centerAt(zm) - widthAt(zm) / 2, centerAt(zm) - widthAt(zm) / 2 + 140, zk(t0), zk(t0 + 0.4));
   }
   // Broadway ribbon — drawn just above the sidewalk plinths so the diagonal
   // reads against the grid (physically it's ordinary street: no buildings)
@@ -570,20 +596,16 @@ scene.add(sun);
   res.position.set((CENTRAL_PARK.x0 + CENTRAL_PARK.x1) / 2, 0.4, zk(11.2));
   scene.add(res);
 }
-// sidewalk plinths — one per BLOCK, so the street grid reads at any density
+// sidewalk plinths — one per BLOCK (rects precomputed with the city data,
+// since supportAt treats them as physical 0.3 m curbs)
 {
   const geo = new THREE.BoxGeometry(1, 1, 1);
   const mat = new THREE.MeshLambertMaterial({ color: 0x8f959c });
-  const m = new THREE.InstancedMesh(geo, mat, blocks.length);
+  const m = new THREE.InstancedMesh(geo, mat, plinths.length);
   const M = new THREE.Matrix4();
-  blocks.forEach((b, i) => {
-    // sidewalk padding skips any side that faces a park — a padded plinth
-    // bleeding under a lawn would sit 0.1 m below it, inside z-fight range
-    const cx = (b.x0 + b.x1) / 2, cz = (b.z0 + b.z1) / 2;
-    const x0 = b.x0 - (inPark(b.x0 - 6, cz) ? 0 : 4), x1 = b.x1 + (inPark(b.x1 + 6, cz) ? 0 : 4);
-    const z0 = b.z0 - (inPark(cx, b.z0 - 6) ? 0 : 4), z1 = b.z1 + (inPark(cx, b.z1 + 6) ? 0 : 4);
-    M.makeScale(x1 - x0, 0.3, z1 - z0);
-    M.setPosition((x0 + x1) / 2, 0.15, (z0 + z1) / 2);
+  plinths.forEach((p, i) => {
+    M.makeScale(p.x1 - p.x0, 0.3, p.z1 - p.z0);
+    M.setPosition((p.x0 + p.x1) / 2, 0.15, (p.z0 + p.z1) / 2);
     m.setMatrixAt(i, M);
   });
   scene.add(m);
@@ -688,7 +710,10 @@ for (let t = 0; t <= 21.6; t += 0.2) {
   MM_X1 = Math.max(MM_X1, pw(C_PTS, t) + pw(W_PTS, t) / 2 + 100);
 }
 const MM_PAD = 4;
-const mmX = x => MM_PAD + (x - MM_X0) / (MM_X1 - MM_X0) * (MM_W - MM_PAD * 2);
+// x is FLIPPED on the map: +x is world-west (axis law), and a north-up map
+// must draw east on the right — this is also what makes the dot move the
+// same direction you steer
+const mmX = x => MM_PAD + (MM_X1 - x) / (MM_X1 - MM_X0) * (MM_W - MM_PAD * 2);
 const mmZ = z => MM_PAD + (1 - (z - Z0) / ISLAND_L) * (MM_H - MM_PAD * 2);
 mini.width = MM_W * MM_DPR;
 mini.height = MM_H * MM_DPR;
@@ -740,7 +765,7 @@ function drawMini() {
   mmCtx.lineWidth = 1.4;
   mmCtx.beginPath();
   mmCtx.moveTo(px, pz);
-  mmCtx.lineTo(px + dx * 6, pz - dz * 6);
+  mmCtx.lineTo(px - dx * 6, pz - dz * 6);   // map-x is flipped (east = -x drawn right)
   mmCtx.stroke();
   mmCtx.fillStyle = '#e23636';
   mmCtx.beginPath();

--- a/apps/spiderman3d/sw.js
+++ b/apps/spiderman3d/sw.js
@@ -3,7 +3,7 @@
 // Three.js comes from the CDN and is cached on first fetch below (runtime
 // cache), so the game works offline after one online play.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'spiderman3d-v5';
+const CACHE = 'spiderman3d-v6';
 const SHELL = ['./', './index.html', './icon.png', './apple-touch-icon.png', './icon-192.png', './manifest.webmanifest'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
## The "inverted tilt" report

V5 touched no steering code (verified by diff against V4). What the playtest actually caught is better: **the world was an east-west mirror of real Manhattan, and the V5 minimap made it visible.**

In a y-up right-handed engine with +z = north, a body facing north has its right hand — east — at **−x**: so **+x is west**. The geography had been placing "west" features (Hudson Yards, Riverside, Broadway's westward drift) at low x, i.e. the in-game *east*. Meanwhile the minimap drew +x on the right. Net effect: steer right while running uptown and the world turns right correctly, but your minimap dot moves **left** — indistinguishable from inverted tilt, surfacing the moment V5 made steering direction legible on screen.

**Fix — the AXIS LAW (codified in CLAUDE.md):**
- All east/west geography mirrored to the true convention: centerline drift, Hudson Yards, Riverside/East River shore strips, Washington/Tompkins/Union/Madison/Bryant Squares, Broadway's curve.
- The minimap draws −x (east) on the **right**: it now reads as a normal north-up map *and* the dot moves the same direction you steer.
- The world now matches real Manhattan from the player's seat: running uptown, Broadway and Riverside are on your **left**, the East River on your **right**.

## Legs sinking into sidewalks

The 0.3 m sidewalk plinths were visual-only, so the runner's feet stayed at street level crossing them. Plinth rects are now precomputed with the city data, spatially hashed, and `supportAt` returns 0.3 on them — the runner steps up onto curbs, same treatment as the V5 park terraces. CLAUDE.md law: any raised ground visual must get a `supportAt` entry.

`VERSION` → 6, `CACHE` → `spiderman3d-v6`.

## Verification

Gate **PASS**: street start swings, wall-running stands at 0.30 (on curbs — confirming physical sidewalks), relative handedness +35.3 over 10 samples, deep-canyon 6/6, boot 665 ms, 90 sim-s sweep 15.3 m/s, **0 rope-through-building violations**, 0 JS errors. Overhead map re-rendered with the corrected axis mapping reads as true-orientation Manhattan (Broadway drifts west going north, Riverside on the west shore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBWoQ9irGgsFBoUC8kVg3P