### PR TITLE
Spider-Man 3D V12: full-body anatomy rebuild — an actual human profile

### DIFF
--- a/apps/spiderman3d/CLAUDE.md
+++ b/apps/spiderman3d/CLAUDE.md
@@ -217,7 +217,15 @@ geometry/material-level. The pillars:
   backward. Run arms swing biased BEHIND the body (+0.14 base, hands travel
   hip-to-chest). Suit zones are
   VERTEX COLORS under one neutral webbing texture (one material for the
-  whole body; the crisp belt line is two stations 5 mm apart). Boots are
+  whole body; the crisp belt line is two stations 5 mm apart). BODY PROFILE
+  LAW (V12): the trunk is a HUMAN profile, not a cylinder — V-taper with
+  chest WIDER than deep (rz/rx ≈ 0.6), waist dip, iliac flare, spine
+  S-curve via cz offsets, and the trunk ENDS at a narrow crotch nub where
+  the thighs take over (a broad bottom station reads as a skirt). Hands are
+  wrist→knuckle-flare→finger-taper with a relaxed cz curl (a flat ellipsoid
+  reads as a paddle). Eyes are near-flat decals (z-scale ≈ 0.12) hugging
+  the mask — bulging hemispheres read as bug eyes. Emblem depth must track
+  the pec surface (cz offset + rz) or it sinks into a smear. Boots are
   rigid on the ankle bones; eyes/emblem ride the head/chest bones. The
   animation controller poses BONES with the same setJ/aimLimbAt calls —
   elbows flex NEGATIVE x (forward), knees POSITIVE (backward), don't swap.

--- a/apps/spiderman3d/CLAUDE.md
+++ b/apps/spiderman3d/CLAUDE.md
@@ -21,6 +21,11 @@ re-decision:
 - **Hold-to-swing** (not tap-toggle): finger down on a screen half = that
   hand's web attaches and you swing; lift = release and fly. Both halves at
   once = double-line swing (two rope constraints, stabler and straighter).
+- **HAND-INTENT LAW (V11)**: a right-hand web must grab something on the
+  RIGHT — correct-side (and near-center, sd ≥ -0.06) anchors are a hard
+  first pass in `pickAnchor()`; wrong-side anchors are a fallback only when
+  that side is empty. Straightness comes from the rail assist, NOT from
+  softening this bias (V10 tried that — it broke hand intent).
 - **Assisted auto-anchor** (not physical raycast): `pickAnchor()` scores roof
   points — ahead of travel, matching that hand's side, rope length near
   `LEN_IDEAL`, elevation near ~50°; behind is heavily penalized (forward-flow
@@ -206,7 +211,11 @@ geometry/material-level. The pillars:
   (winding/caps assume it); joint rings carry split weights (0.5/0.5) for
   the smooth bend; limb root rings embed inside the trunk volume so there
   are no junction seams; `bRoot.updateMatrixWorld(true)` must run BEFORE
-  `new Skeleton(...)` or bind inverses are identity garbage. Suit zones are
+  `new Skeleton(...)` or bind inverses are identity garbage. DELTOID LAW: the deltoid caps are FIXED
+  masses on the chest bone and the arm tube starts BELOW its pivot — an arm
+  tube extending above its pivot swings up into "horns" when the arm biases
+  backward. Run arms swing biased BEHIND the body (+0.14 base, hands travel
+  hip-to-chest). Suit zones are
   VERTEX COLORS under one neutral webbing texture (one material for the
   whole body; the crisp belt line is two stations 5 mm apart). Boots are
   rigid on the ankle bones; eyes/emblem ride the head/chest bones. The

--- a/apps/spiderman3d/index.html
+++ b/apps/spiderman3d/index.html
@@ -87,7 +87,7 @@ import * as THREE from 'three';
 
 const BOOT_T0 = performance.now();   // city gen + scene build cost, exposed as __dbg.bootMs
 
-const VERSION = 11;
+const VERSION = 12;
 // the version badge lives ONLY on the title screen (user decision, V5)
 document.getElementById('tver').textContent = 'V' + VERSION;
 
@@ -1058,8 +1058,8 @@ const bSpine = bone(bRoot, 0, 0.12, 0);         // 1.09
 const bChest = bone(bSpine, 0, 0.16, 0);        // 1.25
 const bHead  = bone(bChest, 0, 0.31, 0);        // 1.56
 const bShL = bone(bChest, 0.205, 0.17, 0), bShR = bone(bChest, -0.205, 0.17, 0);   // 1.42
-const bElL = bone(bShL, 0, -0.28, 0),     bElR = bone(bShR, 0, -0.28, 0);        // 1.16
-const bWrL = bone(bElL, 0, -0.26, 0),     bWrR = bone(bElR, 0, -0.26, 0);        // 0.90
+const bElL = bone(bShL, 0, -0.28, 0),     bElR = bone(bShR, 0, -0.28, 0);        // 1.14
+const bWrL = bone(bElL, 0, -0.26, 0),     bWrR = bone(bElR, 0, -0.26, 0);        // 0.88
 const bHipL = bone(bRoot, 0.10, -0.05, 0), bHipR = bone(bRoot, -0.10, -0.05, 0); // 0.92
 const bKnL = bone(bHipL, 0, -0.42, 0),    bKnR = bone(bHipR, 0, -0.42, 0);       // 0.50
 const bAnL = bone(bKnL, 0, -0.40, 0),     bAnR = bone(bKnR, 0, -0.40, 0);        // 0.10
@@ -1122,43 +1122,51 @@ function skinnedTube(stations, capTop = true, capBot = true) {
   return m;
 }
 const R = SUIT_RED, B = SUIT_BLUE;
-// trunk: crotch → hips → waist → chest → shoulders → neck → HEAD, one surface
+// trunk: a HUMAN profile, not a cylinder — V-taper (chest wider than deep),
+// waist dip, iliac hip flare, subtle spine S-curve via cz offsets, ending in
+// a NARROW crotch exactly where the thighs take over (no skirt below the
+// leg line). Ratios matter more than sizes: rz/rx ≈ 0.6 keeps it flat.
 skinnedTube([
-  { y: 0.76, rx: 0.115, rz: 0.085, w: [[bRoot, 1]], col: B },
-  { y: 0.90, rx: 0.150, rz: 0.105, w: [[bRoot, 1]], col: B },
-  { y: 1.00, rx: 0.145, rz: 0.100, w: [[bRoot, 0.6], [bSpine, 0.4]], col: B },
+  { y: 0.815, rx: 0.045, rz: 0.040, w: [[bRoot, 1]], col: B },              // crotch nub (hidden between thighs)
+  { y: 0.84, rx: 0.095, rz: 0.075, w: [[bRoot, 1]], col: B },
+  { y: 0.92, rx: 0.135, rz: 0.094, cz: -0.008, w: [[bRoot, 1]], col: B },   // glutes
+  { y: 1.00, rx: 0.142, rz: 0.096, cz: -0.004, w: [[bRoot, 0.6], [bSpine, 0.4]], col: B },  // iliac crest
   // crisp belt line: two stations a hair apart so red never gradients into blue
-  { y: 1.045, rx: 0.136, rz: 0.094, w: [[bSpine, 1]], col: B },
-  { y: 1.05, rx: 0.136, rz: 0.094, w: [[bSpine, 1]], col: R },
-  { y: 1.10, rx: 0.125, rz: 0.088, w: [[bSpine, 1]], col: R },
-  { y: 1.22, rx: 0.140, rz: 0.094, w: [[bSpine, 0.4], [bChest, 0.6]], col: R },
-  { y: 1.33, rx: 0.163, rz: 0.101, w: [[bChest, 1]], col: R },
-  { y: 1.42, rx: 0.185, rz: 0.100, w: [[bChest, 1]], col: R },
-  { y: 1.475, rx: 0.125, rz: 0.084, w: [[bChest, 1]], col: R },
-  { y: 1.51, rx: 0.052, rz: 0.048, w: [[bChest, 0.4], [bHead, 0.6]], col: R },
-  { y: 1.545, rx: 0.062, rz: 0.06, w: [[bHead, 1]], col: R },
-  { y: 1.60, rx: 0.112, rz: 0.104, w: [[bHead, 1]], col: R },
-  { y: 1.68, rx: 0.124, rz: 0.116, w: [[bHead, 1]], col: R },
-  { y: 1.75, rx: 0.104, rz: 0.100, w: [[bHead, 1]], col: R },
-  { y: 1.80, rx: 0.076, rz: 0.074, w: [[bHead, 1]], col: R },
-  { y: 1.832, rx: 0.048, rz: 0.048, w: [[bHead, 1]], col: R },
-  { y: 1.85, rx: 0.02, rz: 0.02, w: [[bHead, 1]], col: R },   // dome, not a point
+  { y: 1.045, rx: 0.126, rz: 0.088, w: [[bSpine, 1]], col: B },
+  { y: 1.05, rx: 0.126, rz: 0.088, w: [[bSpine, 1]], col: R },
+  { y: 1.10, rx: 0.113, rz: 0.082, cz: -0.004, w: [[bSpine, 1]], col: R },  // waist dip
+  { y: 1.20, rx: 0.138, rz: 0.092, cz: 0.004, w: [[bSpine, 0.4], [bChest, 0.6]], col: R },  // lats
+  { y: 1.30, rx: 0.160, rz: 0.099, cz: 0.010, w: [[bChest, 1]], col: R },   // pec mass
+  { y: 1.38, rx: 0.174, rz: 0.100, cz: 0.008, w: [[bChest, 1]], col: R },
+  { y: 1.43, rx: 0.184, rz: 0.097, w: [[bChest, 1]], col: R },              // shoulder line
+  { y: 1.472, rx: 0.120, rz: 0.082, w: [[bChest, 1]], col: R },             // trap slope
+  { y: 1.508, rx: 0.052, rz: 0.048, w: [[bChest, 0.4], [bHead, 0.6]], col: R },  // neck
+  { y: 1.545, rx: 0.062, rz: 0.058, w: [[bHead, 1]], col: R },              // jaw base
+  { y: 1.585, rx: 0.096, rz: 0.090, w: [[bHead, 1]], col: R },              // jaw
+  { y: 1.65, rx: 0.122, rz: 0.112, w: [[bHead, 1]], col: R },               // cheeks/ears line
+  { y: 1.73, rx: 0.114, rz: 0.107, w: [[bHead, 1]], col: R },
+  { y: 1.78, rx: 0.088, rz: 0.084, w: [[bHead, 1]], col: R },
+  { y: 1.812, rx: 0.060, rz: 0.058, w: [[bHead, 1]], col: R },
+  { y: 1.835, rx: 0.036, rz: 0.035, w: [[bHead, 1]], col: R },
+  { y: 1.848, rx: 0.016, rz: 0.016, w: [[bHead, 1]], col: R },              // crown dome
 ]);
-// arms: deltoid → bicep → elbow → forearm → wrist → mitt, smooth elbow bend
+// arms: bicep/forearm masses with a REAL hand — wrist, knuckle flare,
+// finger taper with a relaxed forward curl (the old mitt read as a paddle)
 function armTube(bSh, bEl, bWr, sx) {
   const x = 0.205 * sx;
   // stations MUST ascend in y (winding/caps assume it)
   return skinnedTube([
-    { y: 0.78, rx: 0.030, rz: 0.024, cx: x, w: [[bWr, 1]], col: R },
-    { y: 0.85, rx: 0.048, rz: 0.034, cx: x, w: [[bWr, 1]], col: R },
-    { y: 0.90, rx: 0.037, rz: 0.036, cx: x, w: [[bEl, 0.4], [bWr, 0.6]], col: R },
-    { y: 0.97, rx: 0.043, rz: 0.042, cx: x, w: [[bEl, 1]], col: R },
-    { y: 1.07, rx: 0.050, rz: 0.048, cx: x, w: [[bEl, 1]], col: R },
-    { y: 1.16, rx: 0.049, rz: 0.048, cx: x, w: [[bSh, 0.5], [bEl, 0.5]], col: R },
-    { y: 1.245, rx: 0.054, rz: 0.052, cx: x, w: [[bSh, 1]], col: R },
-    { y: 1.34, rx: 0.062, rz: 0.060, cx: x, w: [[bSh, 1]], col: R },
-    { y: 1.405, rx: 0.066, rz: 0.064, cx: x, w: [[bSh, 1]], col: R },
-    { y: 1.435, rx: 0.052, rz: 0.050, cx: x, w: [[bSh, 1]], col: R },
+    { y: 0.725, rx: 0.016, rz: 0.011, cx: x, cz: 0.010, w: [[bWr, 1]], col: R },  // fingertips
+    { y: 0.775, rx: 0.036, rz: 0.020, cx: x, cz: 0.006, w: [[bWr, 1]], col: R },  // fingers
+    { y: 0.84, rx: 0.045, rz: 0.025, cx: x, w: [[bWr, 1]], col: R },              // knuckles/palm
+    { y: 0.88, rx: 0.029, rz: 0.020, cx: x, w: [[bEl, 0.4], [bWr, 0.6]], col: R },  // wrist
+    { y: 0.95, rx: 0.040, rz: 0.037, cx: x, w: [[bEl, 1]], col: R },
+    { y: 1.04, rx: 0.052, rz: 0.048, cx: x, w: [[bEl, 1]], col: R },              // forearm bulge
+    { y: 1.14, rx: 0.046, rz: 0.044, cx: x, w: [[bSh, 0.5], [bEl, 0.5]], col: R },  // elbow
+    { y: 1.23, rx: 0.055, rz: 0.051, cx: x, w: [[bSh, 1]], col: R },
+    { y: 1.32, rx: 0.063, rz: 0.058, cx: x, w: [[bSh, 1]], col: R },              // bicep
+    { y: 1.405, rx: 0.066, rz: 0.062, cx: x, w: [[bSh, 1]], col: R },
+    { y: 1.435, rx: 0.050, rz: 0.048, cx: x, w: [[bSh, 1]], col: R },
   ]);
 }
 armTube(bShL, bElL, bWrL, 1);
@@ -1187,11 +1195,11 @@ for (const bAn of [bAnL, bAnR]) {
 }
 // eyes + emblem ride their bones
 for (const s of [-1, 1]) {
-  const outline = part(new THREE.SphereGeometry(0.052, 10, 8), MAT_DARK, 0.048 * s, 0.10, 0.096, bHead);
-  outline.scale.set(1.02, 1.32, 0.26);
+  const outline = part(new THREE.SphereGeometry(0.049, 10, 8), MAT_DARK, 0.047 * s, 0.095, 0.100, bHead);
+  outline.scale.set(1.0, 1.30, 0.13);   // near-flat: eyes are mask DECALS, not bulbs
   outline.rotation.z = -0.30 * s;
-  const lens = part(new THREE.SphereGeometry(0.044, 10, 8), MAT_EYE, 0.049 * s, 0.10, 0.104, bHead);
-  lens.scale.set(0.98, 1.26, 0.24);
+  const lens = part(new THREE.SphereGeometry(0.042, 10, 8), MAT_EYE, 0.048 * s, 0.095, 0.104, bHead);
+  lens.scale.set(0.96, 1.24, 0.12);
   lens.rotation.z = -0.30 * s;
 }
 {

--- a/apps/spiderman3d/index.html
+++ b/apps/spiderman3d/index.html
@@ -1057,7 +1057,7 @@ const bRoot  = bone(null, 0, 0.97, 0);          // pelvis
 const bSpine = bone(bRoot, 0, 0.12, 0);         // 1.09
 const bChest = bone(bSpine, 0, 0.16, 0);        // 1.25
 const bHead  = bone(bChest, 0, 0.31, 0);        // 1.56
-const bShL = bone(bChest, 0.205, 0.17, 0), bShR = bone(bChest, -0.205, 0.17, 0);   // 1.44
+const bShL = bone(bChest, 0.205, 0.17, 0), bShR = bone(bChest, -0.205, 0.17, 0);   // 1.42
 const bElL = bone(bShL, 0, -0.28, 0),     bElR = bone(bShR, 0, -0.28, 0);        // 1.16
 const bWrL = bone(bElL, 0, -0.26, 0),     bWrR = bone(bElR, 0, -0.26, 0);        // 0.90
 const bHipL = bone(bRoot, 0.10, -0.05, 0), bHipR = bone(bRoot, -0.10, -0.05, 0); // 0.92

--- a/apps/spiderman3d/index.html
+++ b/apps/spiderman3d/index.html
@@ -87,7 +87,7 @@ import * as THREE from 'three';
 
 const BOOT_T0 = performance.now();   // city gen + scene build cost, exposed as __dbg.bootMs
 
-const VERSION = 10;
+const VERSION = 11;
 // the version badge lives ONLY on the title screen (user decision, V5)
 document.getElementById('tver').textContent = 'V' + VERSION;
 
@@ -1057,7 +1057,7 @@ const bRoot  = bone(null, 0, 0.97, 0);          // pelvis
 const bSpine = bone(bRoot, 0, 0.12, 0);         // 1.09
 const bChest = bone(bSpine, 0, 0.16, 0);        // 1.25
 const bHead  = bone(bChest, 0, 0.31, 0);        // 1.56
-const bShL = bone(bChest, 0.215, 0.19, 0), bShR = bone(bChest, -0.215, 0.19, 0);   // 1.44
+const bShL = bone(bChest, 0.205, 0.17, 0), bShR = bone(bChest, -0.205, 0.17, 0);   // 1.44
 const bElL = bone(bShL, 0, -0.28, 0),     bElR = bone(bShR, 0, -0.28, 0);        // 1.16
 const bWrL = bone(bElL, 0, -0.26, 0),     bWrR = bone(bElR, 0, -0.26, 0);        // 0.90
 const bHipL = bone(bRoot, 0.10, -0.05, 0), bHipR = bone(bRoot, -0.10, -0.05, 0); // 0.92
@@ -1133,8 +1133,8 @@ skinnedTube([
   { y: 1.10, rx: 0.125, rz: 0.088, w: [[bSpine, 1]], col: R },
   { y: 1.22, rx: 0.140, rz: 0.094, w: [[bSpine, 0.4], [bChest, 0.6]], col: R },
   { y: 1.33, rx: 0.163, rz: 0.101, w: [[bChest, 1]], col: R },
-  { y: 1.42, rx: 0.172, rz: 0.100, w: [[bChest, 1]], col: R },
-  { y: 1.475, rx: 0.115, rz: 0.082, w: [[bChest, 1]], col: R },
+  { y: 1.42, rx: 0.185, rz: 0.100, w: [[bChest, 1]], col: R },
+  { y: 1.475, rx: 0.125, rz: 0.084, w: [[bChest, 1]], col: R },
   { y: 1.51, rx: 0.052, rz: 0.048, w: [[bChest, 0.4], [bHead, 0.6]], col: R },
   { y: 1.545, rx: 0.062, rz: 0.06, w: [[bHead, 1]], col: R },
   { y: 1.60, rx: 0.112, rz: 0.104, w: [[bHead, 1]], col: R },
@@ -1146,7 +1146,7 @@ skinnedTube([
 ]);
 // arms: deltoid → bicep → elbow → forearm → wrist → mitt, smooth elbow bend
 function armTube(bSh, bEl, bWr, sx) {
-  const x = 0.215 * sx;
+  const x = 0.205 * sx;
   // stations MUST ascend in y (winding/caps assume it)
   return skinnedTube([
     { y: 0.78, rx: 0.030, rz: 0.024, cx: x, w: [[bWr, 1]], col: R },
@@ -1157,8 +1157,8 @@ function armTube(bSh, bEl, bWr, sx) {
     { y: 1.16, rx: 0.049, rz: 0.048, cx: x, w: [[bSh, 0.5], [bEl, 0.5]], col: R },
     { y: 1.245, rx: 0.054, rz: 0.052, cx: x, w: [[bSh, 1]], col: R },
     { y: 1.34, rx: 0.062, rz: 0.060, cx: x, w: [[bSh, 1]], col: R },
-    { y: 1.44, rx: 0.072, rz: 0.070, cx: x, w: [[bSh, 1]], col: R },
-    { y: 1.50, rx: 0.055, rz: 0.055, cx: x, w: [[bSh, 1]], col: R },
+    { y: 1.405, rx: 0.066, rz: 0.064, cx: x, w: [[bSh, 1]], col: R },
+    { y: 1.435, rx: 0.052, rz: 0.050, cx: x, w: [[bSh, 1]], col: R },
   ]);
 }
 armTube(bShL, bElL, bWrL, 1);
@@ -1415,22 +1415,30 @@ function pickAnchor(side) {
       const fx = dx / hd, fz = dz / hd;
       const fwd = fx * md.x + fz * md.z;                     // ahead vs behind
       const sd = (fx * rx + fz * rz) * side;                 // matches this hand's side?
-      // side weight kept LOW (was 0.8): strongly-sided anchors weave you
-      // across the street — hugging the travel line makes straight runs easy
-      let score = 2.2 * fwd + 0.5 * sd
+      // forward-dominant scoring; straightness comes from the rail assist,
+      // hand INTENT comes from the hard side partition below
+      let score = 2.2 * fwd + 0.3 * sd
                 - 0.8 * Math.abs(len - LEN_IDEAL) / LEN_IDEAL
                 - 0.5 * Math.abs(elev - 0.9) / 0.9;
       if (fwd < 0) score -= 2.5;                             // forward-only game: behind is a last resort
-      cand.push({ i, score });
+      cand.push({ i, score, sd });
     }
   }
-  // best candidate with a clear line of sight — never start a rope through a building
+  // HAND-INTENT LAW: shooting from the right hand means "grab something on
+  // my right" — correct-side (and near-center) anchors are a hard first
+  // pass; wrong-side anchors are only a fallback when that side is empty.
   cand.sort((a, b) => b.score - a.score);
   const eye = { x: P.pos.x, y: P.pos.y + 1.5, z: P.pos.z };
-  for (let k = 0; k < Math.min(10, cand.length); k++) {
-    const a = anchors[cand[k].i];
-    if (!segBlocked(eye, a)) return a;
-    wrapStats.losReject++;
+  for (const wrongSideOk of [false, true]) {
+    let tried = 0;
+    for (let k = 0; k < cand.length && tried < 10; k++) {
+      if (!wrongSideOk && cand[k].sd < -0.06) continue;   // wrong side: skip in pass 1
+      if (wrongSideOk && cand[k].sd >= -0.06) continue;   // pass 2: only the leftovers
+      tried++;
+      const a = anchors[cand[k].i];
+      if (!segBlocked(eye, a)) return a;
+      wrapStats.losReject++;
+    }
   }
   return null;
 }
@@ -1866,8 +1874,8 @@ function updateSpidey(dt) {
     setJ(legL.foot, 0.30 * Math.sin(gaitPh + 0.7) - 0.12, 0, 0, k);
     setJ(legR.foot, 0.30 * Math.sin(gaitPh + Math.PI + 0.7) - 0.12, 0, 0, k);
     // arms counter-swing, elbows flex more on the forward swing
-    setJ(armL.shoulder,  s * swingAmp * 0.8, 0,  0.10, k);
-    setJ(armR.shoulder, -s * swingAmp * 0.8, 0, -0.10, k);
+    setJ(armL.shoulder, 0.14 + s * swingAmp * 0.8, 0,  0.10, k);
+    setJ(armR.shoulder, 0.14 - s * swingAmp * 0.8, 0, -0.10, k);
     // elbows flex FORWARD (negative x — opposite of knees), more on the front swing
     setJ(armL.elbow, -(1.2 + 0.25 * Math.max(0, -s)), 0, 0, k);
     setJ(armR.elbow, -(1.2 + 0.25 * Math.max(0,  s)), 0, 0, k);

--- a/apps/spiderman3d/sw.js
+++ b/apps/spiderman3d/sw.js
@@ -3,7 +3,7 @@
 // Three.js comes from the CDN and is cached on first fetch below (runtime
 // cache), so the game works offline after one online play.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'spiderman3d-v10';
+const CACHE = 'spiderman3d-v11';
 const SHELL = ['./', './index.html', './icon.png', './apple-touch-icon.png', './icon-192.png', './manifest.webmanifest'];
 
 self.addEventListener('install', e => {

--- a/apps/spiderman3d/sw.js
+++ b/apps/spiderman3d/sw.js
@@ -3,7 +3,7 @@
 // Three.js comes from the CDN and is cached on first fetch below (runtime
 // cache), so the game works offline after one online play.
 // Bump CACHE when a deploy must invalidate old copies immediately.
-const CACHE = 'spiderman3d-v11';
+const CACHE = 'spiderman3d-v12';
 const SHELL = ['./', './index.html', './icon.png', './apple-touch-icon.png', './icon-192.png', './manifest.webmanifest'];
 
 self.addEventListener('install', e => {


### PR DESCRIPTION
> Stacks on unmerged #311 (hand-intent anchors + shoulder anatomy) — merge #311 first or this PR includes it.

Playtest response — every named flaw, rebuilt against real human proportions:

- **"Why is the torso a cylinder?"** It isn't anymore: V-taper with the chest *wider than deep* (rz/rx ≈ 0.6 — human torsos are flat, not round), a real waist dip, iliac hip flare, glute mass, and a subtle spine S-curve via per-station front/back offsets. Shoulder line broadened into the trapezius slope.
- **"Why does it extend past where the legs meet?"** The trunk now ends in a narrow crotch nub tucked between the thighs, exactly where the legs take over — the old broad bottom station hung a visible skirt below the leg line.
- **"Why are the hands shaped weird?"** Real hand structure: wrist → knuckle flare → finger mass → fingertip taper, with a relaxed forward curl. The old flat ellipsoid read as a paddle.
- **"Why are the eyes bulging?"** They're near-flat decals hugging the mask now (z-scale ~0.12, tucked to the head surface) instead of protruding hemispheres.
- Bonus fixes from portrait review: jaw/cheek head profile with a proper crown dome, and the chest emblem re-seated proud of the new pec surface (it sank into a smear when the chest moved forward).

The **BODY PROFILE LAW** is documented in CLAUDE.md so these ratios survive future edits. `VERSION` → 12, `CACHE` → `spiderman3d-v12`. Gate: PASS — 0 clips, 0 errors, canyon 6/6, handedness +38.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBWoQ9irGgsFBoUC8kVg3P