### PR TITLE
Auto: fix flipped left/right controls

### DIFF
--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -56,6 +56,35 @@ console.log(G.isWater(-3000,-2500) /* Magnolia: must be false */,
 A shoreline polygon that doubles back swallows a whole neighbourhood; that is how
 Magnolia disappeared during the first build.
 
+## Heading sense (the sign trap)
+
+`heading` is literally a three.js `rotation.y`, so **forward = `(sin h, cos h)`**
+and heading `0` faces `+Z`, which in this world is *south*. That makes the sim
+consistent with the models (a car's local `+Z` is its nose) but it has one
+consequence that is easy to get backwards:
+
+> **A larger heading rotates anticlockwise — i.e. it turns LEFT on screen.**
+
+So anything converting a screen-space or compass-space intent into a heading has
+to flip the horizontal sign. The three places that do:
+
+- `player.updateDrive`: `steer = -input.x`.
+- `player.updateFoot`: `Math.atan2(-input.x, -input.y) + camYaw + PI`.
+- `hud`: minimap rotates by `camYaw` (not `-camYaw`), the minimap arrow uses
+  `camYaw + PI - heading`, and the north-up full map uses `PI - heading`.
+
+`util.dirDeg()` is the *other* convention (compass bearing, `0` = north,
+clockwise). It is only used for district grid axes in geo.js — never for an
+entity heading. Don't mix them.
+
+To check a change, don't reason about it — measure. Project a world point to
+NDC and see which side of the screen it lands on:
+
+```js
+// facing heading 0, world +X must land at NEGATIVE ndc.x (screen left)
+new THREE.Vector3(p.x + 30, p.y + 1, p.z + 40).project(__dbg.camera).x
+```
+
 ## The one height surface
 
 `geo.rawTerrainHeight()` is expensive (polygon distance tests), so it is baked

--- a/apps/auto/src/hud.js
+++ b/apps/auto/src/hud.js
@@ -132,7 +132,11 @@ export class Hud {
     ctx.arc(S / 2, S / 2, S / 2, 0, Math.PI * 2);
     ctx.clip();
     ctx.translate(S / 2, S / 2);
-    ctx.rotate(-player.camYaw + Math.PI);
+    // The map image is drawn world-aligned (+X right, +Z down). Rotating by
+    // camYaw puts the camera's forward heading (camYaw + PI) at the top and,
+    // because a larger heading is a left turn, also puts the player's
+    // screen-right on the right of the dial.
+    ctx.rotate(player.camYaw);
     ctx.scale(zoom, zoom);
     const sx = (p.x + G.MAP_HALF) * SCALE;
     const sz = (p.z + G.MAP_HALF) * SCALE;
@@ -161,7 +165,8 @@ export class Hud {
     // player arrow, always upright at centre
     ctx.save();
     ctx.translate(S / 2, S / 2);
-    const rel = -player.camYaw + Math.PI + (player.onFoot ? player.heading : player.vehicle ? player.vehicle.heading : 0);
+    const heading = player.onFoot ? player.heading : player.vehicle ? player.vehicle.heading : 0;
+    const rel = player.camYaw + Math.PI - heading;
     ctx.rotate(rel);
     ctx.fillStyle = '#ffffff';
     ctx.strokeStyle = '#101418';
@@ -249,7 +254,8 @@ export class Hud {
     const [px, pz] = toC(p.x, p.z);
     ctx.save();
     ctx.translate(px, pz);
-    ctx.rotate(player.onFoot ? player.heading : player.vehicle ? player.vehicle.heading : 0);
+    // North-up map: heading 0 faces +Z, which is south, i.e. down the page.
+    ctx.rotate(Math.PI - (player.onFoot ? player.heading : player.vehicle ? player.vehicle.heading : 0));
     ctx.fillStyle = '#ffffff';
     ctx.strokeStyle = '#000';
     ctx.lineWidth = 1.5;

--- a/apps/auto/src/player.js
+++ b/apps/auto/src/player.js
@@ -99,8 +99,10 @@ export class Player {
     const run = input.sprint ? 6.4 : 3.3;
     let target = 0;
     if (mag > 0.12) {
-      // stick is camera-relative
-      const ang = Math.atan2(input.x, -input.y) + this.camYaw + Math.PI;
+      // Stick is camera-relative. Note HEADING_SENSE: heading is three.js
+      // rotation.y, so a LARGER heading turns anticlockwise = left on screen.
+      // Pushing the stick right therefore has to subtract from the heading.
+      const ang = Math.atan2(-input.x, -input.y) + this.camYaw + Math.PI;
       this.heading += clamp(angleWrap(ang - this.heading), -10 * dt, 10 * dt);
       target = run * clamp(mag, 0, 1);
     }
@@ -160,7 +162,7 @@ export class Player {
   updateDrive(dt, input, traffic, peds) {
     const v = this.vehicle;
     if (!v) { this.onFoot = true; this.h.group.visible = true; return; }
-    const steer = input.x;
+    const steer = -input.x; // HEADING_SENSE: +steer raises heading, which is a left turn
     const throttle = input.gas ? 1 : 0;
     const brake = input.brake ? 1 : 0;
     v.update(dt, { throttle, brake, steer, handbrake: input.hand ? 1 : 0 });

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -16,7 +16,7 @@
 // fetches by URL with cache:'no-cache' — WebKit rejects fetch() of a
 // navigation-mode Request, which would silently kill the refresh of './' on
 // iOS, and no-cache skips GitHub Pages' 10-minute heuristic.
-const CACHE = 'auto-v1';
+const CACHE = 'auto-v2';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];


### PR DESCRIPTION
Playtest: "the left and right directions, the controls are flipped."

## Cause

`heading` in this game is literally a three.js `rotation.y`, so forward is `(sin h, cos h)` and **a larger heading rotates anticlockwise — a left turn on screen**. Both input paths fed the stick's horizontal axis straight in, so pushing right raised the heading and turned left.

Measured rather than guessed — facing heading 0, world `+X` projects to `ndc.x = -0.54`, i.e. screen left:

```js
new THREE.Vector3(p.x + 30, p.y + 1, p.z + 40).project(__dbg.camera).x  // -0.535
```

## Fix

Flip the sign at the two places where screen intent becomes a heading:

- `player.updateDrive`: `steer = -input.x`
- `player.updateFoot`: `Math.atan2(-input.x, -input.y)`

The minimap inherited the same error and was worse than it looked — it rotated the *wrong way* as you turned, so standing on Alaskan Way with Elliott Bay on your right showed the water on the left of the dial. Both map arrows were wrong too. Now the dial rotates by `camYaw`, the minimap arrow uses `camYaw + PI - heading`, and the north-up full map uses `PI - heading`.

## Verified

- On foot facing `+Z`, stick right moves the player to world `-X` (screen right).
- Driving from heading 0, stick right swings the nose to `-X` and the car curves that way.
- Waterfront screenshot: water is on the right in the 3D view **and** on the right of the minimap.
- Full map arrow points down at heading 0 (= south, north-up map).
- 30 s police-chase stress run, no console errors, draw calls unchanged.

Added a "Heading sense (the sign trap)" section to `apps/auto/CLAUDE.md` with the convention, the three sites that flip it, and the NDC measurement recipe. SW cache bumped to `auto-v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzbBgfdZ4DFiYRkp5Dx7Gh