### PR TITLE
Auto: fix the control stick latching in one direction

### DIFF
--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -56,6 +56,35 @@ console.log(G.isWater(-3000,-2500) /* Magnolia: must be false */,
 A shoreline polygon that doubles back swallows a whole neighbourhood; that is how
 Magnolia disappeared during the first build.
 
+## Input lifecycle (never latch a held pointer)
+
+`pointerup` is not guaranteed. iOS steals the gesture at a screen edge, an
+overlay can open under the finger, and a captured element that gets
+`display:none`'d on a mode switch drops its pointer silently. The rule:
+
+- **No input path may refuse a new press because an old one is still "held".**
+  `onStickDown` used to `return` when `_stickId` was set, so one missing
+  `pointerup` latched the stick at its last deflection *and* made it impossible
+  to ever grab again — the reported "stick stuck in one direction". Last touch
+  wins instead.
+- Held presses listen for `lostpointercapture` as well as `pointerup` /
+  `pointercancel`; that is the event you actually get in the failure cases.
+- `setMode()` clears every button, because switching foot/drive hides the button
+  set that may be under a thumb (exiting a car with GAS down stuck the throttle).
+- `blur` / `pagehide` / `visibilitychange` call `resetAll()`.
+
+Regression test — dispatch synthetic `PointerEvent`s and simply never send the
+`pointerup`, then check a fresh press re-acquires:
+
+```js
+const z = document.getElementById('stickZone');
+const ev = (t, id, x, y) => z.dispatchEvent(new PointerEvent(t,
+  { pointerId: id, clientX: x, clientY: y, bubbles: true, pointerType: 'touch' }));
+ev('pointerdown', 1, 100, 300); ev('pointermove', 1, 180, 300); // stick.x === 1
+ev('pointerdown', 2, 100, 300);                                 // must re-grab
+__dbg.controls.stick.x; // must be 0, and _stickId must be 2
+```
+
 ## Heading sense (the sign trap)
 
 `heading` is literally a three.js `rotation.y`, so **forward = `(sin h, cos h)`**

--- a/apps/auto/src/controls.js
+++ b/apps/auto/src/controls.js
@@ -31,11 +31,24 @@ export class Controls {
     window.addEventListener('pointercancel', (e) => this.onUp(e), opts);
     this.lookZone.addEventListener('pointerdown', (e) => this.onLookDown(e), opts);
 
+    // A held pointer can end without ever delivering pointerup: iOS steals the
+    // gesture at a screen edge, an overlay opens over the finger, or a captured
+    // element gets display:none'd on a mode switch. Every one of those fires
+    // lostpointercapture instead, so listen for it everywhere a press is held.
+    for (const ev of ['pointerup', 'pointercancel', 'lostpointercapture']) {
+      this.stickZone.addEventListener(ev, (e) => {
+        if (e.pointerId === this._stickId) this.releaseStick();
+      }, opts);
+      this.lookZone.addEventListener(ev, (e) => {
+        if (e.pointerId === this._lookId) this.releaseLook();
+      }, opts);
+    }
+
     for (const b of this.buttons) {
       b.addEventListener('pointerdown', (e) => {
         e.preventDefault();
         e.stopPropagation();
-        b.setPointerCapture?.(e.pointerId);
+        try { b.setPointerCapture?.(e.pointerId); } catch (err) { /* capture is best-effort */ }
         this.btn[b.dataset.btn] = true;
         this._pointers.set(e.pointerId, { kind: 'btn', el: b });
         b.classList.add('down');
@@ -49,10 +62,19 @@ export class Controls {
       };
       b.addEventListener('pointerup', up, opts);
       b.addEventListener('pointercancel', up, opts);
+      b.addEventListener('lostpointercapture', up, opts);
       b.addEventListener('pointerleave', (e) => {
         if (e.buttons === 0) up(e);
       });
     }
+
+    // Last resort: anything that takes the app away drops every held input.
+    const panic = () => this.resetAll();
+    window.addEventListener('blur', panic);
+    window.addEventListener('pagehide', panic);
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) panic();
+    });
 
     // keyboard
     this.keys = new Set();
@@ -67,10 +89,40 @@ export class Controls {
     window.addEventListener('blur', () => this.keys.clear());
   }
 
+  releaseStick() {
+    if (this._stickId !== null) this._pointers.delete(this._stickId);
+    this._stickId = null;
+    this.stick.x = 0;
+    this.stick.y = 0;
+    this.stickBase.classList.remove('active');
+    this.stickKnob.style.transform = 'translate(-50%,-50%)';
+  }
+
+  releaseLook() {
+    if (this._lookId !== null) this._pointers.delete(this._lookId);
+    this._lookId = null;
+  }
+
+  /** Drop every held input. Used when the app loses focus or is backgrounded. */
+  resetAll() {
+    this.releaseStick();
+    this.releaseLook();
+    for (const b of this.buttons) {
+      this.btn[b.dataset.btn] = false;
+      b.classList.remove('down');
+    }
+    this._pointers.clear();
+    this.keys.clear();
+  }
+
   onStickDown(e) {
     e.preventDefault();
-    if (this._stickId !== null) return;
+    // Never refuse a new touch because an old one is still "held". If a
+    // pointerup went missing, refusing here latched the stick at its last
+    // deflection with no way to ever grab it again. Last touch wins.
+    if (this._stickId !== null && this._stickId !== e.pointerId) this.releaseStick();
     this._stickId = e.pointerId;
+    try { this.stickZone.setPointerCapture?.(e.pointerId); } catch (err) { /* best-effort */ }
     const r = this.stickZone.getBoundingClientRect();
     this._stickOrigin = { x: e.clientX, y: e.clientY };
     this.stickBase.style.left = `${e.clientX - r.left}px`;
@@ -82,8 +134,9 @@ export class Controls {
 
   onLookDown(e) {
     e.preventDefault();
-    if (this._lookId !== null) return;
+    if (this._lookId !== null && this._lookId !== e.pointerId) this.releaseLook();
     this._lookId = e.pointerId;
+    try { this.lookZone.setPointerCapture?.(e.pointerId); } catch (err) { /* best-effort */ }
     this._lookLast = { x: e.clientX, y: e.clientY };
     this._pointers.set(e.pointerId, { kind: 'look' });
   }
@@ -107,13 +160,9 @@ export class Controls {
     if (!p) return;
     this._pointers.delete(e.pointerId);
     if (p.kind === 'stick') {
-      this._stickId = null;
-      this.stick.x = 0;
-      this.stick.y = 0;
-      this.stickBase.classList.remove('active');
-      this.stickKnob.style.transform = 'translate(-50%,-50%)';
+      this.releaseStick();
     } else if (p.kind === 'look') {
-      this._lookId = null;
+      this.releaseLook();
     } else if (p.kind === 'btn') {
       this.btn[p.el.dataset.btn] = false;
       p.el.classList.remove('down');
@@ -134,6 +183,16 @@ export class Controls {
   setMode(mode) {
     if (this.mode === mode) return;
     this.mode = mode;
+    // Getting in or out of a car display:none's the button set that is on
+    // screen. A button held at that moment would otherwise stay latched on --
+    // most memorably, exiting with GAS down left the throttle stuck open.
+    for (const b of this.buttons) {
+      this.btn[b.dataset.btn] = false;
+      b.classList.remove('down');
+    }
+    for (const [id, p] of [...this._pointers]) {
+      if (p.kind === 'btn') this._pointers.delete(id);
+    }
     this.root.dataset.mode = mode;
   }
 
@@ -158,6 +217,7 @@ export class Controls {
 
   /** Merged analogue state, touch + keyboard. */
   read() {
+    if (this._stickId === null && (this.stick.x || this.stick.y)) this.releaseStick();
     let sx = this.stick.x, sy = this.stick.y;
     if (this.key('KeyA', 'ArrowLeft')) sx -= 1;
     if (this.key('KeyD', 'ArrowRight')) sx += 1;

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -16,7 +16,7 @@
 // fetches by URL with cache:'no-cache' — WebKit rejects fetch() of a
 // navigation-mode Request, which would silently kill the refresh of './' on
 // iOS, and no-cache skips GitHub Pages' 10-minute heuristic.
-const CACHE = 'auto-v2';
+const CACHE = 'auto-v3';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];


### PR DESCRIPTION
Playtest: "the control stick somehow got stuck in one direction, can't move it."

## Cause

```js
onStickDown(e) {
  if (this._stickId !== null) return;   // <- the latch
```

`pointerup` is not guaranteed to arrive. iOS steals the gesture at a screen edge, an overlay can open under the finger, and an element that gets `display:none`'d while holding pointer capture drops its pointer silently. When that happened, `_stickId` stayed set forever: the stick kept its last deflection **and** every subsequent touch was refused, so there was no way to recover short of relaunching.

Reproduced against the shipped build with synthetic PointerEvents — press, drag right, withhold the `pointerup`, press again:

```
heldRight      { x: 1 }
afterNewTouch  { x: 1, id: 1 }   // new touch ignored, stick still hard right
```

## Fix

- **No input path refuses a new press.** Last touch wins, so a stuck stick is always one tap from recovery.
- Stick, look zone and buttons all listen for `lostpointercapture` alongside `pointerup`/`pointercancel` — that's the event the failure cases actually fire.
- `setMode()` clears every button. Switching foot/drive `display:none`s the button set that may be under a thumb; holding GAS while exiting a car could leave the throttle latched on. Same class of bug, so it's fixed here too.
- `blur` / `pagehide` / `visibilitychange` drop all held input.
- `read()` zeroes a stick that has no owning pointer, as a backstop.

## Verified

Same synthetic-pointer harness, after the fix:

| step | stick.x | _stickId |
|---|---|---|
| held right | 1 | 1 |
| pointer vanished, no pointerup | 1 | 1 |
| re-grabbed with a new touch | 0 | 2 |
| released | 0 | null |
| after `lostpointercapture` (from −1) | 0 | null |
| after `blur` | 0 | null |

Plus end-to-end: a real synthetic touch dragged right moves the player screen-right and zeroes on release; button stays cleared across a mode switch; 30 s police-chase stress run with no console errors.

Added an "Input lifecycle (never latch a held pointer)" section to `apps/auto/CLAUDE.md` with the rule and the regression test. SW cache bumped to `auto-v3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzbBgfdZ4DFiYRkp5Dx7Gh