### PR TITLE
Auto: PS3-era graphics pass — PBR lighting, lofted cars, skinned characters

### DIFF
--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -196,16 +196,34 @@ landmarks would otherwise cost hundreds of draw calls.
 
 ## Draw-call budget
 
-Target is ~250 draw calls / ~150k triangles. Costs that crept up during the
-build and how they were paid down:
+Roughly 300 draw calls / 300k triangles during a police chase at `high`.
+`__dbg.sceneStats` reports the scene pass specifically — read `renderer.info`
+yourself and you'll get the post chain's fullscreen quad instead, because the
+counters reset on every `render()`.
+
+Where the budget goes, and the rules that keep it there:
 
 - chunk streaming: `CHUNK = 400`, `NEAR_R = 2` (full detail), `MID_R = 4` (roads
-  only). Up to 7 merged meshes per near chunk.
-- traffic cars bake their wheels into the detail mesh (2 draws each); only the
-  player's car calls `setDetailed(true)` for steerable wheels.
-- crowd pedestrians bake their arms into the torso (3 draws each); the player
-  passes `animateArms: true` for 5.
+  only). Up to 8 merged meshes per near chunk (road, sidewalk, flat, glow, and
+  one per facade material).
+- **vehicles are 3 draws each** — `paint` / `trim` / `matte`, sharing geometry
+  and the two non-paint materials across every instance. Traffic uses the
+  `…GeoW` variants with the wheels baked in; only the player's car calls
+  `setDetailed(true)`, which swaps to the wheel-less geometry and adds four
+  articulated wheel groups.
+- **characters are 1 draw each.** They're `SkinnedMesh`es over a pool of 12
+  shared geometries (`variants()`), so per-instance cost is a skeleton, not a
+  buffer. **Never dispose a pooled geometry** — `makeHumanoid` returns a
+  `dispose()` that no-ops unless the character was built `unique`, and
+  `PedSystem.remove` must go through it. Disposing it directly yanks the GPU
+  buffers out from under every other pedestrian wearing that look.
 - every tall building in the whole city is one static "far skyline" mesh.
+- parked cars only exist within `PARKED_RADIUS` and hide past 140 m.
+
+`roadLift()` is a 3×3-chunk edge scan, so **anything that samples the ground
+more than once a frame computes the lift once and passes it in**: vehicles take
+seven samples, the player two, pedestrians one. Calling `groundAt(x, z, y)`
+without the 4th argument silently re-runs the scan.
 
 ## Verifying
 

--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -114,6 +114,52 @@ NDC and see which side of the screen it lands on:
 new THREE.Vector3(p.x + 30, p.y + 1, p.z + 40).project(__dbg.camera).x
 ```
 
+## Rendering pipeline
+
+Physically-shaded, image-based-lit, tone-mapped, with a hand-rolled post chain.
+
+- **IBL is the ambient.** `textures.js` draws an equirectangular sky; `world.buildSky()`
+  sets it as `scene.background` and runs it through `PMREMGenerator` into
+  `scene.environment`. The analytic lights are only a key plus a fill, so
+  `envMapIntensity` on a material is the main dial for how a surface reads in shade.
+- **Tone mapping is ACES**, applied during the scene pass. Exposure lives in main.js.
+- **Every surface is a set**: albedo + normal + roughness (+ emissive where there
+  are lit windows). Normals are sobel'd from a purpose-drawn *height* pass, not
+  from the albedo, so window reveals read as recesses.
+- **`postfx.js` is deliberately not three's EffectComposer** — no addon files, and
+  every render target can be `UnsignedByteType`. Half-float targets are
+  unreliable on iOS (silent black screen), so the scene is tone-mapped into an
+  8-bit sRGB target and bloom / FXAA / grade / vignette all work in gamma space.
+  If you add a pass, keep it 8-bit.
+- **Adaptive quality.** The phone this ships to can't be profiled from here, so
+  the game measures its own frame rate and steps `high -> medium -> low`
+  (post off, then pixel ratio down). `applyQuality(q, true)` locks it manually.
+  When testing headlessly, set `window.__noAutoQuality = true` **before boot** or
+  SwiftShader's ~5 fps immediately drops the tier and every screenshot lies.
+
+## Models
+
+Cars and characters are the two things a player looks at closely, and both are
+built rather than blocked out:
+
+- **Vehicles** (`vehicles.js`) loft a shell through ~26 sampled cross-sections.
+  The bottom edge of that profile **arches up over each wheel** (`archLift`) —
+  without the cut, tyres just intersect a straight sill and the whole thing
+  reads as a toy. Three geometries per type share materials across all
+  instances: `paint` (tinted per car), `trim` (glass/chrome/lenses/rims,
+  metallic) and `matte` (tyres/plastic/arches). Cars keep a glass greenhouse
+  with a painted roof skin over it; vans, trucks and buses are **painted** bodies
+  with glazing cut in — lofting those in glass turns the upper body into one
+  dark slab.
+- **Characters** (`peds.js`) are `SkinnedMesh`es: one draw call each, but with an
+  18-bone skeleton, so elbows and knees actually bend. Geometry comes from a
+  pool of 12 pre-built looks (per-instance variety is skeleton, scale and gait),
+  and `animateWalk` is a procedural cycle — hip swing with knee flex through the
+  swing phase, counter-rotating chest, level head, breathing idle. The one
+  non-obvious term is the **hip scissor drop**: `hips.y` has to fall by
+  `legLen * (1 - cos(stride))` as the legs open, or the planted foot sinks
+  through the ground and the figure looks like it is floating.
+
 ## The one height surface
 
 `geo.rawTerrainHeight()` is expensive (polygon distance tests), so it is baked
@@ -124,6 +170,18 @@ surface from the one the terrain mesh is built on, roads sink into the ground.
 
 Bridges and freeway decks are separate: `city.groundAt(x, z, currentY)` returns
 the highest deck below `currentY + 2.6`, else the terrain.
+
+**Paved surfaces sit above the terrain and everything standing on them has to be
+lifted by the same amount.** `ROAD_LIFT` / `WALK_LIFT` in citygen.js are the
+single source of truth, shared with world.js. `city.roadLift(x, z)` reports the
+lift at a point; `groundAt` takes it as an optional 4th argument because
+vehicles sample the ground seven times a frame and the edge scan is too
+expensive to repeat per wheel. Forgetting this is what buried every car 22 cm
+into the asphalt.
+
+Sidewalks stop short of each junction (`nodeRadius`) and the corner is filled by
+a ring drawn in `meshNode`. A strip run end to end marches straight across the
+cross street.
 
 ## Geometry building
 

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -199,6 +199,13 @@
   }
   .cta.ghost { background: rgba(255,255,255,0.06); border-color: rgba(255,255,255,0.16); }
   input[type=range] { width: 130px; accent-color: #7ec8f0; }
+  .seg { display: flex; gap: 4px; }
+  .segbtn {
+    padding: 6px 12px; border-radius: 9px; font-size: 12px; font-weight: 700;
+    background: rgba(255,255,255,0.07); border: 1px solid rgba(255,255,255,0.14);
+    color: var(--ink); opacity: .65;
+  }
+  .segbtn.on { background: rgba(90,170,230,0.34); border-color: rgba(150,215,255,0.5); opacity: 1; }
   .help { font-size: 12px; opacity: .65; line-height: 1.5; margin-top: 12px; }
 
   /* ---------- loading ---------- */
@@ -281,6 +288,11 @@
     <div id="pauseCard">
       <h2>AUTO</h2>
       <p class="sub">Seattle, Washington</p>
+      <div class="row"><span>Graphics</span><div class="seg">
+        <button class="segbtn" data-quality="high">High</button>
+        <button class="segbtn" data-quality="medium">Med</button>
+        <button class="segbtn" data-quality="low">Low</button>
+      </div></div>
       <div class="row"><span>Shadows</span><div class="toggle" id="setShadows"></div></div>
       <div class="row"><span>Radio</span><div class="toggle" id="setMusic"></div></div>
       <div class="row"><span>Sound effects</span><div class="toggle" id="setSound"></div></div>

--- a/apps/auto/src/build.js
+++ b/apps/auto/src/build.js
@@ -90,18 +90,81 @@ export class Builder {
    * face goes -- getting that wrong silently backface-culls the whole surface.
    */
   quad(a, b, c, d, n, uvs, col) {
+    // `col` is one rgb triple, or four of them (per corner) for baked AO.
+    // `n` is one normal, or four of them (per corner) for smooth shading.
+    let cols = Array.isArray(col[0]) ? col : [col, col, col, col];
+    let nrm = Array.isArray(n[0]) ? n : [n, n, n, n];
     const ux = b[0] - a[0], uy = b[1] - a[1], uz = b[2] - a[2];
     const vx = c[0] - a[0], vy = c[1] - a[1], vz = c[2] - a[2];
     const cx = uy * vz - uz * vy, cy = uz * vx - ux * vz, cz = ux * vy - uy * vx;
-    if (cx * n[0] + cy * n[1] + cz * n[2] < 0) {
+    if (cx * nrm[0][0] + cy * nrm[0][1] + cz * nrm[0][2] < 0) {
       const t = b; b = d; d = t;
       uvs = [uvs[0], uvs[1], uvs[6], uvs[7], uvs[4], uvs[5], uvs[2], uvs[3]];
+      cols = [cols[0], cols[3], cols[2], cols[1]];
+      nrm = [nrm[0], nrm[3], nrm[2], nrm[1]];
     }
-    const i0 = this.vert(a[0], a[1], a[2], n[0], n[1], n[2], uvs[0], uvs[1], col[0], col[1], col[2]);
-    const i1 = this.vert(b[0], b[1], b[2], n[0], n[1], n[2], uvs[2], uvs[3], col[0], col[1], col[2]);
-    const i2 = this.vert(c[0], c[1], c[2], n[0], n[1], n[2], uvs[4], uvs[5], col[0], col[1], col[2]);
-    const i3 = this.vert(d[0], d[1], d[2], n[0], n[1], n[2], uvs[6], uvs[7], col[0], col[1], col[2]);
+    const i0 = this.vert(a[0], a[1], a[2], nrm[0][0], nrm[0][1], nrm[0][2], uvs[0], uvs[1], cols[0][0], cols[0][1], cols[0][2]);
+    const i1 = this.vert(b[0], b[1], b[2], nrm[1][0], nrm[1][1], nrm[1][2], uvs[2], uvs[3], cols[1][0], cols[1][1], cols[1][2]);
+    const i2 = this.vert(c[0], c[1], c[2], nrm[2][0], nrm[2][1], nrm[2][2], uvs[4], uvs[5], cols[2][0], cols[2][1], cols[2][2]);
+    const i3 = this.vert(d[0], d[1], d[2], nrm[3][0], nrm[3][1], nrm[3][2], uvs[6], uvs[7], cols[3][0], cols[3][1], cols[3][2]);
     this.idx.push(i0, i1, i2, i0, i2, i3);
+  }
+
+  /**
+   * Loft a smooth shell through a list of cross-sections. `rings` is
+   * [{ z, pts: [[x,y], ...] }] with the same point count in every ring; normals
+   * are computed from the surface itself so the result shades smoothly instead
+   * of faceting, which is the whole difference between a car and a box.
+   */
+  loft(rings, col, opts = {}) {
+    const { capStart = false, capEnd = false, colTop = null, topFrom = 1e9 } = opts;
+    const R = rings.length, K = rings[0].pts.length;
+    const P = [];
+    for (let i = 0; i < R; i++) {
+      P.push(rings[i].pts.map((p) => [p[0], p[1], rings[i].z]));
+    }
+    const sub = (a, b) => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+    const cross = (a, b) => [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]];
+    const norm = (v) => {
+      const l = Math.hypot(v[0], v[1], v[2]) || 1;
+      return [v[0] / l, v[1] / l, v[2] / l];
+    };
+    // centroid per ring, used to force normals outward
+    const cen = P.map((ring) => {
+      let x = 0, y = 0;
+      for (const p of ring) { x += p[0]; y += p[1]; }
+      return [x / K, y / K];
+    });
+    const N = [];
+    for (let i = 0; i < R; i++) {
+      N.push([]);
+      for (let k = 0; k < K; k++) {
+        const ip = P[Math.max(0, i - 1)][k], inx = P[Math.min(R - 1, i + 1)][k];
+        const kp = P[i][(k - 1 + K) % K], kn = P[i][(k + 1) % K];
+        let n = norm(cross(sub(kn, kp), sub(inx, ip)));
+        const ox = P[i][k][0] - cen[i][0], oy = P[i][k][1] - cen[i][1];
+        if (n[0] * ox + n[1] * oy < 0) n = [-n[0], -n[1], -n[2]];
+        N[i].push(n);
+      }
+    }
+    for (let i = 0; i < R - 1; i++) {
+      for (let k = 0; k < K; k++) {
+        const k2 = (k + 1) % K;
+        const c0 = colTop && P[i][k][1] > topFrom ? colTop : col;
+        this.quad(P[i][k], P[i][k2], P[i + 1][k2], P[i + 1][k],
+          [N[i][k], N[i][k2], N[i + 1][k2], N[i + 1][k]],
+          [0, 0, 1, 0, 1, 1, 0, 1], c0);
+      }
+    }
+    const cap = (i, dir) => {
+      const c = [cen[i][0], cen[i][1], rings[i].z];
+      for (let k = 0; k < K; k++) {
+        const k2 = (k + 1) % K;
+        this.tri(c, P[i][k], P[i][k2], [0, 0, dir], col);
+      }
+    };
+    if (capStart) cap(0, -1);
+    if (capEnd) cap(R - 1, 1);
   }
 
   tri(a, b, c, n, col) {
@@ -120,7 +183,7 @@ export class Builder {
    * uScale/vScale give metres per texture tile; pass 0 for a 0..1 mapping.
    */
   box(cx, by, cz, w, h, d, rot, col, opts = {}) {
-    const { uScale = 0, vScale = 0, top = true, vOff = 0, sides = true } = opts;
+    const { uScale = 0, vScale = 0, top = true, vOff = 0, sides = true, ao = 0 } = opts;
     const cr = Math.cos(rot), sr = Math.sin(rot);
     const hw = w / 2, hd = d / 2;
     const P = (lx, ly, lz) => [cx + lx * cr - lz * sr, by + ly, cz + lx * sr + lz * cr];
@@ -129,19 +192,23 @@ export class Builder {
     const rd = uScale > 0 ? d / uScale : 1;
     const rv = vScale > 0 ? h / vScale : 1;
     const v0 = vOff;
+    // Cheap baked ambient occlusion: darken the bottom edge of the side faces so
+    // the mass reads as sitting on the ground rather than floating over it.
+    const lo = ao > 0 ? [col[0] * (1 - ao), col[1] * (1 - ao), col[2] * (1 - ao)] : col;
+    const sideCols = ao > 0 ? [lo, lo, col, col] : col;
     if (sides) {
       // +local z
       this.quad(P(-hw, 0, hd), P(hw, 0, hd), P(hw, h, hd), P(-hw, h, hd), N(0, 1),
-        [0, v0, ru, v0, ru, v0 + rv, 0, v0 + rv], col);
+        [0, v0, ru, v0, ru, v0 + rv, 0, v0 + rv], sideCols);
       // -local z
       this.quad(P(hw, 0, -hd), P(-hw, 0, -hd), P(-hw, h, -hd), P(hw, h, -hd), N(0, -1),
-        [0, v0, ru, v0, ru, v0 + rv, 0, v0 + rv], col);
+        [0, v0, ru, v0, ru, v0 + rv, 0, v0 + rv], sideCols);
       // +local x
       this.quad(P(hw, 0, hd), P(hw, 0, -hd), P(hw, h, -hd), P(hw, h, hd), N(1, 0),
-        [0, v0, rd, v0, rd, v0 + rv, 0, v0 + rv], col);
+        [0, v0, rd, v0, rd, v0 + rv, 0, v0 + rv], sideCols);
       // -local x
       this.quad(P(-hw, 0, -hd), P(-hw, 0, hd), P(-hw, h, hd), P(-hw, h, -hd), N(-1, 0),
-        [0, v0, rd, v0, rd, v0 + rv, 0, v0 + rv], col);
+        [0, v0, rd, v0, rd, v0 + rv, 0, v0 + rv], sideCols);
     }
     if (top) {
       this.quad(P(-hw, h, hd), P(hw, h, hd), P(hw, h, -hd), P(-hw, h, -hd), [0, 1, 0],
@@ -183,6 +250,56 @@ export class Builder {
       const mx = Math.cos((a0 + a1) / 2), mz = Math.sin((a0 + a1) / 2);
       this.tri([x0, by, z0], [x1, by, z1], [cx, by + h, cz], [mx, 0.45, mz], col);
     }
+  }
+
+  /**
+   * Loft swept along Y instead of Z, for anything that stands up: torsos,
+   * limbs, necks. `rings` is [{ y, pts: [[x,z], ...] }].
+   */
+  loftY(rings, col, opts = {}) {
+    const { capStart = false, capEnd = false } = opts;
+    const R = rings.length, K = rings[0].pts.length;
+    const P = rings.map((r) => r.pts.map((p) => [p[0], r.y, p[1]]));
+    const sub = (a, b) => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+    const cross = (a, b) => [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]];
+    const norm = (v) => {
+      const l = Math.hypot(v[0], v[1], v[2]) || 1;
+      return [v[0] / l, v[1] / l, v[2] / l];
+    };
+    const cen = P.map((r) => {
+      let x = 0, z = 0;
+      for (const p of r) { x += p[0]; z += p[2]; }
+      return [x / K, z / K];
+    });
+    const N = [];
+    for (let i = 0; i < R; i++) {
+      N.push([]);
+      for (let k = 0; k < K; k++) {
+        const ip = P[Math.max(0, i - 1)][k], inx = P[Math.min(R - 1, i + 1)][k];
+        const kp = P[i][(k - 1 + K) % K], kn = P[i][(k + 1) % K];
+        let n = norm(cross(sub(kn, kp), sub(inx, ip)));
+        const ox = P[i][k][0] - cen[i][0], oz = P[i][k][2] - cen[i][1];
+        if (n[0] * ox + n[2] * oz < 0) n = [-n[0], -n[1], -n[2]];
+        N[i].push(n);
+      }
+    }
+    const colOf = (i) => (Array.isArray(col) && Array.isArray(col[0]) ? col[Math.min(col.length - 1, i)] : col);
+    for (let i = 0; i < R - 1; i++) {
+      for (let k = 0; k < K; k++) {
+        const k2 = (k + 1) % K;
+        this.quad(P[i][k], P[i][k2], P[i + 1][k2], P[i + 1][k],
+          [N[i][k], N[i][k2], N[i + 1][k2], N[i + 1][k]],
+          [0, 0, 1, 0, 1, 1, 0, 1], colOf(i));
+      }
+    }
+    const cap = (i, dir) => {
+      const c = [cen[i][0], rings[i].y, cen[i][1]];
+      for (let k = 0; k < K; k++) {
+        this.tri(c, P[i][k], P[i][(k + 1) % K], [0, dir, 0], colOf(i));
+      }
+    };
+    if (capStart) cap(0, -1);
+    if (capEnd) cap(R - 1, 1);
   }
 
   build() {

--- a/apps/auto/src/build.js
+++ b/apps/auto/src/build.js
@@ -97,7 +97,12 @@ export class Builder {
     const ux = b[0] - a[0], uy = b[1] - a[1], uz = b[2] - a[2];
     const vx = c[0] - a[0], vy = c[1] - a[1], vz = c[2] - a[2];
     const cx = uy * vz - uz * vy, cy = uz * vx - ux * vz, cz = ux * vy - uy * vx;
-    if (cx * nrm[0][0] + cy * nrm[0][1] + cz * nrm[0][2] < 0) {
+    // average the corner normals: with per-corner normals from loft(), a single
+    // unrepresentative corner could flip the whole quad at a high-curvature spot
+    const ax = (nrm[0][0] + nrm[1][0] + nrm[2][0] + nrm[3][0]) / 4;
+    const ay = (nrm[0][1] + nrm[1][1] + nrm[2][1] + nrm[3][1]) / 4;
+    const az = (nrm[0][2] + nrm[1][2] + nrm[2][2] + nrm[3][2]) / 4;
+    if (cx * ax + cy * ay + cz * az < 0) {
       const t = b; b = d; d = t;
       uvs = [uvs[0], uvs[1], uvs[6], uvs[7], uvs[4], uvs[5], uvs[2], uvs[3]];
       cols = [cols[0], cols[3], cols[2], cols[1]];

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -6,6 +6,14 @@ import { rng, dirDeg, distToSeg, clamp, hash2, DEG } from './util.js';
 
 export const CHUNK = 400;
 
+// Road and sidewalk surfaces are drawn slightly proud of the terrain so they
+// don't z-fight it. Anything that stands ON them has to be lifted by the same
+// amount or it sinks into the asphalt -- these are the single source of truth,
+// shared with world.js.
+export const ROAD_LIFT = 0.22;
+export const NODE_LIFT = 0.25;
+export const WALK_LIFT = 0.44;
+
 const CLASS_HW = { hwy: 15, art: 9.5, st: 6.5, res: 5.5, ramp: 5.5 };
 const CLASS_SPEED = { hwy: 30, art: 17, st: 12, res: 9, ramp: 14 };
 
@@ -407,9 +415,41 @@ export function* cityGenerator() {
     drivable,
     surfaces,
 
-    /** Ground height accounting for bridge decks under the given Y. */
-    groundAt(x, z, curY) {
-      const terr = G.terrainHeight(x, z);
+    /**
+     * How far the paved surface at (x,z) sits above the raw terrain. Callers
+     * that sample the ground many times per frame (vehicles take five) should
+     * compute this once for the body centre and pass it in, rather than paying
+     * for the edge scan on every sample.
+     */
+    roadLift(x, z) {
+      let lift = 0;
+      const c0 = Math.floor(x / CHUNK), d0 = Math.floor(z / CHUNK);
+      for (let cx = c0 - 1; cx <= c0 + 1; cx++) {
+        for (let cz = d0 - 1; cz <= d0 + 1; cz++) {
+          const c = chunks.get(ck(cx, cz));
+          if (!c) continue;
+          for (const ei of c.edges) {
+            const e = g.edges[ei];
+            if (e.elev) continue;
+            const a = g.nodes[e.a], b = g.nodes[e.b];
+            const r = distToSeg(x, z, a.x, a.z, b.x, b.z);
+            const walk = (e.cls === 'st' || e.cls === 'art' || e.cls === 'res')
+              ? (e.cls === 'art' ? 3.2 : 2.6) : 0;
+            const outer = e.hw + walk;
+            if (r.d > outer) continue;
+            let l = r.d <= e.hw ? ROAD_LIFT : WALK_LIFT;
+            // taper the last half metre so nothing steps off a cliff edge
+            if (r.d > outer - 0.5) l *= (outer - r.d) / 0.5;
+            if (l > lift) lift = l;
+          }
+        }
+      }
+      return lift;
+    },
+
+    /** Ground height accounting for paved lift and for bridge decks under Y. */
+    groundAt(x, z, curY, lift) {
+      const terr = G.terrainHeight(x, z) + (lift != null ? lift : this.roadLift(x, z));
       let best = terr;
       const l = surfGrid.get(skey(Math.floor(x / surfCell), Math.floor(z / surfCell)));
       if (l) {
@@ -417,7 +457,7 @@ export function* cityGenerator() {
           const s = surfaces[si];
           const r = distToSeg(x, z, s.ax, s.az, s.bx, s.bz);
           if (r.d > s.hw) continue;
-          const y = s.ay + (s.by - s.ay) * r.t;
+          const y = s.ay + (s.by - s.ay) * r.t + ROAD_LIFT * 0.3;
           if (curY == null || y <= curY + 2.6) {
             if (y > best) best = y;
           }

--- a/apps/auto/src/main.js
+++ b/apps/auto/src/main.js
@@ -13,6 +13,7 @@ import { Controls } from './controls.js';
 import { Hud, buildMapCanvas } from './hud.js';
 import { Effects } from './effects.js';
 import { Audio } from './audio.js';
+import { PostFX } from './postfx.js';
 import { clamp, lerp, rng, dist2, formatMoney } from './util.js';
 
 const app = document.getElementById('app');
@@ -192,10 +193,11 @@ class Game {
 
 // ---------------------------------------------------------------------------
 
-let renderer, scene, camera, sun, world, cityRef, traffic, peds, player, controls, hud, fx, audio, game, marker;
+let renderer, scene, camera, sun, world, cityRef, traffic, peds, player, controls, hud, fx, audio, game, marker, postfx;
 let pickups = [];
 let last = 0;
 let accumFps = 0, frames = 0, fps = 60;
+let startedAt = 0;
 
 async function boot() {
   const step = async (p, msg) => {
@@ -233,8 +235,12 @@ async function boot() {
   // --- renderer ---
   const canvas = document.getElementById('gl');
   const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
-  renderer = new THREE.WebGLRenderer({ canvas, antialias: !isMobile, powerPreference: 'high-performance' });
+  // Antialiasing comes from FXAA in the post chain, so the context never needs
+  // MSAA -- which also means the scene can render into a target for free.
+  renderer = new THREE.WebGLRenderer({ canvas, antialias: false, powerPreference: 'high-performance' });
   renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, isMobile ? 2 : 1.6));
+  renderer.toneMapping = THREE.ACESFilmicToneMapping;
+  renderer.toneMappingExposure = 1.5;
   const viewW = () => canvas.clientWidth || window.innerWidth;
   const viewH = () => canvas.clientHeight || window.innerHeight;
   renderer.setSize(viewW(), viewH(), false);
@@ -243,27 +249,33 @@ async function boot() {
   renderer.outputColorSpace = THREE.SRGBColorSpace;
 
   scene = new THREE.Scene();
-  scene.fog = new THREE.FogExp2(0xbdc9d2, 0.00035);
-  camera = new THREE.PerspectiveCamera(64, viewW() / viewH(), 0.6, 9000);
+  scene.fog = new THREE.FogExp2(0xb9c6d0, 0.00032);
+  camera = new THREE.PerspectiveCamera(62, viewW() / viewH(), 0.5, 9000);
 
-  const hemi = new THREE.HemisphereLight(0xdfeaf2, 0x54604f, 1.0);
+  // The sky IBL supplies most of the ambient, so the analytic lights are just a
+  // key with a cool bounce fill.
+  const hemi = new THREE.HemisphereLight(0xdcecf6, 0x7b8474, 2.0);
   scene.add(hemi);
-  sun = new THREE.DirectionalLight(0xfff3e2, 1.15);
+  sun = new THREE.DirectionalLight(0xfff0d8, 2.5);
   sun.position.set(-160, 240, -110);
   sun.castShadow = true;
-  sun.shadow.mapSize.set(1024, 1024);
+  sun.shadow.mapSize.set(2048, 2048);
   sun.shadow.camera.near = 20;
-  sun.shadow.camera.far = 520;
-  const S = 90;
+  sun.shadow.camera.far = 620;
+  const S = 105;
   sun.shadow.camera.left = -S;
   sun.shadow.camera.right = S;
   sun.shadow.camera.top = S;
   sun.shadow.camera.bottom = -S;
-  sun.shadow.bias = -0.0012;
+  sun.shadow.bias = -0.0009;
+  sun.shadow.normalBias = 0.04;
   scene.add(sun);
   scene.add(sun.target);
 
-  world = new World(scene, city, tx, { shadows: true });
+  postfx = new PostFX(renderer);
+  postfx.setSize(viewW(), viewH(), renderer.getPixelRatio());
+
+  world = new World(scene, city, tx, { shadows: true, renderer });
   world.buildSky();
   const terrGen = world.buildTerrain();
   let tr = terrGen.next();
@@ -312,9 +324,11 @@ async function boot() {
   }
 
   await step(1, 'Welcome to Seattle');
-  window.__dbg = { game, city, player, world, traffic, peds, scene, camera, renderer, G, fx, hud, controls, audio, pickups, THREE };
+  window.__dbg = { game, city, player, world, traffic, peds, scene, camera, renderer, G, fx, hud, controls, audio, pickups, THREE, postfx, applyQuality, sun, sceneStats };
   wireUi();
   game.newTarget();
+  applyQuality('high', false);
+  startedAt = performance.now();
   loading.classList.add('hide');
   setTimeout(() => loading.remove(), 700);
   last = performance.now();
@@ -435,7 +449,10 @@ function wireUi() {
     });
     el.classList.toggle('on', game.settings[key]);
   };
-  bind('setShadows', 'shadows', (v) => { renderer.shadowMap.enabled = v; scene.traverse((o) => { if (o.isMesh) o.material.needsUpdate = true; }); });
+  bind('setShadows', 'shadows', (v) => { renderer.shadowMap.enabled = v && game.settings.quality !== 'low'; });
+  for (const el of document.querySelectorAll('[data-quality]')) {
+    el.addEventListener('click', () => applyQuality(el.dataset.quality, true));
+  }
   bind('setMusic', 'music', (v) => { audio.musicOn = v; });
   bind('setSound', 'sound', (v) => { audio.enabled = v; });
 
@@ -467,6 +484,7 @@ function wireUi() {
     renderer.setSize(w, h, false);
     camera.aspect = w / h;
     camera.updateProjectionMatrix();
+    postfx.setSize(w, h, renderer.getPixelRatio());
     hud.resize();
   };
   window.addEventListener('resize', fit);
@@ -506,7 +524,7 @@ function frame(now) {
   }
 
   if (game.paused || game.mapOpen) {
-    renderer.render(scene, camera);
+    draw(now);
     return;
   }
 
@@ -593,7 +611,54 @@ function frame(now) {
   });
 
   hud.update(dt, game, player, traffic);
+  world.animate(dt, now / 1000);
+  draw(now);
+  autoQuality(dt);
+}
+
+function draw(now) {
+  renderer.setRenderTarget(postfx.target);
   renderer.render(scene, camera);
+  // capture before the post passes reset the counters
+  sceneStats.calls = renderer.info.render.calls;
+  sceneStats.tris = renderer.info.render.triangles;
+  postfx.render(now / 1000);
+  renderer.setRenderTarget(null);
+}
+const sceneStats = { calls: 0, tris: 0 };
+
+// The phone this ships to can't be profiled from here, so the game measures
+// itself and steps the quality down if it can't hold frame rate.
+const TIERS = ['high', 'medium', 'low'];
+let tierIdx = 0;
+let slowFor = 0;
+let qualityLocked = false;
+
+function autoQuality(dt) {
+  if (qualityLocked || tierIdx >= TIERS.length - 1) return;
+  if (performance.now() - startedAt < 4000) return;
+  if (window.__noAutoQuality) return;
+  slowFor = fps < 40 ? slowFor + dt : 0;
+  if (slowFor > 2.5) {
+    slowFor = 0;
+    applyQuality(TIERS[++tierIdx], false);
+    hud.showToast(`Graphics: ${TIERS[tierIdx]}`);
+  }
+}
+
+function applyQuality(q, manual) {
+  if (manual) { qualityLocked = true; tierIdx = TIERS.indexOf(q); }
+  game.settings.quality = q;
+  postfx.setQuality(q);
+  renderer.shadowMap.enabled = q !== 'low' && game.settings.shadows;
+  const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+  const cap = q === 'high' ? (isMobile ? 2 : 1.6) : q === 'medium' ? 1.5 : 1.15;
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, cap));
+  renderer.setSize(renderer.domElement.clientWidth, renderer.domElement.clientHeight, false);
+  postfx.setSize(renderer.domElement.clientWidth, renderer.domElement.clientHeight, renderer.getPixelRatio());
+  for (const el of document.querySelectorAll('[data-quality]')) {
+    el.classList.toggle('on', el.dataset.quality === q);
+  }
 }
 
 boot().catch((e) => {

--- a/apps/auto/src/peds.js
+++ b/apps/auto/src/peds.js
@@ -14,83 +14,375 @@ const SHIRTS = [
 const PANTS = [[0.18, 0.22, 0.34], [0.2, 0.2, 0.22], [0.35, 0.3, 0.25], [0.45, 0.45, 0.48], [0.12, 0.14, 0.18]];
 const HAIR = [[0.12, 0.09, 0.07], [0.35, 0.22, 0.1], [0.6, 0.5, 0.32], [0.75, 0.75, 0.75], [0.5, 0.15, 0.1]];
 
-const pedMat = new THREE.MeshLambertMaterial({ vertexColors: true });
+const pedMat = new THREE.MeshStandardMaterial({
+  vertexColors: true, roughness: 0.87, metalness: 0.0, envMapIntensity: 0.7,
+});
+
+// Skeleton layout. Characters are skinned meshes: one draw call each, but with
+// real elbows, knees and a spine, which is the difference between a walk cycle
+// and a pair of swinging planks.
+const B = {
+  root: 0, hips: 1, spine: 2, chest: 3, neck: 4, head: 5,
+  shoulderL: 6, elbowL: 7, handL: 8,
+  shoulderR: 9, elbowR: 10, handR: 11,
+  thighL: 12, kneeL: 13, footL: 14,
+  thighR: 15, kneeR: 16, footR: 17,
+};
+const BONE_COUNT = 18;
+
+// Joint heights in character space (feet at y = 0, nominal height 1.75 m)
+const J = {
+  hip: 0.90, spine: 1.02, chest: 1.22, neck: 1.46, head: 1.53,
+  shoulder: 1.385, elbow: 1.085, wrist: 0.805,
+  knee: 0.46, ankle: 0.055,
+};
+const SHOULDER_X = 0.150;
+const HIP_X = 0.068;
+
+function makeSkeletonBones() {
+  const bones = [];
+  for (let i = 0; i < BONE_COUNT; i++) bones.push(new THREE.Bone());
+  const set = (b, x, y, z) => bones[b].position.set(x, y, z);
+  const link = (parent, child) => bones[parent].add(bones[child]);
+
+  set(B.root, 0, 0, 0);
+  set(B.hips, 0, J.hip, 0);
+  set(B.spine, 0, J.spine - J.hip, 0);
+  set(B.chest, 0, J.chest - J.spine, 0);
+  set(B.neck, 0, J.neck - J.chest, 0);
+  set(B.head, 0, J.head - J.neck, 0);
+  set(B.shoulderL, -SHOULDER_X, J.shoulder - J.chest, 0);
+  set(B.elbowL, 0, J.elbow - J.shoulder, 0);
+  set(B.handL, 0, J.wrist - J.elbow, 0);
+  set(B.shoulderR, SHOULDER_X, J.shoulder - J.chest, 0);
+  set(B.elbowR, 0, J.elbow - J.shoulder, 0);
+  set(B.handR, 0, J.wrist - J.elbow, 0);
+  set(B.thighL, -HIP_X, 0, 0);
+  set(B.kneeL, 0, J.knee - J.hip, 0);
+  set(B.footL, 0, J.ankle - J.knee, 0);
+  set(B.thighR, HIP_X, 0, 0);
+  set(B.kneeR, 0, J.knee - J.hip, 0);
+  set(B.footR, 0, J.ankle - J.knee, 0);
+
+  link(B.root, B.hips);
+  link(B.hips, B.spine); link(B.spine, B.chest);
+  link(B.chest, B.neck); link(B.neck, B.head);
+  link(B.chest, B.shoulderL); link(B.shoulderL, B.elbowL); link(B.elbowL, B.handL);
+  link(B.chest, B.shoulderR); link(B.shoulderR, B.elbowR); link(B.elbowR, B.handR);
+  link(B.hips, B.thighL); link(B.thighL, B.kneeL); link(B.kneeL, B.footL);
+  link(B.hips, B.thighR); link(B.thighR, B.kneeR); link(B.kneeR, B.footR);
+  return bones;
+}
+
+/** Elliptical cross-section in the XZ plane. */
+function oval(rx, rz, n = 10, ox = 0, oz = 0) {
+  const pts = [];
+  for (let i = 0; i < n; i++) {
+    const a = (i / n) * Math.PI * 2;
+    pts.push([ox + Math.cos(a) * rx, oz + Math.sin(a) * rz]);
+  }
+  return pts;
+}
+
+const smoothT = (v) => v * v * (3 - 2 * v);
 
 /**
- * Builds a blocky humanoid. Returns the group plus the limb meshes so callers
- * can animate a walk cycle.
+ * Accumulates parts into one skinned geometry. Each part supplies a weight
+ * function so vertices near a joint blend between two bones instead of
+ * creasing.
  */
-export function makeHumanoid(opts = {}) {
+class SkinAcc {
+  constructor() {
+    this.pos = []; this.nor = []; this.col = []; this.idx = [];
+    this.si = []; this.sw = [];
+  }
+  add(builder, weightFn) {
+    const base = this.pos.length / 3;
+    for (let i = 0; i < builder.pos.length; i += 3) {
+      const x = builder.pos[i], y = builder.pos[i + 1], z = builder.pos[i + 2];
+      this.pos.push(x, y, z);
+      this.nor.push(builder.nor[i], builder.nor[i + 1], builder.nor[i + 2]);
+      this.col.push(builder.col[i], builder.col[i + 1], builder.col[i + 2]);
+      const w = weightFn(x, y, z);
+      this.si.push(w[0], w[2] != null ? w[2] : 0, 0, 0);
+      this.sw.push(w[1], w[3] != null ? w[3] : 0, 0, 0);
+    }
+    for (const ix of builder.idx) this.idx.push(base + ix);
+  }
+  build() {
+    const g = new THREE.BufferGeometry();
+    g.setAttribute('position', new THREE.Float32BufferAttribute(this.pos, 3));
+    g.setAttribute('normal', new THREE.Float32BufferAttribute(this.nor, 3));
+    g.setAttribute('color', new THREE.Float32BufferAttribute(this.col, 3));
+    g.setAttribute('skinIndex', new THREE.Uint16BufferAttribute(this.si, 4));
+    g.setAttribute('skinWeight', new THREE.Float32BufferAttribute(this.sw, 4));
+    g.setIndex(this.idx);
+    g.computeBoundingSphere();
+    g.computeBoundingBox();
+    return g;
+  }
+}
+
+/** Blend between two bones across a joint at height `jy`. */
+const across = (jy, span, above, below) => (x, y) => {
+  const t = smoothT(clamp((y - (jy - span)) / (span * 2), 0, 1));
+  return [above, t, below, 1 - t];
+};
+const solid = (b) => () => [b, 1, 0, 0];
+
+function limbInto(b, segs, col) {
+  b.loftY(segs.map((sg) => ({ y: sg[0], pts: oval(sg[1], sg[2], 8) })), col,
+    { capStart: true, capEnd: true });
+}
+
+/**
+ * Builds one character variant: a skinned geometry in the rest pose. Callers
+ * pair it with a fresh skeleton per instance.
+ */
+export function buildCharacter(opts = {}) {
   const seed = opts.seed != null ? opts.seed : 0;
   const skin = opts.skin || SKINS[Math.floor(hash2(seed, 1) * SKINS.length)];
   const shirt = opts.shirt || SHIRTS[Math.floor(hash2(seed, 2) * SHIRTS.length)];
   const pants = opts.pants || PANTS[Math.floor(hash2(seed, 3) * PANTS.length)];
   const hair = opts.hair || HAIR[Math.floor(hash2(seed, 4) * HAIR.length)];
-  const scale = opts.scale || (0.92 + hash2(seed, 5) * 0.18);
+  const build = 0.92 + hash2(seed, 6) * 0.16;
+  const jacket = opts.vest ? true : hash2(seed, 7) > 0.5;
+  const shortSleeve = !jacket && hash2(seed, 8) > 0.55;
+  const shoeCol = [0.11, 0.11, 0.12];
+  const coat = jacket ? [shirt[0] * 0.66, shirt[1] * 0.66, shirt[2] * 0.7] : shirt;
+
+  const acc = new SkinAcc();
+  const bw = 0.132 * build, bd = 0.096 * build;
+  const cw = 0.160 * build, cd = 0.112 * build;
+  const sw = 0.152 * build, sd = 0.107 * build;
+  const outer = jacket ? 1.05 : 1.0;
+
+  // --- pelvis + torso ------------------------------------------------------
+  const pelvis = new Builder(false);
+  pelvis.loftY([
+    { y: J.hip - 0.14, pts: oval(bw * 0.95, bd * 0.97, 10) },
+    { y: J.hip, pts: oval(bw, bd, 10) },
+    { y: J.hip + 0.07, pts: oval(bw * 0.95, bd * 0.95, 10) },
+  ], pants, { capStart: true });
+  acc.add(pelvis, across(J.spine - 0.06, 0.09, B.spine, B.hips));
 
   const torso = new Builder(false);
-  // hips -> shoulders
-  torso.box(0, 0, 0, 0.42, 0.52, 0.24, 0, shirt);
-  torso.box(0, 0.52, 0, 0.2, 0.12, 0.2, 0, skin); // neck
-  torso.box(0, 0.64, 0, 0.27, 0.28, 0.26, 0, skin); // head
-  torso.box(0, 0.85, 0, 0.29, 0.09, 0.28, 0, hair);
-  torso.box(0, 0.78, -0.02, 0.30, 0.09, 0.30, 0, hair);
-  if (opts.hat) torso.box(0, 0.9, 0, 0.34, 0.08, 0.36, 0, opts.hat);
-  if (opts.vest) torso.box(0, 0.06, 0, 0.45, 0.4, 0.27, 0, opts.vest);
-
-  const armB = () => {
-    const b = new Builder(false);
-    b.box(0, -0.44, 0, 0.13, 0.36, 0.14, 0, shirt);
-    b.box(0, -0.62, 0, 0.12, 0.2, 0.13, 0, skin);
-    return b.build();
-  };
-  // Crowd extras bake their arms into the torso: 3 draw calls per body instead
-  // of 5, which matters once there are two dozen of them on screen.
-  if (!opts.animateArms) {
-    for (const sx of [-0.28, 0.28]) {
-      torso.box(sx, -0.02, 0, 0.13, 0.36, 0.14, 0, shirt);
-      torso.box(sx, -0.20, 0, 0.12, 0.2, 0.13, 0, skin);
-    }
+  torso.loftY([
+    { y: J.hip + 0.06, pts: oval(bw * 0.93 * outer, bd * 0.94 * outer, 10) },
+    { y: J.spine, pts: oval(bw * 0.86 * outer, bd * 0.9 * outer, 10) },
+    { y: J.chest, pts: oval(cw * outer, cd * outer, 10) },
+    { y: J.shoulder - 0.02, pts: oval(sw * outer, sd * outer, 10) },
+    { y: J.shoulder + 0.045, pts: oval(sw * 0.7 * outer, sd * 0.88 * outer, 10) },
+    { y: J.shoulder + 0.085, pts: oval(sw * 0.42 * outer, sd * 0.66 * outer, 10) },
+  ], coat, {});
+  if (jacket) {
+    torso.box(0, J.hip + 0.07, bd * 0.92 * outer, 0.04, J.chest - J.hip + 0.18, 0.02, 0,
+      [coat[0] * 0.6, coat[1] * 0.6, coat[2] * 0.64]);
   }
-  const legB = () => {
-    const b = new Builder(false);
-    b.box(0, -0.44, 0, 0.16, 0.46, 0.16, 0, pants);
-    b.box(0, -0.52, 0.03, 0.17, 0.09, 0.26, 0, [0.14, 0.13, 0.13]);
-    return b.build();
-  };
-
-  const g = new THREE.Group();
-  const body = new THREE.Mesh(torso.build(), pedMat);
-  body.position.y = 0.86;
-  g.add(body);
-
-  const mkLimb = (geo, x, y) => {
-    const m = new THREE.Mesh(geo, pedMat);
-    m.position.set(x, y, 0);
-    g.add(m);
-    return m;
-  };
-  const legGeo = legB();
-  let armL = null, armR = null;
-  if (opts.animateArms) {
-    const armGeo = armB();
-    armL = mkLimb(armGeo, -0.28, 1.32);
-    armR = mkLimb(armGeo, 0.28, 1.32);
+  if (opts.vest) {
+    torso.loftY([
+      { y: J.hip + 0.12, pts: oval(bw * 1.03 * outer, bd * 1.05 * outer, 10) },
+      { y: J.chest + 0.06, pts: oval(cw * 1.03 * outer, cd * 1.05 * outer, 10) },
+      { y: J.shoulder - 0.04, pts: oval(sw * 0.98 * outer, sd * 1.02 * outer, 10) },
+    ], opts.vest, {});
   }
-  const legL = mkLimb(legGeo, -0.11, 0.88);
-  const legR = mkLimb(legGeo, 0.11, 0.88);
-  g.scale.setScalar(scale);
-  g.traverse((o) => { if (o.isMesh) o.castShadow = true; });
-  return { group: g, body, armL, armR, legL, legR, height: 1.75 * scale };
+  acc.add(torso, (x, y) => {
+    if (y < J.spine) return across(J.spine - 0.05, 0.1, B.spine, B.hips)(x, y);
+    return across(J.chest - 0.06, 0.12, B.chest, B.spine)(x, y);
+  });
+
+  // --- neck + head ---------------------------------------------------------
+  const head = new Builder(false);
+  head.loftY([
+    { y: J.shoulder + 0.03, pts: oval(0.061, 0.057, 8) },
+    { y: J.neck + 0.02, pts: oval(0.051, 0.049, 8) },
+  ], skin, {});
+  const HY = J.neck + 0.09;
+  head.loftY([
+    { y: J.neck - 0.01, pts: oval(0.056, 0.055, 10) },
+    { y: J.neck + 0.05, pts: oval(0.079, 0.086, 10, 0, 0.006) },
+    { y: HY, pts: oval(0.094, 0.102, 10, 0, 0.006) },
+    { y: HY + 0.07, pts: oval(0.091, 0.098, 10, 0, 0.002) },
+    { y: HY + 0.13, pts: oval(0.062, 0.066, 10, 0, -0.008) },
+    { y: HY + 0.16, pts: oval(0.026, 0.028, 10, 0, -0.012) },
+  ], skin, { capStart: true, capEnd: true });
+  head.loftY([
+    { y: HY - 0.075, pts: oval(0.086, 0.094, 10, 0, -0.032) },
+    { y: HY - 0.015, pts: oval(0.098, 0.106, 10, 0, -0.018) },
+    { y: HY + 0.072, pts: oval(0.096, 0.102, 10, 0, -0.018) },
+    { y: HY + 0.132, pts: oval(0.066, 0.070, 10, 0, -0.02) },
+    { y: HY + 0.163, pts: oval(0.027, 0.029, 10, 0, -0.016) },
+  ], hair, { capEnd: true });
+  head.box(0, HY + 0.03, 0.086, 0.125, 0.02, 0.028, 0, hair);
+  head.box(0, HY - 0.012, 0.09, 0.026, 0.048, 0.032, 0, skin);
+  for (const sx of [-0.04, 0.04]) head.box(sx, HY + 0.008, 0.088, 0.026, 0.016, 0.018, 0, [0.13, 0.12, 0.13]);
+  if (opts.hat) {
+    head.loftY([
+      { y: HY + 0.06, pts: oval(0.104, 0.111, 10) },
+      { y: HY + 0.15, pts: oval(0.097, 0.103, 10) },
+      { y: HY + 0.178, pts: oval(0.068, 0.073, 10) },
+    ], opts.hat, { capEnd: true });
+    head.box(0, HY + 0.055, 0.078, 0.196, 0.02, 0.13, 0, opts.hat);
+  }
+  acc.add(head, (x, y) => {
+    if (y < J.neck) return across(J.neck - 0.04, 0.07, B.neck, B.chest)(x, y);
+    return across(J.head + 0.01, 0.05, B.head, B.neck)(x, y);
+  });
+
+  // --- arms ----------------------------------------------------------------
+  for (const side of [-1, 1]) {
+    const arm = new Builder(false);
+    const X = side * SHOULDER_X;
+    const seg = (y, rx, rz) => [y, rx, rz];
+    const upper = new Builder(false);
+    upper.loftY([
+      { y: J.shoulder + 0.038, pts: oval(0.028, 0.026, 8, X, 0) },
+      { y: J.shoulder + 0.018, pts: oval(0.050, 0.047, 8, X, 0) },
+      { y: J.shoulder - 0.022, pts: oval(0.060, 0.057, 8, X, 0) },
+      { y: J.shoulder - 0.10, pts: oval(0.051, 0.049, 8, X, 0) },
+      { y: J.elbow + 0.02, pts: oval(0.044, 0.043, 8, X, 0) },
+      { y: J.elbow - 0.02, pts: oval(0.043, 0.042, 8, X, 0) },
+      { y: J.wrist + 0.03, pts: oval(0.035, 0.034, 8, X, 0) },
+    ], shortSleeve
+      ? [coat, coat, coat, coat, skin, skin, skin]
+      : coat, { capStart: true, capEnd: true });
+    arm.pos = upper.pos; arm.nor = upper.nor; arm.col = upper.col; arm.idx = upper.idx;
+    acc.add(arm, (x, y) => {
+      if (y > J.elbow) return across(J.elbow + 0.05, 0.09, side < 0 ? B.shoulderL : B.shoulderR, side < 0 ? B.elbowL : B.elbowR)(x, y);
+      return [side < 0 ? B.elbowL : B.elbowR, 1, 0, 0];
+    });
+    const hand = new Builder(false);
+    hand.loftY([
+      { y: J.wrist + 0.01, pts: oval(0.034, 0.031, 8, X, 0) },
+      { y: J.wrist - 0.05, pts: oval(0.039, 0.029, 8, X, 0.004) },
+      { y: J.wrist - 0.115, pts: oval(0.029, 0.022, 8, X, 0.006) },
+    ], skin, { capStart: true, capEnd: true });
+    acc.add(hand, solid(side < 0 ? B.handL : B.handR));
+  }
+
+  // --- legs ----------------------------------------------------------------
+  for (const side of [-1, 1]) {
+    const X = side * HIP_X;
+    const leg = new Builder(false);
+    leg.loftY([
+      { y: J.hip + 0.03, pts: oval(0.092, 0.09, 8, X, 0) },
+      { y: J.hip - 0.08, pts: oval(0.086, 0.085, 8, X, 0) },
+      { y: J.knee + 0.08, pts: oval(0.062, 0.062, 8, X, 0) },
+      { y: J.knee + 0.02, pts: oval(0.058, 0.059, 8, X, 0) },
+      { y: J.knee - 0.03, pts: oval(0.058, 0.060, 8, X, 0.004) },
+      { y: J.knee - 0.16, pts: oval(0.055, 0.058, 8, X, 0.002) },
+      { y: J.ankle + 0.09, pts: oval(0.042, 0.045, 8, X, 0) },
+    ], pants, { capStart: true, capEnd: true });
+    acc.add(leg, (x, y) => across(J.knee + 0.04, 0.1,
+      side < 0 ? B.thighL : B.thighR, side < 0 ? B.kneeL : B.kneeR)(x, y));
+
+    const foot = new Builder(false);
+    foot.loftY([
+      { y: J.ankle + 0.09, pts: oval(0.041, 0.044, 8, X, 0) },
+      { y: J.ankle, pts: oval(0.043, 0.05, 8, X, 0.012) },
+      { y: J.ankle - 0.04, pts: oval(0.048, 0.078, 8, X, 0.042) },
+      { y: J.ankle - 0.055, pts: oval(0.044, 0.082, 8, X, 0.05) },
+    ], shoeCol, { capStart: true, capEnd: true });
+    acc.add(foot, solid(side < 0 ? B.footL : B.footR));
+  }
+
+  return acc.build();
 }
 
-export function animateWalk(h, phase, amp, dt) {
-  const s = Math.sin(phase) * amp;
-  const c = Math.sin(phase + Math.PI) * amp;
-  h.legL.rotation.x = s;
-  h.legR.rotation.x = c;
-  if (h.armL) { h.armL.rotation.x = c * 0.8; h.armR.rotation.x = s * 0.8; }
-  h.body.rotation.z = Math.sin(phase * 2) * amp * 0.05;
+// A small pool of pre-built looks, shared by every pedestrian. Per-instance
+// variety comes from the skeleton, scale and gait rather than new geometry.
+let VARIANTS = null;
+function variants() {
+  if (!VARIANTS) {
+    VARIANTS = [];
+    for (let i = 0; i < 12; i++) VARIANTS.push(buildCharacter({ seed: i * 7919 + 13 }));
+  }
+  return VARIANTS;
+}
+
+export function makeHumanoid(opts = {}) {
+  const seed = opts.seed != null ? opts.seed : 0;
+  const geo = opts.geometry
+    || (opts.unique ? buildCharacter(opts) : variants()[Math.floor(hash2(seed, 9) * 12) % 12]);
+  const bones = makeSkeletonBones();
+  const mesh = new THREE.SkinnedMesh(geo, pedMat);
+  mesh.add(bones[B.root]);
+  mesh.bind(new THREE.Skeleton(bones));
+  mesh.castShadow = true;
+  mesh.frustumCulled = false;
+
+  const g = new THREE.Group();
+  g.add(mesh);
+  const scale = opts.scale || (0.94 + hash2(seed, 5) * 0.14);
+  g.scale.setScalar(scale);
+  return {
+    group: g, mesh, bones, height: 1.75 * scale, bob: 0,
+    gait: 0.85 + hash2(seed, 11) * 0.3,
+    lean: hash2(seed, 12) * 0.06,
+    swing: 0.8 + hash2(seed, 13) * 0.45,
+    t: hash2(seed, 14) * 10,
+  };
+}
+
+/**
+ * Procedural walk/idle cycle. Hips bob and sway, knees and elbows actually
+ * bend, the chest counter-rotates against the pelvis and the head stays level.
+ */
+export function animateWalk(h, phase, amp, dt, speed) {
+  const b = h.bones;
+  h.t += dt || 0;
+  const A = amp * h.gait;
+  const s = Math.sin(phase), c = Math.cos(phase);
+  const spd = speed != null ? speed : amp * 4;
+  const run = clamp(spd / 6, 0, 1);
+
+  // legs: hip swing with a knee that flexes through the swing phase
+  const kneeFor = (ph) => 0.12 + (0.55 + 0.5 * run) * A * Math.max(0, 1 - Math.cos(ph + 0.5)) * 0.5;
+  const stride = A * 0.95;
+  b[B.thighL].rotation.x = -stride * s;
+  b[B.thighR].rotation.x = stride * s;
+  b[B.kneeL].rotation.x = kneeFor(phase + Math.PI);
+  b[B.kneeR].rotation.x = kneeFor(phase);
+  b[B.footL].rotation.x = -0.35 * b[B.kneeL].rotation.x + A * 0.35 * s + 0.06;
+  b[B.footR].rotation.x = -0.35 * b[B.kneeR].rotation.x - A * 0.35 * s + 0.06;
+
+  // arms: opposite phase, elbows carried bent and tightening on the forward swing
+  const armA = A * 0.8 * h.swing;
+  b[B.shoulderL].rotation.x = armA * 1.1 * s;
+  b[B.shoulderR].rotation.x = -armA * 1.1 * s;
+  b[B.shoulderL].rotation.z = 0.06 + A * 0.1;
+  b[B.shoulderR].rotation.z = -0.06 - A * 0.1;
+  b[B.elbowL].rotation.x = -(0.22 + 0.5 * run) - Math.max(0, armA * 1.4 * s);
+  b[B.elbowR].rotation.x = -(0.22 + 0.5 * run) - Math.max(0, -armA * 1.4 * s);
+
+  // Pelvis: the hips have to DROP as the legs scissor, or the planted foot
+  // slides under the ground and the whole figure looks like it is floating.
+  const legLen = J.hip - J.ankle;
+  const scissor = legLen * (1 - Math.cos(stride * Math.abs(s)));
+  b[B.hips].position.y = J.hip - scissor - Math.abs(s) * A * 0.03;
+  b[B.hips].position.x = s * A * 0.035;
+  b[B.hips].rotation.z = -s * A * 0.11;
+  b[B.hips].rotation.y = -s * A * 0.30;
+  b[B.spine].rotation.y = s * A * 0.16;
+  b[B.chest].rotation.y = s * A * 0.30;
+  b[B.chest].rotation.x = h.lean + A * 0.10 + run * 0.10;
+  b[B.chest].rotation.z = -c * A * 0.05;
+
+  // head stays level and pointed where the body is going
+  b[B.neck].rotation.x = -h.lean * 0.6 - A * 0.06 - run * 0.08;
+  b[B.head].rotation.y = -s * A * 0.22 + Math.sin(h.t * 0.6) * 0.12 * (1 - run);
+  b[B.head].rotation.x = -A * 0.08 + Math.sin(h.t * 0.9) * 0.03;
+
+  // idle: breathing and a slow weight shift so nobody stands like a statue
+  if (A < 0.05) {
+    const br = Math.sin(h.t * 1.5);
+    b[B.chest].rotation.x = h.lean + br * 0.02;
+    b[B.hips].position.x = Math.sin(h.t * 0.5) * 0.012;
+    b[B.hips].rotation.z = Math.sin(h.t * 0.5) * 0.03;
+    b[B.shoulderL].rotation.x = br * 0.03;
+    b[B.shoulderR].rotation.x = -br * 0.03;
+  }
+  h.bob = 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -248,8 +540,8 @@ export class PedSystem {
       p.z = G.clampToMap(p.z);
       p.y = city.groundAt(p.x, p.z, p.y + 1);
 
-      p.phase += p.speed * 2.6 * dt;
-      animateWalk(p.h, p.phase, clamp(p.speed * 0.22, 0, 0.85), dt);
+      p.phase += (0.9 + p.speed * 2.2) * dt;
+      animateWalk(p.h, p.phase, clamp(p.speed * 0.20, 0, 0.8), dt, p.speed);
       p.h.group.position.set(p.x, p.y, p.z);
       p.h.group.rotation.y = p.heading;
       p.h.group.rotation.z = 0;

--- a/apps/auto/src/peds.js
+++ b/apps/auto/src/peds.js
@@ -30,14 +30,17 @@ const B = {
 };
 const BONE_COUNT = 18;
 
-// Joint heights in character space (feet at y = 0, nominal height 1.75 m)
+// Joint heights in character space, taken from adult anthropometry as
+// fractions of a 1.75 m stature (eye 0.936H, chin 0.870H, acromion 0.812H,
+// elbow 0.630H, wrist 0.485H, hip 0.530H, knee 0.285H, ankle 0.039H).
 const J = {
-  hip: 0.90, spine: 1.02, chest: 1.22, neck: 1.46, head: 1.53,
-  shoulder: 1.385, elbow: 1.085, wrist: 0.805,
-  knee: 0.46, ankle: 0.055,
+  hip: 0.927, spine: 1.06, chest: 1.26, neck: 1.47, head: 1.56,
+  shoulder: 1.421, elbow: 1.103, wrist: 0.849,
+  knee: 0.499, ankle: 0.068,
+  chin: 1.522, eye: 1.638, crown: 1.750,
 };
-const SHOULDER_X = 0.150;
-const HIP_X = 0.068;
+const SHOULDER_X = 0.150;   // glenohumeral centre; the deltoid takes it to 0.21
+const HIP_X = 0.085;
 
 function makeSkeletonBones() {
   const bones = [];
@@ -152,28 +155,33 @@ export function buildCharacter(opts = {}) {
   const coat = jacket ? [shirt[0] * 0.66, shirt[1] * 0.66, shirt[2] * 0.7] : shirt;
 
   const acc = new SkinAcc();
-  const bw = 0.132 * build, bd = 0.096 * build;
-  const cw = 0.160 * build, cd = 0.112 * build;
-  const sw = 0.152 * build, sd = 0.107 * build;
+  // half-breadths: hip 0.167, waist 0.131, chest 0.152, shoulder 0.140
+  const bw = 0.167 * build, bd = 0.115 * build;
+  const ww = 0.131 * build, wd = 0.100 * build;
+  const cw = 0.152 * build, cd = 0.118 * build;
+  const sw = 0.140 * build, sd = 0.104 * build;
   const outer = jacket ? 1.05 : 1.0;
 
   // --- pelvis + torso ------------------------------------------------------
   const pelvis = new Builder(false);
   pelvis.loftY([
-    { y: J.hip - 0.14, pts: oval(bw * 0.95, bd * 0.97, 10) },
-    { y: J.hip, pts: oval(bw, bd, 10) },
-    { y: J.hip + 0.07, pts: oval(bw * 0.95, bd * 0.95, 10) },
+    { y: J.hip - 0.15, pts: oval(bw * 0.88, bd * 0.92, 10) },
+    { y: J.hip - 0.06, pts: oval(bw, bd, 10, 0, -0.008) },
+    { y: J.hip + 0.04, pts: oval(bw * 0.94, bd * 0.94, 10) },
+    { y: J.hip + 0.10, pts: oval(bw * 0.86, bd * 0.9, 10) },
   ], pants, { capStart: true });
   acc.add(pelvis, across(J.spine - 0.06, 0.09, B.spine, B.hips));
 
   const torso = new Builder(false);
   torso.loftY([
-    { y: J.hip + 0.06, pts: oval(bw * 0.93 * outer, bd * 0.94 * outer, 10) },
-    { y: J.spine, pts: oval(bw * 0.86 * outer, bd * 0.9 * outer, 10) },
-    { y: J.chest, pts: oval(cw * outer, cd * outer, 10) },
-    { y: J.shoulder - 0.02, pts: oval(sw * outer, sd * outer, 10) },
-    { y: J.shoulder + 0.045, pts: oval(sw * 0.7 * outer, sd * 0.88 * outer, 10) },
-    { y: J.shoulder + 0.085, pts: oval(sw * 0.42 * outer, sd * 0.66 * outer, 10) },
+    { y: J.hip + 0.08, pts: oval(bw * 0.86 * outer, bd * 0.9 * outer, 10) },
+    { y: 1.085, pts: oval(ww * outer, wd * outer, 10) },
+    { y: J.chest, pts: oval(cw * outer, cd * outer, 10, 0, 0.006) },
+    { y: 1.34, pts: oval(cw * 1.02 * outer, cd * 0.98 * outer, 10) },
+    { y: J.shoulder - 0.02, pts: oval(sw * 1.08 * outer, sd * outer, 10) },
+    { y: J.shoulder + 0.012, pts: oval(sw * 0.92 * outer, sd * 0.92 * outer, 10) },
+    // trapezius sloping in to the neck, set back so the throat stays visible
+    { y: J.shoulder + 0.046, pts: oval(sw * 0.5 * outer, sd * 0.56 * outer, 10, 0, -0.014) },
   ], coat, {});
   if (jacket) {
     torso.box(0, J.hip + 0.07, bd * 0.92 * outer, 0.04, J.chest - J.hip + 0.18, 0.02, 0,
@@ -192,41 +200,57 @@ export function buildCharacter(opts = {}) {
   });
 
   // --- neck + head ---------------------------------------------------------
+  // Head width is 0.086H (half 0.075) and depth 0.115H (half 0.101). The old
+  // head was 25% too wide, which is most of what made these look wrong.
   const head = new Builder(false);
   head.loftY([
-    { y: J.shoulder + 0.03, pts: oval(0.061, 0.057, 8) },
-    { y: J.neck + 0.02, pts: oval(0.051, 0.049, 8) },
+    { y: J.chest + 0.09, pts: oval(0.062, 0.060, 8) },
+    { y: J.shoulder + 0.01, pts: oval(0.057, 0.055, 8, 0, -0.004) },
+    { y: J.chin - 0.01, pts: oval(0.052, 0.050, 8, 0, -0.006) },
   ], skin, {});
-  const HY = J.neck + 0.09;
   head.loftY([
-    { y: J.neck - 0.01, pts: oval(0.056, 0.055, 10) },
-    { y: J.neck + 0.05, pts: oval(0.079, 0.086, 10, 0, 0.006) },
-    { y: HY, pts: oval(0.094, 0.102, 10, 0, 0.006) },
-    { y: HY + 0.07, pts: oval(0.091, 0.098, 10, 0, 0.002) },
-    { y: HY + 0.13, pts: oval(0.062, 0.066, 10, 0, -0.008) },
-    { y: HY + 0.16, pts: oval(0.026, 0.028, 10, 0, -0.012) },
+    { y: J.chin - 0.012, pts: oval(0.040, 0.055, 10, 0, 0.020) },
+    { y: J.chin + 0.023, pts: oval(0.062, 0.082, 10, 0, 0.010) },
+    { y: J.chin + 0.063, pts: oval(0.073, 0.096, 10, 0, 0.004) },
+    { y: J.eye, pts: oval(0.075, 0.100, 10, 0, 0) },
+    { y: J.eye + 0.050, pts: oval(0.070, 0.092, 10, 0, -0.004) },
+    { y: J.crown - 0.025, pts: oval(0.055, 0.070, 10, 0, -0.010) },
+    { y: J.crown, pts: oval(0.022, 0.028, 10, 0, -0.014) },
   ], skin, { capStart: true, capEnd: true });
+
+  // hair: starts at the hairline so the forehead is not swallowed
   head.loftY([
-    { y: HY - 0.075, pts: oval(0.086, 0.094, 10, 0, -0.032) },
-    { y: HY - 0.015, pts: oval(0.098, 0.106, 10, 0, -0.018) },
-    { y: HY + 0.072, pts: oval(0.096, 0.102, 10, 0, -0.018) },
-    { y: HY + 0.132, pts: oval(0.066, 0.070, 10, 0, -0.02) },
-    { y: HY + 0.163, pts: oval(0.027, 0.029, 10, 0, -0.016) },
+    { y: J.chin + 0.038, pts: oval(0.070, 0.078, 10, 0, -0.030) },
+    { y: J.eye - 0.018, pts: oval(0.080, 0.094, 10, 0, -0.022) },
+    { y: J.eye + 0.050, pts: oval(0.077, 0.097, 10, 0, -0.012) },
+    { y: J.crown - 0.030, pts: oval(0.059, 0.074, 10, 0, -0.012) },
+    { y: J.crown + 0.003, pts: oval(0.024, 0.031, 10, 0, -0.014) },
   ], hair, { capEnd: true });
-  head.box(0, HY + 0.03, 0.086, 0.125, 0.02, 0.028, 0, hair);
-  head.box(0, HY - 0.012, 0.09, 0.026, 0.048, 0.032, 0, skin);
-  for (const sx of [-0.04, 0.04]) head.box(sx, HY + 0.008, 0.088, 0.026, 0.016, 0.018, 0, [0.13, 0.12, 0.13]);
+
+  // face: brow, eyes set into their sockets, a nose with a bridge, mouth, ears
+  const brow = [hair[0] * 0.75 + skin[0] * 0.2, hair[1] * 0.75 + skin[1] * 0.2, hair[2] * 0.75 + skin[2] * 0.2];
+  for (const sx of [-1, 1]) {
+    head.box(sx * 0.032, J.eye + 0.021, 0.088, 0.036, 0.011, 0.02, 0, brow);
+    head.box(sx * 0.031, J.eye, 0.090, 0.026, 0.013, 0.014, 0, [0.94, 0.93, 0.9]);
+    head.box(sx * 0.031, J.eye, 0.095, 0.012, 0.012, 0.008, 0, [0.16, 0.13, 0.11]);
+    head.box(sx * 0.077, J.eye - 0.014, 0.008, 0.014, 0.042, 0.028, 0, skin);
+  }
+  head.box(0, J.eye - 0.004, 0.098, 0.019, 0.052, 0.016, 0, skin);
+  head.box(0, J.eye - 0.034, 0.104, 0.026, 0.018, 0.018, 0, skin);
+  head.box(0, J.chin + 0.040, 0.092, 0.044, 0.009, 0.014, 0,
+    [skin[0] * 0.62, skin[1] * 0.42, skin[2] * 0.42]);
+
   if (opts.hat) {
     head.loftY([
-      { y: HY + 0.06, pts: oval(0.104, 0.111, 10) },
-      { y: HY + 0.15, pts: oval(0.097, 0.103, 10) },
-      { y: HY + 0.178, pts: oval(0.068, 0.073, 10) },
+      { y: J.eye + 0.014, pts: oval(0.085, 0.110, 10, 0, -0.006) },
+      { y: J.eye + 0.070, pts: oval(0.081, 0.104, 10, 0, -0.008) },
+      { y: J.crown - 0.006, pts: oval(0.056, 0.072, 10, 0, -0.01) },
     ], opts.hat, { capEnd: true });
-    head.box(0, HY + 0.055, 0.078, 0.196, 0.02, 0.13, 0, opts.hat);
+    head.box(0, J.eye + 0.012, 0.086, 0.166, 0.018, 0.11, 0, opts.hat);
   }
   acc.add(head, (x, y) => {
-    if (y < J.neck) return across(J.neck - 0.04, 0.07, B.neck, B.chest)(x, y);
-    return across(J.head + 0.01, 0.05, B.head, B.neck)(x, y);
+    if (y < J.neck) return across(J.neck - 0.06, 0.09, B.neck, B.chest)(x, y);
+    return across(J.head - 0.03, 0.04, B.head, B.neck)(x, y);
   });
 
   // --- arms ----------------------------------------------------------------
@@ -236,15 +260,18 @@ export function buildCharacter(opts = {}) {
     const seg = (y, rx, rz) => [y, rx, rz];
     const upper = new Builder(false);
     upper.loftY([
-      { y: J.shoulder + 0.038, pts: oval(0.028, 0.026, 8, X, 0) },
-      { y: J.shoulder + 0.018, pts: oval(0.050, 0.047, 8, X, 0) },
-      { y: J.shoulder - 0.022, pts: oval(0.060, 0.057, 8, X, 0) },
-      { y: J.shoulder - 0.10, pts: oval(0.051, 0.049, 8, X, 0) },
-      { y: J.elbow + 0.02, pts: oval(0.044, 0.043, 8, X, 0) },
-      { y: J.elbow - 0.02, pts: oval(0.043, 0.042, 8, X, 0) },
-      { y: J.wrist + 0.03, pts: oval(0.035, 0.034, 8, X, 0) },
+      // deltoid widest just BELOW the shoulder line, and capped under the
+      // trapezius -- capping it above turns the shoulders into puffed sleeves
+      { y: J.shoulder - 0.014, pts: oval(0.044, 0.042, 8, X, 0) },
+      { y: J.shoulder - 0.042, pts: oval(0.059, 0.056, 8, X, 0) },
+      { y: J.shoulder - 0.080, pts: oval(0.061, 0.058, 8, X, 0) },
+      { y: J.shoulder - 0.14, pts: oval(0.051, 0.050, 8, X, 0) },
+      { y: J.elbow + 0.03, pts: oval(0.045, 0.044, 8, X, 0) },
+      { y: J.elbow - 0.02, pts: oval(0.044, 0.043, 8, X, 0) },
+      { y: J.wrist + 0.05, pts: oval(0.031, 0.030, 8, X, 0) },
+      { y: J.wrist, pts: oval(0.028, 0.026, 8, X, 0) },
     ], shortSleeve
-      ? [coat, coat, coat, coat, skin, skin, skin]
+      ? [coat, coat, coat, coat, skin, skin, skin, skin]
       : coat, { capStart: true, capEnd: true });
     arm.pos = upper.pos; arm.nor = upper.nor; arm.col = upper.col; arm.idx = upper.idx;
     acc.add(arm, (x, y) => {
@@ -252,10 +279,12 @@ export function buildCharacter(opts = {}) {
       return [side < 0 ? B.elbowL : B.elbowR, 1, 0, 0];
     });
     const hand = new Builder(false);
+    // hand length is 0.108H = 0.189 m from wrist to fingertip
     hand.loftY([
-      { y: J.wrist + 0.01, pts: oval(0.034, 0.031, 8, X, 0) },
-      { y: J.wrist - 0.05, pts: oval(0.039, 0.029, 8, X, 0.004) },
-      { y: J.wrist - 0.115, pts: oval(0.029, 0.022, 8, X, 0.006) },
+      { y: J.wrist + 0.005, pts: oval(0.030, 0.028, 8, X, 0) },
+      { y: J.wrist - 0.045, pts: oval(0.038, 0.026, 8, X, 0.004) },
+      { y: J.wrist - 0.115, pts: oval(0.036, 0.023, 8, X, 0.006) },
+      { y: J.wrist - 0.189, pts: oval(0.022, 0.015, 8, X, 0.006) },
     ], skin, { capStart: true, capEnd: true });
     acc.add(hand, solid(side < 0 ? B.handL : B.handR));
   }
@@ -265,23 +294,24 @@ export function buildCharacter(opts = {}) {
     const X = side * HIP_X;
     const leg = new Builder(false);
     leg.loftY([
-      { y: J.hip + 0.03, pts: oval(0.092, 0.09, 8, X, 0) },
-      { y: J.hip - 0.08, pts: oval(0.086, 0.085, 8, X, 0) },
-      { y: J.knee + 0.08, pts: oval(0.062, 0.062, 8, X, 0) },
-      { y: J.knee + 0.02, pts: oval(0.058, 0.059, 8, X, 0) },
-      { y: J.knee - 0.03, pts: oval(0.058, 0.060, 8, X, 0.004) },
-      { y: J.knee - 0.16, pts: oval(0.055, 0.058, 8, X, 0.002) },
-      { y: J.ankle + 0.09, pts: oval(0.042, 0.045, 8, X, 0) },
+      { y: J.hip + 0.04, pts: oval(0.094, 0.092, 8, X, 0) },
+      { y: J.hip - 0.09, pts: oval(0.088, 0.087, 8, X, 0) },
+      { y: J.knee + 0.10, pts: oval(0.064, 0.064, 8, X, 0) },
+      { y: J.knee + 0.02, pts: oval(0.059, 0.060, 8, X, 0) },
+      { y: J.knee - 0.04, pts: oval(0.059, 0.062, 8, X, 0.005) },
+      { y: J.knee - 0.15, pts: oval(0.057, 0.060, 8, X, 0.002) },
+      { y: J.ankle + 0.10, pts: oval(0.037, 0.040, 8, X, 0) },
     ], pants, { capStart: true, capEnd: true });
     acc.add(leg, (x, y) => across(J.knee + 0.04, 0.1,
       side < 0 ? B.thighL : B.thighR, side < 0 ? B.kneeL : B.kneeR)(x, y));
 
     const foot = new Builder(false);
+    // foot length is 0.152H = 0.266 m; the old shoe was barely 0.16 m
     foot.loftY([
-      { y: J.ankle + 0.09, pts: oval(0.041, 0.044, 8, X, 0) },
-      { y: J.ankle, pts: oval(0.043, 0.05, 8, X, 0.012) },
-      { y: J.ankle - 0.04, pts: oval(0.048, 0.078, 8, X, 0.042) },
-      { y: J.ankle - 0.055, pts: oval(0.044, 0.082, 8, X, 0.05) },
+      { y: J.ankle + 0.10, pts: oval(0.036, 0.039, 8, X, 0) },
+      { y: J.ankle + 0.02, pts: oval(0.043, 0.056, 8, X, 0.018) },
+      { y: J.ankle - 0.030, pts: oval(0.050, 0.105, 8, X, 0.052) },
+      { y: J.ankle - 0.062, pts: oval(0.046, 0.112, 8, X, 0.060) },
     ], shoeCol, { capStart: true, capEnd: true });
     acc.add(foot, solid(side < 0 ? B.footL : B.footR));
   }
@@ -350,10 +380,12 @@ export function animateWalk(h, phase, amp, dt, speed) {
   const armA = A * 0.8 * h.swing;
   b[B.shoulderL].rotation.x = armA * 1.1 * s;
   b[B.shoulderR].rotation.x = -armA * 1.1 * s;
-  b[B.shoulderL].rotation.z = 0.06 + A * 0.1;
-  b[B.shoulderR].rotation.z = -0.06 - A * 0.1;
-  b[B.elbowL].rotation.x = -(0.22 + 0.5 * run) - Math.max(0, armA * 1.4 * s);
-  b[B.elbowR].rotation.x = -(0.22 + 0.5 * run) - Math.max(0, -armA * 1.4 * s);
+  // Abduction keeps the hands clear of the thighs. Positive Z swings a limb
+  // toward +X, so the LEFT arm (at -X) needs a negative angle to move outward.
+  b[B.shoulderL].rotation.z = -(0.12 + A * 0.07);
+  b[B.shoulderR].rotation.z = 0.12 + A * 0.07;
+  b[B.elbowL].rotation.x = -(0.20 + 0.5 * run) - Math.max(0, armA * 1.4 * s);
+  b[B.elbowR].rotation.x = -(0.20 + 0.5 * run) - Math.max(0, -armA * 1.4 * s);
 
   // Pelvis: the hips have to DROP as the legs scissor, or the planted foot
   // slides under the ground and the whole figure looks like it is floating.
@@ -381,6 +413,8 @@ export function animateWalk(h, phase, amp, dt, speed) {
     b[B.hips].rotation.z = Math.sin(h.t * 0.5) * 0.03;
     b[B.shoulderL].rotation.x = br * 0.03;
     b[B.shoulderR].rotation.x = -br * 0.03;
+    b[B.elbowL].rotation.x = -0.16 + br * 0.02;
+    b[B.elbowR].rotation.x = -0.16 - br * 0.02;
   }
   h.bob = 0;
 }

--- a/apps/auto/src/peds.js
+++ b/apps/auto/src/peds.js
@@ -133,11 +133,6 @@ const across = (jy, span, above, below) => (x, y) => {
 };
 const solid = (b) => () => [b, 1, 0, 0];
 
-function limbInto(b, segs, col) {
-  b.loftY(segs.map((sg) => ({ y: sg[0], pts: oval(sg[1], sg[2], 8) })), col,
-    { capStart: true, capEnd: true });
-}
-
 /**
  * Builds one character variant: a skinned geometry in the rest pose. Callers
  * pair it with a fresh skeleton per instance.
@@ -255,11 +250,9 @@ export function buildCharacter(opts = {}) {
 
   // --- arms ----------------------------------------------------------------
   for (const side of [-1, 1]) {
-    const arm = new Builder(false);
     const X = side * SHOULDER_X;
-    const seg = (y, rx, rz) => [y, rx, rz];
-    const upper = new Builder(false);
-    upper.loftY([
+    const arm = new Builder(false);
+    arm.loftY([
       // deltoid widest just BELOW the shoulder line, and capped under the
       // trapezius -- capping it above turns the shoulders into puffed sleeves
       { y: J.shoulder - 0.014, pts: oval(0.044, 0.042, 8, X, 0) },
@@ -273,7 +266,6 @@ export function buildCharacter(opts = {}) {
     ], shortSleeve
       ? [coat, coat, coat, coat, skin, skin, skin, skin]
       : coat, { capStart: true, capEnd: true });
-    arm.pos = upper.pos; arm.nor = upper.nor; arm.col = upper.col; arm.idx = upper.idx;
     acc.add(arm, (x, y) => {
       if (y > J.elbow) return across(J.elbow + 0.05, 0.09, side < 0 ? B.shoulderL : B.shoulderR, side < 0 ? B.elbowL : B.elbowR)(x, y);
       return [side < 0 ? B.elbowL : B.elbowR, 1, 0, 0];
@@ -332,6 +324,7 @@ function variants() {
 
 export function makeHumanoid(opts = {}) {
   const seed = opts.seed != null ? opts.seed : 0;
+  const pooled = !opts.geometry && !opts.unique;
   const geo = opts.geometry
     || (opts.unique ? buildCharacter(opts) : variants()[Math.floor(hash2(seed, 9) * 12) % 12]);
   const bones = makeSkeletonBones();
@@ -347,6 +340,9 @@ export function makeHumanoid(opts = {}) {
   g.scale.setScalar(scale);
   return {
     group: g, mesh, bones, height: 1.75 * scale, bob: 0,
+    // Pooled variants are shared by every pedestrian using that look, so only a
+    // uniquely-built character may dispose its own geometry.
+    dispose() { if (!pooled) geo.dispose(); },
     gait: 0.85 + hash2(seed, 11) * 0.3,
     lean: hash2(seed, 12) * 0.06,
     swing: 0.8 + hash2(seed, 13) * 0.45,
@@ -456,7 +452,7 @@ export class PedSystem {
         ? makeHumanoid({ seed, shirt: [0.12, 0.16, 0.3], pants: [0.1, 0.12, 0.2], hat: [0.08, 0.1, 0.18], vest: [0.16, 0.2, 0.36] })
         : makeHumanoid({ seed });
       const p = {
-        h, x, z, y: city.groundAt(x, z, null), heading: this.R.n() * Math.PI * 2,
+        h, x, z, y: city.groundAt(x, z, null), lift: 0, heading: this.R.n() * Math.PI * 2,
         edge: ei, side, t, dirSign: this.R.n() < 0.5 ? 1 : -1,
         speed: 0, phase: this.R.n() * 6.28, state: 'walk', timer: 0,
         cop: !!cop, shootCd: 1 + this.R.n(), down: 0, hp: cop ? 60 : 30,
@@ -472,7 +468,7 @@ export class PedSystem {
     const i = this.peds.indexOf(p);
     if (i >= 0) this.peds.splice(i, 1);
     this.scene.remove(p.h.group);
-    p.h.group.traverse((o) => { if (o.geometry) o.geometry.dispose(); });
+    p.h.dispose();
   }
 
   scare(x, z, radius) {
@@ -572,7 +568,8 @@ export class PedSystem {
       p.z += Math.cos(p.heading) * p.speed * dt;
       p.x = G.clampToMap(p.x);
       p.z = G.clampToMap(p.z);
-      p.y = city.groundAt(p.x, p.z, p.y + 1);
+      p.lift = city.roadLift(p.x, p.z);
+      p.y = city.groundAt(p.x, p.z, p.y + 1, p.lift);
 
       p.phase += (0.9 + p.speed * 2.2) * dt;
       animateWalk(p.h, p.phase, clamp(p.speed * 0.20, 0, 0.8), dt, p.speed);
@@ -601,7 +598,7 @@ export class PedSystem {
     p.fallDir = Math.random() < 0.5 ? 1 : -1;
     p.x += dir.x * clamp(force * 0.12, 0.4, 3);
     p.z += dir.z * clamp(force * 0.12, 0.4, 3);
-    p.y = this.city.groundAt(p.x, p.z, p.y + 1);
+    p.y = this.city.groundAt(p.x, p.z, p.y + 1, this.city.roadLift(p.x, p.z));
     p.h.group.position.set(p.x, p.y + 0.3, p.z);
   }
 

--- a/apps/auto/src/player.js
+++ b/apps/auto/src/player.js
@@ -28,6 +28,7 @@ export class Player {
     this.ammo = 0;
     this.attackCd = 0;
     this.enterCd = 0;
+    this.lift = 0;
     this.dead = false;
 
     this.camYaw = this.heading + Math.PI;
@@ -115,7 +116,9 @@ export class Player {
     } else if (!this.blocked(nx, this.z)) this.x = G.clampToMap(nx);
     else if (!this.blocked(this.x, nz)) this.z = G.clampToMap(nz);
 
-    const ground = this.city.groundAt(this.x, this.z, this.y + 1.2);
+    // one paved-surface scan per frame, shared by the ground and camera queries
+    this.lift = this.city.roadLift(this.x, this.z);
+    const ground = this.city.groundAt(this.x, this.z, this.y + 1.2, this.lift);
     if (input.jump && this.grounded) {
       this.vy = 6.2;
       this.grounded = false;
@@ -241,7 +244,8 @@ export class Player {
     this.camPos.x = damp(this.camPos.x, wanted.x, rate, dt);
     this.camPos.y = damp(this.camPos.y, wanted.y, rate, dt);
     this.camPos.z = damp(this.camPos.z, wanted.z, rate, dt);
-    const minY = this.city.groundAt(this.camPos.x, this.camPos.z, null) + 1.1;
+    // the camera clamp does not need 22 cm of kerb accuracy, so skip the scan
+    const minY = this.city.groundAt(this.camPos.x, this.camPos.z, null, 0) + 1.1;
     if (this.camPos.y < minY) this.camPos.y = minY;
     this.camLook.set(
       damp(this.camLook.x, target.x, 16, dt),

--- a/apps/auto/src/player.js
+++ b/apps/auto/src/player.js
@@ -11,7 +11,7 @@ export class Player {
     this.scene = scene;
     this.city = city;
     this.game = game;
-    this.h = makeHumanoid({ seed: 1, shirt: [0.15, 0.18, 0.24], pants: [0.12, 0.13, 0.16], hair: [0.1, 0.08, 0.07], scale: 1.02, animateArms: true });
+    this.h = makeHumanoid({ seed: 1, unique: true, shirt: [0.16, 0.2, 0.3], pants: [0.12, 0.13, 0.17], hair: [0.1, 0.08, 0.07], scale: 1.03 });
     scene.add(this.h.group);
     this.x = G.SPAWN.x;
     this.z = G.SPAWN.z;
@@ -131,8 +131,8 @@ export class Player {
     // drowning
     if (this.y < -0.6 && G.isWater(this.x, this.z)) this.game.onDrown();
 
-    this.phase += this.speed * 2.2 * dt;
-    animateWalk(this.h, this.phase, clamp(this.speed * 0.16, 0, 0.9), dt);
+    this.phase += (0.9 + this.speed * 2.0) * dt;
+    animateWalk(this.h, this.phase, clamp(this.speed * 0.16, 0, 0.85), dt, this.speed);
     this.h.group.position.set(this.x, this.y, this.z);
     this.h.group.rotation.y = this.heading;
 
@@ -219,7 +219,7 @@ export class Player {
       target.set(v.x, v.y, v.z);
       const sp = Math.abs(v.vLong);
       dist = 7.6 + v.spec.len * 0.42 + clamp(sp * 0.09, 0, 3.4);
-      height = 3.2 + v.spec.bodyH * 0.7;
+      height = 3.2 + v.spec.roof * 0.42;
       lookH = 1.05;
       // ease the camera behind the car when driving forward
       if (v.vLong > 3) {

--- a/apps/auto/src/postfx.js
+++ b/apps/auto/src/postfx.js
@@ -1,0 +1,208 @@
+// A small hand-rolled post chain: bloom + FXAA + grade + vignette.
+//
+// Deliberately not three's EffectComposer -- this ships no addon files, and it
+// lets every render target be UnsignedByte. Half-float targets are unreliable
+// on iOS (silent black screens), so the scene is tone-mapped during the main
+// pass and everything downstream works in gamma space, which is also where you
+// want FXAA anyway.
+
+import * as THREE from './three.js';
+
+const QUAD = new THREE.PlaneGeometry(2, 2);
+const CAM = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+
+const VERT = `
+varying vec2 vUv;
+void main() {
+  vUv = uv;
+  gl_Position = vec4(position.xy, 0.0, 1.0);
+}`;
+
+const BRIGHT = `
+uniform sampler2D tScene;
+uniform float threshold;
+uniform float softness;
+varying vec2 vUv;
+void main() {
+  vec3 c = texture2D(tScene, vUv).rgb;
+  float l = dot(c, vec3(0.2126, 0.7152, 0.0722));
+  float k = smoothstep(threshold, threshold + softness, l);
+  gl_FragColor = vec4(c * k, 1.0);
+}`;
+
+// Separable 9-tap gaussian, sampled with bilinear pairs.
+const BLUR = `
+uniform sampler2D tSrc;
+uniform vec2 dir;
+varying vec2 vUv;
+void main() {
+  vec3 sum = texture2D(tSrc, vUv).rgb * 0.2270270270;
+  sum += texture2D(tSrc, vUv + dir * 1.3846153846).rgb * 0.3162162162;
+  sum += texture2D(tSrc, vUv - dir * 1.3846153846).rgb * 0.3162162162;
+  sum += texture2D(tSrc, vUv + dir * 3.2307692308).rgb * 0.0702702703;
+  sum += texture2D(tSrc, vUv - dir * 3.2307692308).rgb * 0.0702702703;
+  gl_FragColor = vec4(sum, 1.0);
+}`;
+
+const COMPOSITE = `
+uniform sampler2D tScene;
+uniform sampler2D tBloom;
+uniform vec2 texel;
+uniform float bloomStrength;
+uniform float vignette;
+uniform float grain;
+uniform float time;
+uniform float fxaa;
+varying vec2 vUv;
+
+// FXAA 3.11 console variant -- cheap, and plenty at phone resolutions.
+vec3 fxaaFilter(vec2 uv) {
+  vec3 rgbNW = texture2D(tScene, uv + vec2(-1.0, -1.0) * texel).rgb;
+  vec3 rgbNE = texture2D(tScene, uv + vec2( 1.0, -1.0) * texel).rgb;
+  vec3 rgbSW = texture2D(tScene, uv + vec2(-1.0,  1.0) * texel).rgb;
+  vec3 rgbSE = texture2D(tScene, uv + vec2( 1.0,  1.0) * texel).rgb;
+  vec3 rgbM  = texture2D(tScene, uv).rgb;
+  vec3 luma = vec3(0.299, 0.587, 0.114);
+  float lNW = dot(rgbNW, luma), lNE = dot(rgbNE, luma);
+  float lSW = dot(rgbSW, luma), lSE = dot(rgbSE, luma);
+  float lM = dot(rgbM, luma);
+  float lMin = min(lM, min(min(lNW, lNE), min(lSW, lSE)));
+  float lMax = max(lM, max(max(lNW, lNE), max(lSW, lSE)));
+  if (lMax - lMin < lMax * 0.18) return rgbM;
+  vec2 dir = vec2(-((lNW + lNE) - (lSW + lSE)), ((lNW + lSW) - (lNE + lSE)));
+  float reduce = max((lNW + lNE + lSW + lSE) * 0.03125, 0.0078125);
+  float rcpDir = 1.0 / (min(abs(dir.x), abs(dir.y)) + reduce);
+  dir = clamp(dir * rcpDir, -8.0, 8.0) * texel;
+  vec3 a = 0.5 * (texture2D(tScene, uv + dir * (1.0 / 3.0 - 0.5)).rgb +
+                  texture2D(tScene, uv + dir * (2.0 / 3.0 - 0.5)).rgb);
+  vec3 b = a * 0.5 + 0.25 * (texture2D(tScene, uv - dir * 0.5).rgb +
+                             texture2D(tScene, uv + dir * 0.5).rgb);
+  float lB = dot(b, luma);
+  return (lB < lMin || lB > lMax) ? a : b;
+}
+
+void main() {
+  vec3 c = fxaa > 0.5 ? fxaaFilter(vUv) : texture2D(tScene, vUv).rgb;
+  c += texture2D(tBloom, vUv).rgb * bloomStrength;
+
+  // grade: lift the shadows slightly cool, warm the highlights, add contrast
+  c = mix(c, c * c * (3.0 - 2.0 * c), 0.09);
+  c = mix(vec3(dot(c, vec3(0.2126, 0.7152, 0.0722))), c, 1.12);
+  c += vec3(-0.008, 0.0, 0.014) * (1.0 - c);
+  c *= vec3(1.015, 1.0, 0.985);
+
+  float d = distance(vUv, vec2(0.5));
+  c *= 1.0 - vignette * smoothstep(0.35, 0.95, d);
+
+  float n = fract(sin(dot(vUv * time, vec2(12.9898, 78.233))) * 43758.5453);
+  c += (n - 0.5) * grain;
+
+  gl_FragColor = vec4(clamp(c, 0.0, 1.0), 1.0);
+}`;
+
+function pass(fragmentShader, uniforms) {
+  const mat = new THREE.ShaderMaterial({
+    uniforms, vertexShader: VERT, fragmentShader,
+    depthTest: false, depthWrite: false,
+  });
+  return new THREE.Mesh(QUAD, mat);
+}
+
+function makeRT(w, h, depth) {
+  const rt = new THREE.WebGLRenderTarget(Math.max(2, w), Math.max(2, h), {
+    minFilter: THREE.LinearFilter,
+    magFilter: THREE.LinearFilter,
+    type: THREE.UnsignedByteType, // never HalfFloat: iOS silently renders black
+    depthBuffer: !!depth,
+    stencilBuffer: false,
+  });
+  rt.texture.colorSpace = THREE.SRGBColorSpace;
+  rt.texture.generateMipmaps = false;
+  return rt;
+}
+
+export class PostFX {
+  constructor(renderer) {
+    this.renderer = renderer;
+    this.enabled = true;
+    this.scenePass = new THREE.Scene();
+    this.quadScene = new THREE.Scene();
+
+    this.sceneRT = makeRT(2, 2, true);
+    this.bloomA = makeRT(2, 2, false);
+    this.bloomB = makeRT(2, 2, false);
+
+    this.bright = pass(BRIGHT, {
+      tScene: { value: null }, threshold: { value: 0.72 }, softness: { value: 0.28 },
+    });
+    this.blur = pass(BLUR, { tSrc: { value: null }, dir: { value: new THREE.Vector2() } });
+    this.composite = pass(COMPOSITE, {
+      tScene: { value: null }, tBloom: { value: null },
+      texel: { value: new THREE.Vector2() },
+      bloomStrength: { value: 0.62 },
+      vignette: { value: 0.15 },
+      grain: { value: 0.016 },
+      time: { value: 0 },
+      fxaa: { value: 1 },
+    });
+    this.holder = new THREE.Scene();
+  }
+
+  setSize(w, h, pixelRatio) {
+    const W = Math.max(2, Math.floor(w * pixelRatio));
+    const H = Math.max(2, Math.floor(h * pixelRatio));
+    if (this._w === W && this._h === H) return;
+    this._w = W; this._h = H;
+    this.sceneRT.setSize(W, H);
+    const bw = Math.max(2, Math.floor(W / 4)), bh = Math.max(2, Math.floor(H / 4));
+    this.bloomA.setSize(bw, bh);
+    this.bloomB.setSize(bw, bh);
+    this.composite.material.uniforms.texel.value.set(1 / W, 1 / H);
+    this._bw = bw; this._bh = bh;
+  }
+
+  get target() {
+    return this.enabled ? this.sceneRT : null;
+  }
+
+  /** Run the chain. The scene must already have been rendered into `target`. */
+  render(time) {
+    if (!this.enabled) return;
+    const r = this.renderer;
+    const draw = (mesh, rt) => {
+      this.holder.clear();
+      this.holder.add(mesh);
+      r.setRenderTarget(rt);
+      r.render(this.holder, CAM);
+    };
+
+    this.bright.material.uniforms.tScene.value = this.sceneRT.texture;
+    draw(this.bright, this.bloomA);
+
+    const bu = this.blur.material.uniforms;
+    for (let i = 0; i < 3; i++) {
+      const spread = 1 + i * 1.6;
+      bu.tSrc.value = this.bloomA.texture;
+      bu.dir.value.set(spread / this._bw, 0);
+      draw(this.blur, this.bloomB);
+      bu.tSrc.value = this.bloomB.texture;
+      bu.dir.value.set(0, spread / this._bh);
+      draw(this.blur, this.bloomA);
+    }
+
+    const cu = this.composite.material.uniforms;
+    cu.tScene.value = this.sceneRT.texture;
+    cu.tBloom.value = this.bloomA.texture;
+    cu.time.value = time;
+    r.setRenderTarget(null);
+    draw(this.composite, null);
+  }
+
+  setQuality(q) {
+    const cu = this.composite.material.uniforms;
+    this.enabled = q !== 'low';
+    cu.fxaa.value = q === 'high' ? 1 : 0;
+    cu.bloomStrength.value = q === 'high' ? 0.62 : 0.5;
+    cu.grain.value = q === 'high' ? 0.016 : 0;
+  }
+}

--- a/apps/auto/src/postfx.js
+++ b/apps/auto/src/postfx.js
@@ -105,7 +105,14 @@ function pass(fragmentShader, uniforms) {
     uniforms, vertexShader: VERT, fragmentShader,
     depthTest: false, depthWrite: false,
   });
-  return new THREE.Mesh(QUAD, mat);
+  const mesh = new THREE.Mesh(QUAD, mat);
+  mesh.frustumCulled = false;
+  // Each pass keeps its own scene. Re-parenting one quad between passes every
+  // frame is scene-graph churn on exactly the tiers trying to claw back time.
+  const scene = new THREE.Scene();
+  scene.add(mesh);
+  mesh.userData.scene = scene;
+  return mesh;
 }
 
 function makeRT(w, h, depth) {
@@ -145,7 +152,6 @@ export class PostFX {
       time: { value: 0 },
       fxaa: { value: 1 },
     });
-    this.holder = new THREE.Scene();
   }
 
   setSize(w, h, pixelRatio) {
@@ -170,10 +176,8 @@ export class PostFX {
     if (!this.enabled) return;
     const r = this.renderer;
     const draw = (mesh, rt) => {
-      this.holder.clear();
-      this.holder.add(mesh);
       r.setRenderTarget(rt);
-      r.render(this.holder, CAM);
+      r.render(mesh.userData.scene, CAM);
     };
 
     this.bright.material.uniforms.tScene.value = this.sceneRT.texture;
@@ -198,10 +202,18 @@ export class PostFX {
     draw(this.composite, null);
   }
 
+  dispose() {
+    for (const rt of [this.sceneRT, this.bloomA, this.bloomB]) rt.dispose();
+    for (const m of [this.bright, this.blur, this.composite]) m.material.dispose();
+    QUAD.dispose();
+  }
+
   setQuality(q) {
     const cu = this.composite.material.uniforms;
     this.enabled = q !== 'low';
-    cu.fxaa.value = q === 'high' ? 1 : 0;
+    // FXAA is a single fullscreen tap and the context has no MSAA, so keep it on
+    // for medium too -- dropping it entirely was a visible edge-quality cliff.
+    cu.fxaa.value = q === 'low' ? 0 : 1;
     cu.bloomStrength.value = q === 'high' ? 0.62 : 0.5;
     cu.grain.value = q === 'high' ? 0.016 : 0;
   }

--- a/apps/auto/src/textures.js
+++ b/apps/auto/src/textures.js
@@ -1,5 +1,10 @@
 // Every texture in the game is drawn procedurally into a canvas at boot, so the
 // app ships as code only and works offline with no image assets.
+//
+// Surfaces come as a set: albedo + normal + roughness (+ emissive for the ones
+// with lit windows). The normal maps are derived from a purpose-drawn height
+// pass rather than from the albedo, so window reveals actually read as recesses
+// instead of just as dark paint.
 
 import * as THREE from './three.js';
 import { mulberry32 } from './util.js';
@@ -11,14 +16,16 @@ function canvas(w, h) {
   return { c, g: c.getContext('2d') };
 }
 
-function tex(c, repeat = true, aniso = 8) {
+function tex(c, { repeat = true, aniso = 8, srgb = true, mips = true } = {}) {
   const t = new THREE.CanvasTexture(c);
   if (repeat) {
     t.wrapS = THREE.RepeatWrapping;
     t.wrapT = THREE.RepeatWrapping;
   }
   t.anisotropy = aniso;
-  t.colorSpace = THREE.SRGBColorSpace;
+  if (srgb) t.colorSpace = THREE.SRGBColorSpace;
+  t.generateMipmaps = mips;
+  if (!mips) t.minFilter = THREE.LinearFilter;
   return t;
 }
 
@@ -35,243 +42,482 @@ function noise(g, w, h, amount, seed) {
   g.putImageData(img, 0, 0);
 }
 
-// --- glass curtain wall -----------------------------------------------------
-function glassTexture() {
-  const S = 256, { c, g } = canvas(S, S);
+/** Sobel a greyscale height canvas into a tangent-space normal map. */
+function normalFrom(heightCanvas, strength = 2.0) {
+  const w = heightCanvas.width, h = heightCanvas.height;
+  const src = heightCanvas.getContext('2d').getImageData(0, 0, w, h).data;
+  const lum = new Float32Array(w * h);
+  for (let i = 0; i < w * h; i++) lum[i] = src[i * 4] / 255;
+  const { c, g } = canvas(w, h);
+  const img = g.createImageData(w, h);
+  const d = img.data;
+  const at = (x, y) => lum[(((y % h) + h) % h) * w + (((x % w) + w) % w)];
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      const dx = (at(x + 1, y) - at(x - 1, y)) * strength;
+      // canvas Y runs down, texture V runs up, so the sign flips back here
+      const dy = (at(x, y + 1) - at(x, y - 1)) * strength;
+      let nx = -dx, ny = dy, nz = 1;
+      const l = Math.hypot(nx, ny, nz);
+      const i = (y * w + x) * 4;
+      d[i] = ((nx / l) * 0.5 + 0.5) * 255;
+      d[i + 1] = ((ny / l) * 0.5 + 0.5) * 255;
+      d[i + 2] = ((nz / l) * 0.5 + 0.5) * 255;
+      d[i + 3] = 255;
+    }
+  }
+  g.putImageData(img, 0, 0);
+  return tex(c, { srgb: false });
+}
+
+const grey = (v) => {
+  const n = Math.max(0, Math.min(255, Math.round(v * 255)));
+  return `rgb(${n},${n},${n})`;
+};
+
+// ---------------------------------------------------------------------------
+// Facades. Each generator fills albedo / height / rough / emissive together.
+// ---------------------------------------------------------------------------
+
+function glassSurface() {
+  const S = 512;
+  const a = canvas(S, S), hgt = canvas(S, S), rgh = canvas(S, S), emi = canvas(S, S);
   const r = mulberry32(7);
-  g.fillStyle = '#a7b4bb';
-  g.fillRect(0, 0, S, S);
   const cols = 8, rows = 8;
   const cw = S / cols, ch = S / rows;
+
+  a.g.fillStyle = '#9fb0b9'; a.g.fillRect(0, 0, S, S);
+  hgt.g.fillStyle = grey(0.75); hgt.g.fillRect(0, 0, S, S);
+  rgh.g.fillStyle = grey(0.62); rgh.g.fillRect(0, 0, S, S);
+  emi.g.fillStyle = '#000'; emi.g.fillRect(0, 0, S, S);
+
   for (let y = 0; y < rows; y++) {
     for (let x = 0; x < cols; x++) {
       const px = x * cw, py = y * ch;
-      // spandrel band under each window
-      g.fillStyle = '#9aa6ad';
-      g.fillRect(px, py, cw, ch);
+      // spandrel panel between floors
+      a.g.fillStyle = '#8d9ba3';
+      a.g.fillRect(px, py + ch * 0.72, cw, ch * 0.28);
+      hgt.g.fillStyle = grey(0.82);
+      hgt.g.fillRect(px, py + ch * 0.72, cw, ch * 0.28);
+
+      const ix = px + 3, iy = py + 3, iw = cw - 6, ih = ch * 0.72 - 5;
       const v = r();
-      const b = 0.62 + v * 0.44;
-      const rr = Math.round(118 * b), gg = Math.round(148 * b), bb = Math.round(162 * b);
-      g.fillStyle = `rgb(${rr},${gg},${bb})`;
-      g.fillRect(px + 1.5, py + 2, cw - 3, ch - 6);
-      // sky reflection gradient inside the pane
-      const grad = g.createLinearGradient(px, py + 2, px, py + ch - 4);
-      grad.addColorStop(0, 'rgba(220,238,248,0.45)');
-      grad.addColorStop(0.45, 'rgba(150,180,200,0.10)');
-      grad.addColorStop(1, 'rgba(30,45,55,0.30)');
-      g.fillStyle = grad;
-      g.fillRect(px + 1.5, py + 2, cw - 3, ch - 6);
-      if (v > 0.93) {
-        g.fillStyle = 'rgba(255,236,180,0.55)';
-        g.fillRect(px + 1.5, py + 2, cw - 3, ch - 6);
+      // recessed pane
+      hgt.g.fillStyle = grey(0.22);
+      hgt.g.fillRect(ix, iy, iw, ih);
+      rgh.g.fillStyle = grey(0.07);
+      rgh.g.fillRect(ix, iy, iw, ih);
+
+      const b = 0.6 + v * 0.4;
+      a.g.fillStyle = `rgb(${Math.round(104 * b)},${Math.round(134 * b)},${Math.round(150 * b)})`;
+      a.g.fillRect(ix, iy, iw, ih);
+      const grad = a.g.createLinearGradient(ix, iy, ix, iy + ih);
+      grad.addColorStop(0, 'rgba(226,242,252,0.55)');
+      grad.addColorStop(0.4, 'rgba(150,182,204,0.12)');
+      grad.addColorStop(1, 'rgba(24,38,50,0.34)');
+      a.g.fillStyle = grad;
+      a.g.fillRect(ix, iy, iw, ih);
+      // blinds in some
+      if (v > 0.55 && v < 0.78) {
+        a.g.fillStyle = 'rgba(228,224,210,0.5)';
+        a.g.fillRect(ix, iy, iw, ih * (0.2 + v * 0.4));
+        rgh.g.fillStyle = grey(0.55);
+        rgh.g.fillRect(ix, iy, iw, ih * (0.2 + v * 0.4));
       }
-      // mullions
-      g.fillStyle = '#6d7981';
-      g.fillRect(px, py + ch - 4, cw, 4);
-      g.fillRect(px, py, 1.5, ch);
+      if (v > 0.955) { // lit office
+        a.g.fillStyle = 'rgba(255,232,178,0.6)';
+        a.g.fillRect(ix, iy, iw, ih);
+        emi.g.fillStyle = 'rgb(255,206,132)';
+        emi.g.fillRect(ix, iy, iw, ih);
+      }
+      // mullions stand proud
+      a.g.fillStyle = '#6e7c85';
+      a.g.fillRect(px, py, 3, ch);
+      a.g.fillRect(px, py + ch - 3, cw, 3);
+      hgt.g.fillStyle = grey(1.0);
+      hgt.g.fillRect(px, py, 3, ch);
+      hgt.g.fillRect(px, py + ch - 3, cw, 3);
+      rgh.g.fillStyle = grey(0.72);
+      rgh.g.fillRect(px, py, 3, ch);
+      rgh.g.fillRect(px, py + ch - 3, cw, 3);
     }
   }
-  noise(g, S, S, 12, 3);
-  return tex(c);
+  noise(a.g, S, S, 9, 3);
+  return {
+    map: tex(a.c), normalMap: normalFrom(hgt.c, 2.6),
+    roughnessMap: tex(rgh.c, { srgb: false }), emissiveMap: tex(emi.c),
+  };
 }
 
-// --- masonry / concrete with punched windows --------------------------------
-function masonryTexture() {
-  const S = 256, { c, g } = canvas(S, S);
+function masonrySurface() {
+  const S = 512;
+  const a = canvas(S, S), hgt = canvas(S, S), rgh = canvas(S, S), emi = canvas(S, S);
   const r = mulberry32(21);
-  g.fillStyle = '#b0a191';
-  g.fillRect(0, 0, S, S);
-  // subtle horizontal course lines
-  g.strokeStyle = 'rgba(0,0,0,0.06)';
-  for (let y = 0; y < S; y += 8) {
-    g.beginPath();
-    g.moveTo(0, y + 0.5);
-    g.lineTo(S, y + 0.5);
-    g.stroke();
+  a.g.fillStyle = '#b4a595'; a.g.fillRect(0, 0, S, S);
+  hgt.g.fillStyle = grey(0.72); hgt.g.fillRect(0, 0, S, S);
+  rgh.g.fillStyle = grey(0.88); rgh.g.fillRect(0, 0, S, S);
+  emi.g.fillStyle = '#000'; emi.g.fillRect(0, 0, S, S);
+
+  // stone courses
+  for (let y = 0; y < S; y += 16) {
+    a.g.fillStyle = 'rgba(0,0,0,0.05)';
+    a.g.fillRect(0, y + 14, S, 2);
+    hgt.g.fillStyle = grey(0.55);
+    hgt.g.fillRect(0, y + 14, S, 2);
   }
-  const cols = 5, rows = 5;
+
+  const cols = 4, rows = 4;
   const cw = S / cols, ch = S / rows;
   for (let y = 0; y < rows; y++) {
     for (let x = 0; x < cols; x++) {
-      const px = x * cw + cw * 0.22, py = y * ch + ch * 0.2;
-      const w = cw * 0.56, h = ch * 0.5;
-      g.fillStyle = '#6b6257';
-      g.fillRect(px - 2, py - 2, w + 4, h + 5);
+      const px = x * cw + cw * 0.2, py = y * ch + ch * 0.16;
+      const w = cw * 0.6, h = ch * 0.52;
+      // surround
+      a.g.fillStyle = '#c8bcab';
+      a.g.fillRect(px - 6, py - 6, w + 12, h + 14);
+      hgt.g.fillStyle = grey(0.95);
+      hgt.g.fillRect(px - 6, py - 6, w + 12, h + 14);
+      // recess
+      hgt.g.fillStyle = grey(0.12);
+      hgt.g.fillRect(px, py, w, h);
+      rgh.g.fillStyle = grey(0.12);
+      rgh.g.fillRect(px, py, w, h);
       const v = r();
-      g.fillStyle = v > 0.9 ? '#f0d79a' : `rgb(${40 + v * 26 | 0},${52 + v * 30 | 0},${62 + v * 34 | 0})`;
-      g.fillRect(px, py, w, h);
-      const grad = g.createLinearGradient(px, py, px, py + h);
-      grad.addColorStop(0, 'rgba(210,228,240,0.35)');
-      grad.addColorStop(1, 'rgba(0,0,0,0.25)');
-      g.fillStyle = grad;
-      g.fillRect(px, py, w, h);
-      g.fillStyle = '#cbbfae';
-      g.fillRect(px - 3, py + h + 2, w + 6, 3);
+      a.g.fillStyle = `rgb(${(36 + v * 26) | 0},${(48 + v * 30) | 0},${(58 + v * 34) | 0})`;
+      a.g.fillRect(px, py, w, h);
+      const grad = a.g.createLinearGradient(px, py, px, py + h);
+      grad.addColorStop(0, 'rgba(214,232,244,0.42)');
+      grad.addColorStop(1, 'rgba(0,0,0,0.3)');
+      a.g.fillStyle = grad;
+      a.g.fillRect(px, py, w, h);
+      if (v > 0.94) {
+        a.g.fillStyle = 'rgba(255,228,172,0.62)';
+        a.g.fillRect(px, py, w, h);
+        emi.g.fillStyle = 'rgb(250,198,124)';
+        emi.g.fillRect(px, py, w, h);
+      }
+      // glazing bars
+      a.g.fillStyle = 'rgba(220,214,200,0.7)';
+      a.g.fillRect(px + w / 2 - 1.5, py, 3, h);
+      hgt.g.fillStyle = grey(0.5);
+      hgt.g.fillRect(px + w / 2 - 1.5, py, 3, h);
+      // sill
+      a.g.fillStyle = '#d3c7b4';
+      a.g.fillRect(px - 8, py + h + 4, w + 16, 6);
+      hgt.g.fillStyle = grey(1.0);
+      hgt.g.fillRect(px - 8, py + h + 4, w + 16, 6);
     }
   }
-  noise(g, S, S, 20, 9);
-  return tex(c);
-}
-
-// --- industrial / warehouse -------------------------------------------------
-function industrialTexture() {
-  const S = 256, { c, g } = canvas(S, S);
-  g.fillStyle = '#9aa0a3';
-  g.fillRect(0, 0, S, S);
-  for (let x = 0; x < S; x += 16) {
-    g.fillStyle = 'rgba(255,255,255,0.10)';
-    g.fillRect(x, 0, 6, S);
-    g.fillStyle = 'rgba(0,0,0,0.13)';
-    g.fillRect(x + 10, 0, 5, S);
-  }
-  g.fillStyle = 'rgba(0,0,0,0.18)';
-  g.fillRect(0, 40, S, 4);
-  g.fillRect(0, 208, S, 4);
-  const r = mulberry32(31);
-  for (let i = 0; i < 6; i++) {
-    const x = 12 + i * 40;
-    g.fillStyle = '#3d4750';
-    g.fillRect(x, 16, 26, 18);
-    g.fillStyle = 'rgba(190,215,230,0.55)';
-    g.fillRect(x + 2, 18, 22, 14);
-    if (r() > 0.7) {
-      g.fillStyle = 'rgba(0,0,0,0.35)';
-      g.fillRect(x + 2, 18, 22, 14);
-    }
-  }
-  noise(g, S, S, 22, 5);
-  return tex(c);
-}
-
-// --- house siding (one tile == one wall) ------------------------------------
-function houseTexture() {
-  const S = 256, { c, g } = canvas(S, S);
-  g.fillStyle = '#d8d4cb';
-  g.fillRect(0, 0, S, S);
-  for (let y = 0; y < S; y += 11) {
-    g.fillStyle = 'rgba(0,0,0,0.07)';
-    g.fillRect(0, y + 8, S, 3);
-  }
-  const win = (x, y, w, h) => {
-    g.fillStyle = '#f4f2ec';
-    g.fillRect(x - 4, y - 4, w + 8, h + 8);
-    g.fillStyle = '#2c3742';
-    g.fillRect(x, y, w, h);
-    const grad = g.createLinearGradient(x, y, x, y + h);
-    grad.addColorStop(0, 'rgba(200,222,238,0.6)');
-    grad.addColorStop(1, 'rgba(20,30,40,0.5)');
-    g.fillStyle = grad;
-    g.fillRect(x, y, w, h);
-    g.fillStyle = '#f4f2ec';
-    g.fillRect(x + w / 2 - 2, y, 4, h);
-    g.fillRect(x, y + h / 2 - 2, w, 4);
+  noise(a.g, S, S, 16, 9);
+  noise(hgt.g, S, S, 10, 12);
+  return {
+    map: tex(a.c), normalMap: normalFrom(hgt.c, 2.2),
+    roughnessMap: tex(rgh.c, { srgb: false }), emissiveMap: tex(emi.c),
   };
-  win(40, 46, 56, 62);
-  win(160, 46, 56, 62);
-  win(40, 160, 56, 62);
-  // front door
-  g.fillStyle = '#6d4a34';
-  g.fillRect(158, 150, 56, 92);
-  g.fillStyle = 'rgba(255,255,255,0.25)';
-  g.fillRect(164, 158, 44, 34);
-  g.fillStyle = '#d9c47a';
-  g.fillRect(204, 196, 6, 6);
-  noise(g, S, S, 14, 11);
-  return tex(c);
 }
 
-// --- road surface -----------------------------------------------------------
-function roadTexture() {
-  const S = 256, { c, g } = canvas(S, S);
-  g.fillStyle = '#46484c';
-  g.fillRect(0, 0, S, S);
-  noise(g, S, S, 14, 17);
-  // patchy asphalt -- greyscale only, or the random channels tint the road purple
+function industrialSurface() {
+  const S = 512;
+  const a = canvas(S, S), hgt = canvas(S, S), rgh = canvas(S, S);
+  a.g.fillStyle = '#9ba2a6'; a.g.fillRect(0, 0, S, S);
+  hgt.g.fillStyle = grey(0.5); hgt.g.fillRect(0, 0, S, S);
+  rgh.g.fillStyle = grey(0.55); rgh.g.fillRect(0, 0, S, S);
+  // corrugation
+  for (let x = 0; x < S; x += 24) {
+    const g1 = a.g.createLinearGradient(x, 0, x + 24, 0);
+    g1.addColorStop(0, 'rgba(255,255,255,0.16)');
+    g1.addColorStop(0.5, 'rgba(0,0,0,0.02)');
+    g1.addColorStop(1, 'rgba(0,0,0,0.16)');
+    a.g.fillStyle = g1;
+    a.g.fillRect(x, 0, 24, S);
+    const g2 = hgt.g.createLinearGradient(x, 0, x + 24, 0);
+    g2.addColorStop(0, grey(0.95));
+    g2.addColorStop(0.5, grey(0.5));
+    g2.addColorStop(1, grey(0.08));
+    hgt.g.fillStyle = g2;
+    hgt.g.fillRect(x, 0, 24, S);
+  }
+  // banding rails
+  for (const y of [70, 430]) {
+    a.g.fillStyle = 'rgba(0,0,0,0.2)';
+    a.g.fillRect(0, y, S, 8);
+    hgt.g.fillStyle = grey(1.0);
+    hgt.g.fillRect(0, y, S, 8);
+  }
+  const r = mulberry32(31);
+  for (let i = 0; i < 5; i++) {
+    const x = 30 + i * 96;
+    a.g.fillStyle = '#39434c';
+    a.g.fillRect(x, 24, 56, 38);
+    hgt.g.fillStyle = grey(0.1);
+    hgt.g.fillRect(x, 24, 56, 38);
+    rgh.g.fillStyle = grey(0.18);
+    rgh.g.fillRect(x, 24, 56, 38);
+    a.g.fillStyle = r() > 0.6 ? 'rgba(30,40,50,0.8)' : 'rgba(196,220,236,0.6)';
+    a.g.fillRect(x + 3, 27, 50, 32);
+  }
+  // rust streaks
+  for (let i = 0; i < 26; i++) {
+    const x = r() * S;
+    a.g.fillStyle = `rgba(122,74,42,${0.04 + r() * 0.08})`;
+    a.g.fillRect(x, r() * S * 0.6, 3 + r() * 8, 40 + r() * 160);
+  }
+  noise(a.g, S, S, 16, 5);
+  return { map: tex(a.c), normalMap: normalFrom(hgt.c, 2.0), roughnessMap: tex(rgh.c, { srgb: false }) };
+}
+
+function houseSurface() {
+  const S = 512;
+  const a = canvas(S, S), hgt = canvas(S, S), rgh = canvas(S, S), emi = canvas(S, S);
+  a.g.fillStyle = '#dcd8cf'; a.g.fillRect(0, 0, S, S);
+  hgt.g.fillStyle = grey(0.6); hgt.g.fillRect(0, 0, S, S);
+  rgh.g.fillStyle = grey(0.8); rgh.g.fillRect(0, 0, S, S);
+  emi.g.fillStyle = '#000'; emi.g.fillRect(0, 0, S, S);
+  // lap siding: each board casts a shadow line under it
+  for (let y = 0; y < S; y += 22) {
+    a.g.fillStyle = 'rgba(0,0,0,0.10)';
+    a.g.fillRect(0, y + 18, S, 4);
+    const g1 = hgt.g.createLinearGradient(0, y, 0, y + 22);
+    g1.addColorStop(0, grey(0.35));
+    g1.addColorStop(0.82, grey(0.95));
+    g1.addColorStop(1, grey(0.1));
+    hgt.g.fillStyle = g1;
+    hgt.g.fillRect(0, y, S, 22);
+  }
+  const win = (x, y, w, h, lit) => {
+    a.g.fillStyle = '#f6f4ee'; a.g.fillRect(x - 9, y - 9, w + 18, h + 18);
+    hgt.g.fillStyle = grey(1.0); hgt.g.fillRect(x - 9, y - 9, w + 18, h + 18);
+    hgt.g.fillStyle = grey(0.16); hgt.g.fillRect(x, y, w, h);
+    rgh.g.fillStyle = grey(0.1); rgh.g.fillRect(x, y, w, h);
+    a.g.fillStyle = '#28323d'; a.g.fillRect(x, y, w, h);
+    const grad = a.g.createLinearGradient(x, y, x, y + h);
+    grad.addColorStop(0, 'rgba(206,228,244,0.66)');
+    grad.addColorStop(1, 'rgba(16,26,36,0.55)');
+    a.g.fillStyle = grad; a.g.fillRect(x, y, w, h);
+    if (lit) {
+      a.g.fillStyle = 'rgba(255,226,164,0.7)'; a.g.fillRect(x, y, w, h);
+      emi.g.fillStyle = 'rgb(252,206,140)'; emi.g.fillRect(x, y, w, h);
+    }
+    a.g.fillStyle = '#f6f4ee';
+    a.g.fillRect(x + w / 2 - 3, y, 6, h);
+    a.g.fillRect(x, y + h / 2 - 3, w, 6);
+    hgt.g.fillStyle = grey(0.8);
+    hgt.g.fillRect(x + w / 2 - 3, y, 6, h);
+    hgt.g.fillRect(x, y + h / 2 - 3, w, 6);
+  };
+  win(80, 92, 112, 124, false);
+  win(320, 92, 112, 124, true);
+  win(80, 320, 112, 124, false);
+  // front door with a step and a porch light
+  a.g.fillStyle = '#6f4c35'; a.g.fillRect(316, 300, 112, 184);
+  hgt.g.fillStyle = grey(0.3); hgt.g.fillRect(316, 300, 112, 184);
+  a.g.fillStyle = '#f6f4ee'; a.g.fillRect(306, 292, 132, 10);
+  hgt.g.fillStyle = grey(1.0); hgt.g.fillRect(306, 292, 132, 10);
+  a.g.fillStyle = 'rgba(255,255,255,0.22)'; a.g.fillRect(330, 316, 84, 62);
+  a.g.fillStyle = '#d8c07a'; a.g.fillRect(410, 396, 12, 12);
+  noise(a.g, S, S, 11, 11);
+  return {
+    map: tex(a.c), normalMap: normalFrom(hgt.c, 2.4),
+    roughnessMap: tex(rgh.c, { srgb: false }), emissiveMap: tex(emi.c),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Ground surfaces
+// ---------------------------------------------------------------------------
+
+function roadSurface() {
+  const S = 512;
+  const a = canvas(S, S), hgt = canvas(S, S), rgh = canvas(S, S);
+  a.g.fillStyle = '#56595e'; a.g.fillRect(0, 0, S, S);
+  hgt.g.fillStyle = grey(0.5); hgt.g.fillRect(0, 0, S, S);
+  rgh.g.fillStyle = grey(0.72); rgh.g.fillRect(0, 0, S, S);
   const r = mulberry32(41);
-  for (let i = 0; i < 34; i++) {
+  // aggregate
+  for (let i = 0; i < 5200; i++) {
+    const x = r() * S, y = r() * S, s = 1 + r() * 3;
+    const l = 0.3 + r() * 0.5;
+    a.g.fillStyle = `rgba(${(120 * l) | 0},${(124 * l) | 0},${(130 * l) | 0},0.5)`;
+    a.g.fillRect(x, y, s, s);
+    hgt.g.fillStyle = grey(0.45 + r() * 0.35);
+    hgt.g.fillRect(x, y, s, s);
+  }
+  // patches and repairs, greyscale only so the asphalt never tints
+  for (let i = 0; i < 26; i++) {
     const l = r() > 0.5 ? 255 : 0;
-    g.fillStyle = `rgba(${l},${l},${l},0.028)`;
-    g.fillRect(r() * S, r() * S, 20 + r() * 60, 8 + r() * 30);
+    a.g.fillStyle = `rgba(${l},${l},${l},0.03)`;
+    a.g.fillRect(r() * S, r() * S, 40 + r() * 120, 16 + r() * 60);
+  }
+  // polished wheel tracks: darker and much glossier
+  for (const cx of [S * 0.26, S * 0.74]) {
+    const g1 = rgh.g.createLinearGradient(cx - 26, 0, cx + 26, 0);
+    g1.addColorStop(0, grey(0.72));
+    g1.addColorStop(0.5, grey(0.34));
+    g1.addColorStop(1, grey(0.72));
+    rgh.g.fillStyle = g1;
+    rgh.g.fillRect(cx - 26, 0, 52, S);
   }
   // U runs across the road width, V along its length
-  g.fillStyle = '#e8e6dd';
-  g.fillRect(6, 0, 4, S);
-  g.fillRect(S - 10, 0, 4, S);
-  g.fillStyle = '#e5c33d';
-  for (let y = 0; y < S; y += 40) g.fillRect(S / 2 - 3, y, 6, 24);
-  return tex(c);
-}
-
-function sidewalkTexture() {
-  const S = 128, { c, g } = canvas(S, S);
-  g.fillStyle = '#a8a49c';
-  g.fillRect(0, 0, S, S);
-  noise(g, S, S, 16, 23);
-  g.strokeStyle = 'rgba(0,0,0,0.16)';
-  g.lineWidth = 2;
-  for (let i = 0; i <= S; i += 32) {
-    g.beginPath(); g.moveTo(i, 0); g.lineTo(i, S); g.stroke();
-    g.beginPath(); g.moveTo(0, i); g.lineTo(S, i); g.stroke();
+  const paint = (g, style, x, y, w, h) => { g.fillStyle = style; g.fillRect(x, y, w, h); };
+  paint(a.g, '#e9e7de', 12, 0, 8, S);
+  paint(a.g, '#e9e7de', S - 20, 0, 8, S);
+  paint(hgt.g, grey(0.8), 12, 0, 8, S);
+  paint(hgt.g, grey(0.8), S - 20, 0, 8, S);
+  paint(rgh.g, grey(0.9), 12, 0, 8, S);
+  paint(rgh.g, grey(0.9), S - 20, 0, 8, S);
+  for (let y = 0; y < S; y += 80) {
+    paint(a.g, '#e4c23e', S / 2 - 6, y, 12, 48);
+    paint(hgt.g, grey(0.8), S / 2 - 6, y, 12, 48);
+    paint(rgh.g, grey(0.9), S / 2 - 6, y, 12, 48);
   }
-  return tex(c);
+  return { map: tex(a.c), normalMap: normalFrom(hgt.c, 1.1), roughnessMap: tex(rgh.c, { srgb: false }) };
 }
 
-// Deliberately neutral: the terrain's per-vertex colour decides whether a patch
-// reads as grass, pavement or beach, so this only supplies grain.
-function groundTexture() {
-  const S = 128, { c, g } = canvas(S, S);
-  g.fillStyle = '#b0b0ac';
-  g.fillRect(0, 0, S, S);
+function sidewalkSurface() {
+  const S = 256;
+  const a = canvas(S, S), hgt = canvas(S, S), rgh = canvas(S, S);
+  a.g.fillStyle = '#bab7ae'; a.g.fillRect(0, 0, S, S);
+  hgt.g.fillStyle = grey(0.85); hgt.g.fillRect(0, 0, S, S);
+  rgh.g.fillStyle = grey(0.82); rgh.g.fillRect(0, 0, S, S);
+  const r = mulberry32(23);
+  for (let i = 0; i < 2600; i++) {
+    const l = 0.55 + r() * 0.5;
+    a.g.fillStyle = `rgba(${(168 * l) | 0},${(166 * l) | 0},${(158 * l) | 0},0.45)`;
+    a.g.fillRect(r() * S, r() * S, 1 + r() * 3, 1 + r() * 3);
+  }
+  // expansion joints
+  for (let i = 0; i <= S; i += 64) {
+    a.g.fillStyle = 'rgba(0,0,0,0.22)';
+    a.g.fillRect(i - 2, 0, 4, S);
+    a.g.fillRect(0, i - 2, S, 4);
+    hgt.g.fillStyle = grey(0.08);
+    hgt.g.fillRect(i - 2, 0, 4, S);
+    hgt.g.fillRect(0, i - 2, S, 4);
+  }
+  // stains
+  for (let i = 0; i < 22; i++) {
+    a.g.fillStyle = `rgba(60,58,54,${0.03 + r() * 0.06})`;
+    a.g.beginPath();
+    a.g.ellipse(r() * S, r() * S, 6 + r() * 22, 6 + r() * 18, 0, 0, Math.PI * 2);
+    a.g.fill();
+  }
+  return { map: tex(a.c), normalMap: normalFrom(hgt.c, 1.6), roughnessMap: tex(rgh.c, { srgb: false }) };
+}
+
+// Neutral: the terrain's vertex colour decides grass vs pavement vs beach.
+function groundSurface() {
+  const S = 256;
+  const a = canvas(S, S), hgt = canvas(S, S);
+  a.g.fillStyle = '#b2b2ae'; a.g.fillRect(0, 0, S, S);
+  hgt.g.fillStyle = grey(0.5); hgt.g.fillRect(0, 0, S, S);
   const r = mulberry32(53);
-  for (let i = 0; i < 1100; i++) {
-    const v = 0.55 + r() * 0.6;
-    const l = Math.round(150 * v);
-    g.fillStyle = `rgba(${l},${l},${Math.round(l * 0.97)},0.45)`;
-    g.fillRect(r() * S, r() * S, 2 + r() * 5, 2 + r() * 5);
+  for (let i = 0; i < 4200; i++) {
+    const v = 0.78 + r() * 0.3;
+    const l = Math.round(170 * v);
+    a.g.fillStyle = `rgba(${l},${l},${Math.round(l * 0.98)},0.28)`;
+    const s = 2 + r() * 5;
+    a.g.fillRect(r() * S, r() * S, s, s);
+    hgt.g.fillStyle = grey(0.42 + r() * 0.22);
+    hgt.g.fillRect(r() * S, r() * S, s, s);
   }
-  noise(g, S, S, 22, 61);
-  return tex(c);
+  noise(a.g, S, S, 10, 61);
+  return { map: tex(a.c), normalMap: normalFrom(hgt.c, 1.4) };
 }
 
-function waterTexture() {
-  const S = 256, { c, g } = canvas(S, S);
-  g.fillStyle = '#33566b';
-  g.fillRect(0, 0, S, S);
+function waterSurface() {
+  const S = 512;
+  const hgt = canvas(S, S);
+  hgt.g.fillStyle = grey(0.5); hgt.g.fillRect(0, 0, S, S);
   const r = mulberry32(67);
-  for (let i = 0; i < 500; i++) {
-    const x = r() * S, y = r() * S, w = 8 + r() * 40;
-    g.strokeStyle = `rgba(200,225,240,${0.03 + r() * 0.07})`;
-    g.lineWidth = 1 + r() * 2;
-    g.beginPath();
-    g.moveTo(x, y);
-    g.quadraticCurveTo(x + w / 2, y + (r() - 0.5) * 6, x + w, y);
-    g.stroke();
+  // overlapping long swells + chop
+  for (let i = 0; i < 900; i++) {
+    const x = r() * S, y = r() * S, w = 30 + r() * 150, h = 2 + r() * 5;
+    const g1 = hgt.g.createLinearGradient(0, y - h, 0, y + h);
+    g1.addColorStop(0, grey(0.5));
+    g1.addColorStop(0.5, grey(0.5 + (r() - 0.5) * 0.55));
+    g1.addColorStop(1, grey(0.5));
+    hgt.g.fillStyle = g1;
+    hgt.g.beginPath();
+    hgt.g.ellipse(x, y, w, h, (r() - 0.5) * 0.4, 0, Math.PI * 2);
+    hgt.g.fill();
   }
-  return tex(c);
+  return { normalMap: normalFrom(hgt.c, 1.5) };
 }
 
-function skyTexture() {
-  const W = 512, H = 256, { c, g } = canvas(W, H);
+// ---------------------------------------------------------------------------
+// Sky (equirectangular: doubles as the background and the IBL source)
+// ---------------------------------------------------------------------------
+
+function skyEquirect() {
+  const W = 2048, H = 1024;
+  const { c, g } = canvas(W, H);
   const grad = g.createLinearGradient(0, 0, 0, H);
-  grad.addColorStop(0.0, '#4d6f92');
-  grad.addColorStop(0.42, '#8fa8bd');
-  grad.addColorStop(0.62, '#c3cdd4');
-  grad.addColorStop(0.78, '#d9dde0');
-  grad.addColorStop(1.0, '#b9c3c9');
+  grad.addColorStop(0.00, '#2f5680');
+  grad.addColorStop(0.22, '#4a749a');
+  grad.addColorStop(0.42, '#88a8c2');
+  grad.addColorStop(0.50, '#c2ced6');
+  grad.addColorStop(0.54, '#cdd6db');
+  grad.addColorStop(0.70, '#8e969b');
+  grad.addColorStop(1.00, '#5d6469');
   g.fillStyle = grad;
   g.fillRect(0, 0, W, H);
-  // soft overcast banks
+
+  // Sun: placed to match the key light direction so speculars line up.
+  const sx = 207, sy = 221;
+  const halo = g.createRadialGradient(sx, sy, 0, sx, sy, 460);
+  halo.addColorStop(0, 'rgba(255,247,228,0.95)');
+  halo.addColorStop(0.06, 'rgba(255,240,206,0.55)');
+  halo.addColorStop(0.3, 'rgba(226,232,236,0.22)');
+  halo.addColorStop(1, 'rgba(226,232,236,0)');
+  g.fillStyle = halo;
+  g.fillRect(0, 0, W, H);
+  const disc = g.createRadialGradient(sx, sy, 0, sx, sy, 42);
+  disc.addColorStop(0, 'rgba(255,255,250,1)');
+  disc.addColorStop(0.6, 'rgba(255,250,232,0.9)');
+  disc.addColorStop(1, 'rgba(255,246,220,0)');
+  g.fillStyle = disc;
+  g.fillRect(0, 0, W, H);
+
+  // Broken overcast: soft banks, flattened and denser toward the horizon.
   const r = mulberry32(83);
-  for (let i = 0; i < 90; i++) {
-    const x = r() * W, y = 20 + r() * 120, w = 60 + r() * 180, h = 12 + r() * 34;
-    g.fillStyle = `rgba(255,255,255,${0.03 + r() * 0.07})`;
-    g.beginPath();
-    g.ellipse(x, y, w, h, 0, 0, Math.PI * 2);
-    g.fill();
+  for (let layer = 0; layer < 3; layer++) {
+    const count = 120 + layer * 90;
+    for (let i = 0; i < count; i++) {
+      const y = 40 + Math.pow(r(), 0.6) * (H * 0.46);
+      const x = r() * W;
+      const squash = 0.12 + (y / H) * 0.5;
+      const w = (90 + r() * 340) * (1 + layer * 0.4);
+      const h = w * squash * (0.2 + r() * 0.35);
+      const near = 1 - Math.abs(y - sy) / 900;
+      const bright = 0.72 + Math.max(0, near) * 0.28;
+      const alpha = 0.035 + r() * 0.075;
+      const cg = g.createRadialGradient(x, y, 0, x, y, w);
+      const t = Math.round(255 * bright);
+      cg.addColorStop(0, `rgba(${t},${t},${Math.round(t * 0.99)},${alpha})`);
+      cg.addColorStop(0.55, `rgba(${t},${t},${t},${alpha * 0.5})`);
+      cg.addColorStop(1, 'rgba(255,255,255,0)');
+      g.fillStyle = cg;
+      g.beginPath();
+      g.ellipse(x, y, w, h, 0, 0, Math.PI * 2);
+      g.fill();
+      // undersides
+      g.fillStyle = `rgba(96,110,124,${alpha * 0.5})`;
+      g.beginPath();
+      g.ellipse(x, y + h * 0.55, w * 0.8, h * 0.4, 0, 0, Math.PI * 2);
+      g.fill();
+    }
   }
-  const t = tex(c, false, 2);
+  // horizon haze band
+  const haze = g.createLinearGradient(0, H * 0.44, 0, H * 0.56);
+  haze.addColorStop(0, 'rgba(206,216,222,0)');
+  haze.addColorStop(0.5, 'rgba(206,216,222,0.85)');
+  haze.addColorStop(1, 'rgba(206,216,222,0)');
+  g.fillStyle = haze;
+  g.fillRect(0, 0, W, H);
+
+  const t = tex(c, { repeat: false, aniso: 4, mips: true });
+  t.mapping = THREE.EquirectangularReflectionMapping;
   t.wrapS = THREE.RepeatWrapping;
-  t.wrapT = THREE.ClampToEdgeWrapping;
   return t;
 }
 
@@ -283,20 +529,20 @@ function particleTexture() {
   grad.addColorStop(1, 'rgba(255,255,255,0)');
   g.fillStyle = grad;
   g.fillRect(0, 0, S, S);
-  return tex(c, false, 1);
+  return tex(c, { repeat: false, aniso: 1, mips: false });
 }
 
 export function buildTextures() {
   return {
-    glass: glassTexture(),
-    masonry: masonryTexture(),
-    industrial: industrialTexture(),
-    house: houseTexture(),
-    road: roadTexture(),
-    sidewalk: sidewalkTexture(),
-    ground: groundTexture(),
-    water: waterTexture(),
-    sky: skyTexture(),
+    glass: glassSurface(),
+    masonry: masonrySurface(),
+    industrial: industrialSurface(),
+    house: houseSurface(),
+    road: roadSurface(),
+    sidewalk: sidewalkSurface(),
+    ground: groundSurface(),
+    water: waterSurface(),
+    sky: skyEquirect(),
     particle: particleTexture(),
   };
 }

--- a/apps/auto/src/traffic.js
+++ b/apps/auto/src/traffic.js
@@ -6,7 +6,7 @@ import { clamp, lerp, angleWrap, hash2, rng, dist2 } from './util.js';
 import * as G from './geo.js';
 
 const TRAFFIC_TARGET = 26;
-const PARKED_RADIUS = 155;
+const PARKED_RADIUS = 130;
 const DESPAWN = 520;
 
 export function collideWithBuildings(v, city, onHit) {
@@ -93,7 +93,7 @@ export class TrafficSystem {
       const slots = Math.floor(e.len / 13);
       for (let s = 1; s < slots; s++) {
         const h = hash2(ei * 31 + s, 7);
-        if (h > 0.42) continue;
+        if (h > 0.32) continue;
         const key = ei * 64 + s;
         seen.add(key);
         if (this.parkedSlots.has(key)) continue;
@@ -178,16 +178,26 @@ export class TrafficSystem {
       v.pathT = 0;
       v.repath = 0;
       v.rammed = 0;
-      // light bar strobes
+      // roof light bar: a dark housing with two strobing lenses
       const bar = new THREE.Group();
+      const y = v.spec.roof + 0.09;
+      const housing = new THREE.Mesh(
+        new THREE.BoxGeometry(1.24, 0.1, 0.34),
+        new THREE.MeshStandardMaterial({ color: 0x15181c, roughness: 0.6, metalness: 0.1 })
+      );
+      housing.position.set(0, y - 0.03, 0.05);
+      bar.add(housing);
       const mkL = (c, x) => {
-        const m = new THREE.Mesh(new THREE.BoxGeometry(0.5, 0.14, 0.3), new THREE.MeshBasicMaterial({ color: c }));
-        m.position.set(x, v.spec.bodyH + v.spec.cabH + (v.t.wheelR || 0.34) * 0.72 + 0.14, 0.1);
+        const m = new THREE.Mesh(
+          new THREE.BoxGeometry(0.52, 0.15, 0.3),
+          new THREE.MeshBasicMaterial({ color: c, toneMapped: false })
+        );
+        m.position.set(x, y + 0.07, 0.05);
         bar.add(m);
         return m;
       };
-      v.lightL = mkL(0x2244ff, -0.3);
-      v.lightR = mkL(0xff2222, 0.3);
+      v.lightL = mkL(0x3355ff, -0.31);
+      v.lightR = mkL(0xff2a2a, 0.31);
       v.tilt.add(bar);
       return v;
     }
@@ -310,7 +320,7 @@ export class TrafficSystem {
       if (v.mode === 'police' && game.wanted === 0 && d2 > 140 * 140) { this.remove(v); continue; }
 
       if (v.mode === 'parked') {
-        v.group.visible = d2 < 175 * 175;
+        v.group.visible = d2 < 140 * 140;
         continue;
       }
       v.group.visible = true;

--- a/apps/auto/src/vehicles.js
+++ b/apps/auto/src/vehicles.js
@@ -286,7 +286,6 @@ function buildType(spec) {
     return b;
   };
   const trimW = clone(trim), matteW = clone(matte);
-  const sink = new Builder(false);
   for (const [ax, ay, az] of wheels) addWheel(trimW, matteW, ax, ay, az, wr, tw);
   const wt = new Builder(false), wm = new Builder(false);
   addWheel(wt, wm, 0, 0, 0, wr, tw);

--- a/apps/auto/src/vehicles.js
+++ b/apps/auto/src/vehicles.js
@@ -1,167 +1,308 @@
-// Vehicle models (built once per type) and the arcade driving model.
+// Vehicle models and the arcade driving model.
+//
+// Bodies are lofted through cross-sections rather than assembled from boxes, so
+// they get a real shoulder line, a raked screen and smooth shading. Each type
+// bakes down to three geometries that share materials across every instance:
+//
+//   paint  - the painted shell, tinted per car by its own material colour
+//   trim   - glass, chrome, lamp lenses, wheel rims (shiny, metallic)
+//   matte  - tyres, bumper rubber, plastic, wheel arches (rough, dielectric)
 
 import * as THREE from './three.js';
 import { Builder } from './build.js';
-import { clamp, lerp, angleWrap, hash2 } from './util.js';
+import { clamp, lerp, hash2 } from './util.js';
 import * as G from './geo.js';
 
-const BLACK = [0.06, 0.06, 0.07];
-const GLASSC = [0.16, 0.22, 0.28];
-const CHROME = [0.72, 0.74, 0.76];
-const LIGHT = [1.0, 0.97, 0.82];
-const TAIL = [0.85, 0.12, 0.1];
-const TRIM = [0.2, 0.21, 0.23];
+const TYRE = [0.05, 0.05, 0.055];
+const RIM = [0.80, 0.82, 0.85];
+const HUB = [0.42, 0.44, 0.47];
+const GLASS = [0.06, 0.08, 0.10];
+const CHROME = [0.84, 0.86, 0.89];
+const PLASTIC = [0.11, 0.12, 0.13];
+const LAMP = [1.0, 0.98, 0.9];
+const TAILC = [0.92, 0.12, 0.1];
+const AMBER = [0.95, 0.55, 0.08];
+const PLATE = [0.86, 0.86, 0.82];
+const WHITE = [1, 1, 1];
 
+// len/wid in metres; sill = bottom of the visible bodywork, belt = shoulder
+// line, roof = roof height, cab = greenhouse extent as a fraction of length.
 export const TYPES = {
-  sedan: { len: 4.7, wid: 1.86, bodyH: 0.74, cab: [-0.30, 0.20], cabH: 0.60, mass: 1, top: 42, acc: 9.5 },
-  hatch: { len: 4.05, wid: 1.76, bodyH: 0.72, cab: [-0.30, 0.14], cabH: 0.58, mass: 0.9, top: 38, acc: 9 },
-  compact: { len: 3.7, wid: 1.7, bodyH: 0.70, cab: [-0.26, 0.12], cabH: 0.56, mass: 0.85, top: 36, acc: 8.6 },
-  suv: { len: 4.95, wid: 1.98, bodyH: 1.00, cab: [-0.34, 0.26], cabH: 0.62, mass: 1.3, top: 40, acc: 8.8, wheelR: 0.38 },
-  sports: { len: 4.45, wid: 1.94, bodyH: 0.56, cab: [-0.22, 0.04], cabH: 0.44, mass: 0.85, top: 62, acc: 15, spoiler: true },
-  muscle: { len: 5.05, wid: 2.0, bodyH: 0.72, cab: [-0.20, 0.10], cabH: 0.52, mass: 1.15, top: 55, acc: 13.5 },
-  pickup: { len: 5.5, wid: 2.02, bodyH: 0.92, cab: [-0.06, 0.28], cabH: 0.68, bed: true, mass: 1.4, top: 39, acc: 8.6, wheelR: 0.4 },
-  van: { len: 5.3, wid: 2.02, bodyH: 1.62, cab: [-0.45, 0.32], cabH: 0.0, boxy: true, mass: 1.5, top: 36, acc: 7.6 },
-  taxi: { len: 4.75, wid: 1.88, bodyH: 0.74, cab: [-0.30, 0.20], cabH: 0.60, taxi: true, mass: 1, top: 42, acc: 9.5 },
-  police: { len: 4.95, wid: 1.94, bodyH: 0.78, cab: [-0.30, 0.20], cabH: 0.60, police: true, mass: 1.1, top: 56, acc: 14 },
-  bus: { len: 12.2, wid: 2.55, bodyH: 3.0, bus: true, mass: 4.5, top: 26, acc: 4.2, wheelR: 0.5 },
-  boxtruck: { len: 7.6, wid: 2.4, bodyH: 1.05, cargo: 2.6, cab: [0.16, 0.46], cabH: 1.15, mass: 3, top: 30, acc: 5.2, wheelR: 0.46 },
-  ambulance: { len: 6.4, wid: 2.3, bodyH: 1.0, cargo: 2.2, cab: [0.2, 0.46], cabH: 1.0, mass: 2.4, top: 40, acc: 8, wheelR: 0.42, emergency: true },
-  garbage: { len: 8.2, wid: 2.5, bodyH: 1.2, cargo: 2.4, cab: [0.22, 0.46], cabH: 1.2, mass: 4, top: 26, acc: 4.4, wheelR: 0.5 },
+  sedan: { len: 4.72, wid: 1.83, wheelR: 0.33, sill: 0.30, belt: 0.98, roof: 1.46, cab: [-0.28, 0.19], mass: 1, top: 42, acc: 9.5 },
+  hatch: { len: 4.10, wid: 1.76, wheelR: 0.31, sill: 0.29, belt: 0.96, roof: 1.50, cab: [-0.30, 0.16], mass: 0.9, top: 38, acc: 9 },
+  compact: { len: 3.74, wid: 1.68, wheelR: 0.29, sill: 0.28, belt: 0.94, roof: 1.48, cab: [-0.28, 0.15], mass: 0.85, top: 36, acc: 8.6 },
+  suv: { len: 4.94, wid: 1.96, wheelR: 0.38, sill: 0.42, belt: 1.24, roof: 1.86, cab: [-0.32, 0.24], boxy: 1, mass: 1.3, top: 40, acc: 8.8 },
+  sports: { len: 4.42, wid: 1.92, wheelR: 0.34, sill: 0.24, belt: 0.80, roof: 1.20, cab: [-0.24, 0.06], spoiler: true, mass: 0.85, top: 62, acc: 15 },
+  muscle: { len: 5.02, wid: 1.98, wheelR: 0.35, sill: 0.28, belt: 0.94, roof: 1.36, cab: [-0.24, 0.13], mass: 1.15, top: 55, acc: 13.5 },
+  pickup: { len: 5.48, wid: 2.00, wheelR: 0.40, sill: 0.44, belt: 1.20, roof: 1.86, cab: [0.00, 0.28], bed: true, boxy: 1, mass: 1.4, top: 39, acc: 8.6 },
+  van: { len: 5.26, wid: 2.00, wheelR: 0.35, sill: 0.36, belt: 1.10, roof: 2.28, cab: [-0.44, 0.30], boxy: 2, mass: 1.5, top: 36, acc: 7.6 },
+  taxi: { len: 4.76, wid: 1.85, wheelR: 0.33, sill: 0.30, belt: 0.98, roof: 1.48, cab: [-0.28, 0.19], taxi: true, mass: 1, top: 42, acc: 9.5 },
+  police: { len: 4.98, wid: 1.92, wheelR: 0.34, sill: 0.30, belt: 1.00, roof: 1.48, cab: [-0.28, 0.19], police: true, mass: 1.1, top: 56, acc: 14 },
+  bus: { len: 12.0, wid: 2.55, wheelR: 0.50, sill: 0.50, belt: 1.30, roof: 3.10, cab: [-0.48, 0.48], bus: true, boxy: 3, mass: 4.5, top: 26, acc: 4.2 },
+  boxtruck: { len: 7.5, wid: 2.38, wheelR: 0.46, sill: 0.62, belt: 1.55, roof: 2.55, cab: [0.14, 0.46], cargo: 2.55, boxy: 2, mass: 3, top: 30, acc: 5.2 },
+  ambulance: { len: 6.3, wid: 2.28, wheelR: 0.42, sill: 0.56, belt: 1.42, roof: 2.35, cab: [0.16, 0.46], cargo: 2.25, boxy: 2, emergency: true, mass: 2.4, top: 40, acc: 8 },
+  garbage: { len: 8.1, wid: 2.48, wheelR: 0.50, sill: 0.66, belt: 1.62, roof: 2.6, cab: [0.20, 0.46], cargo: 2.5, boxy: 2, mass: 4, top: 26, acc: 4.4 },
 };
 
 export const CIVILIAN_TYPES = ['sedan', 'sedan', 'hatch', 'compact', 'suv', 'suv', 'sports', 'muscle', 'pickup', 'van', 'taxi', 'boxtruck', 'bus', 'garbage'];
 
 export const CAR_COLORS = [
-  0xb8bcc0, 0x2a2d31, 0xe8e9ea, 0x7d0f14, 0x14406e, 0x1d5c3a, 0x8a6a2b,
-  0x3d4b57, 0xa8a29a, 0x5c2b6b, 0xd07a10, 0x0f6f7a, 0x6f7175, 0xc9cdd2,
+  0x9fa4a9, 0x1b1d20, 0xe6e8ea, 0x6d0f14, 0x102b52, 0x14472f, 0x7a5a22,
+  0x2f3a44, 0x9c968c, 0x4a2058, 0xb85f0c, 0x0d5b66, 0x5b5f63, 0xbcc2c8,
+  0x243b6b, 0x7d2418,
 ];
 
 // ---------------------------------------------------------------------------
+// Geometry
+// ---------------------------------------------------------------------------
+
+/** Rounded-rectangle cross-section: an octagon with chamfered corners. */
+function ring(w, y0, y1, r) {
+  const rr = Math.min(r, Math.abs(y1 - y0) / 2.2, w / 2.2);
+  return [
+    [-w, y0 + rr], [-w + rr, y0], [w - rr, y0], [w, y0 + rr],
+    [w, y1 - rr], [w - rr, y1], [-w + rr, y1], [-w, y1 - rr],
+  ];
+}
+
+/** Tyre into `matte`, rim and spokes into `trim`. */
+function addWheel(trim, matte, cx, cy, cz, r, w) {
+  const seg = 14;
+  const inner = r * 0.6;
+  for (let i = 0; i < seg; i++) {
+    const a0 = (i / seg) * Math.PI * 2, a1 = ((i + 1) / seg) * Math.PI * 2;
+    const c0 = Math.cos(a0), s0 = Math.sin(a0), c1 = Math.cos(a1), s1 = Math.sin(a1);
+    const n0 = [0, c0, s0], n1 = [0, c1, s1];
+    matte.quad(
+      [cx - w / 2, cy + c0 * r, cz + s0 * r], [cx + w / 2, cy + c0 * r, cz + s0 * r],
+      [cx + w / 2, cy + c1 * r, cz + s1 * r], [cx - w / 2, cy + c1 * r, cz + s1 * r],
+      [n0, n0, n1, n1], [0, 0, 1, 0, 1, 1, 0, 1], TYRE);
+    for (const sx of [-1, 1]) {
+      const x = cx + (sx * w) / 2;
+      matte.quad(
+        [x, cy + c0 * r, cz + s0 * r], [x, cy + c0 * inner, cz + s0 * inner],
+        [x, cy + c1 * inner, cz + s1 * inner], [x, cy + c1 * r, cz + s1 * r],
+        [sx, 0, 0], [0, 0, 1, 0, 1, 1, 0, 1], TYRE);
+      // alternating wedges across the rim face read as spokes
+      const rx = x - sx * 0.005;
+      trim.tri([rx, cy, cz], [rx, cy + c0 * inner, cz + s0 * inner], [rx, cy + c1 * inner, cz + s1 * inner],
+        [sx, 0, 0], i % 2 === 0 ? RIM : HUB);
+    }
+  }
+  trim.prism(cx, cy - w * 0.5, cz, r * 0.18, w, 8, CHROME, Math.PI / 8);
+}
 
 function buildType(spec) {
-  const body = new Builder(false);
-  const det = new Builder(false);
-  const L = spec.len, W = spec.wid;
-  const wr = spec.wheelR || 0.34;
-  const floor = wr * 0.72;
-  const white = [1, 1, 1];
+  const paint = new Builder(false);
+  const trim = new Builder(false);
+  const matte = new Builder(false);
+  const L = spec.len, W = spec.wid / 2;
+  const wr = spec.wheelR;
+  const sill = spec.sill, belt = spec.belt, roof = spec.roof;
+  const zAt = (t) => (t - 0.5) * L;
+  const boxy = spec.boxy || 0;
+  const round = boxy >= 2 ? 0.20 : boxy === 1 ? 0.16 : 0.13;
 
-  if (spec.bus) {
-    body.box(0, floor, 0, W, spec.bodyH, L, 0, white);
-    det.box(0, floor + spec.bodyH, 0, W * 0.95, 0.16, L * 0.96, 0, TRIM);
-    // window band
-    for (const sx of [-1, 1]) {
-      det.box(sx * (W / 2 + 0.01), floor + spec.bodyH * 0.52, 0, 0.06, spec.bodyH * 0.34, L * 0.9, 0, GLASSC);
+  // --- lower body ----------------------------------------------------------
+  // Sampled as a continuous profile rather than a handful of key stations, so
+  // the bottom edge can arch up over each wheel. Without that cut the tyres
+  // just intersect a straight sill and the whole thing reads as a toy.
+  const frontT = spec.bus ? 0.84 : boxy >= 2 ? 0.80 : 0.785;
+  const rearT = spec.bus ? 0.16 : boxy >= 2 ? 0.20 : 0.215;
+  const archR = wr + (boxy >= 2 ? 0.13 : 0.11);
+  const archTop = wr + (boxy >= 2 ? 0.10 : 0.08);
+  const archLift = (t) => {
+    let l = 0;
+    for (const wt of [rearT, frontT]) {
+      const dz = Math.abs(t - wt) * L;
+      if (dz < archR) l = Math.max(l, archTop * Math.sqrt(1 - (dz / archR) ** 2));
     }
-    det.box(0, floor + spec.bodyH * 0.5, L / 2 + 0.01, W * 0.86, spec.bodyH * 0.36, 0.06, 0, GLASSC);
-    det.box(0, floor + spec.bodyH * 0.5, -L / 2 - 0.01, W * 0.86, spec.bodyH * 0.32, 0.06, 0, GLASSC);
-    det.box(0, floor + 0.18, L / 2 + 0.02, W * 0.7, 0.22, 0.08, 0, LIGHT);
-    det.box(0, floor + 0.18, -L / 2 - 0.02, W * 0.7, 0.22, 0.08, 0, TAIL);
-  } else if (spec.cargo) {
-    const cabL = (spec.cab[1] - spec.cab[0]) * L;
-    const cabC = ((spec.cab[0] + spec.cab[1]) / 2) * L;
-    body.box(0, floor, 0, W, spec.bodyH, L, 0, white);
-    body.box(0, floor + spec.bodyH, cabC, W, spec.cabH, cabL, 0, white);
-    det.box(0, floor + spec.bodyH + spec.cabH * 0.45, cabC + cabL / 2 + 0.01, W * 0.84, spec.cabH * 0.5, 0.06, 0, GLASSC);
-    const boxL = L * 0.52;
-    det.box(0, floor + spec.bodyH, -L * 0.18, W * 1.01, spec.cargo, boxL, 0, [0.92, 0.92, 0.92]);
-    det.box(0, floor + spec.bodyH + spec.cargo, -L * 0.18, W * 1.03, 0.1, boxL + 0.06, 0, TRIM);
-    det.box(0, floor + 0.2, L / 2 + 0.02, W * 0.76, 0.24, 0.08, 0, LIGHT);
-    det.box(0, floor + 0.2, -L / 2 - 0.02, W * 0.76, 0.24, 0.08, 0, TAIL);
-    if (spec.emergency) {
-      det.box(0, floor + spec.bodyH + spec.cargo + 0.1, -L * 0.18, 1.1, 0.18, 0.4, 0, [0.9, 0.15, 0.12]);
-    }
+    return l;
+  };
+  const endTaper = boxy >= 2 ? 0.07 : 0.13;
+  const endWidth = boxy >= 2 ? 0.86 : 0.72;
+  const widthAt = (t) => {
+    const e = clamp(Math.min(t, 1 - t) / endTaper, 0, 1);
+    return endWidth + (1 - endWidth) * Math.sqrt(e);
+  };
+  const beltAt = (t) => {
+    if (boxy >= 2) return belt;
+    const hood = -0.17 * clamp((t - 0.70) / 0.30, 0, 1) ** 1.7;
+    const trunk = -0.11 * clamp((0.22 - t) / 0.22, 0, 1) ** 1.7;
+    const crown = 0.02 * Math.sin(Math.PI * clamp((t - 0.2) / 0.6, 0, 1));
+    return belt + hood + trunk + crown;
+  };
+  const STATIONS = boxy >= 2 ? 20 : 26;
+  const bodyRings = [];
+  for (let i = 0; i <= STATIONS; i++) {
+    const t = i / STATIONS;
+    bodyRings.push({
+      z: zAt(t),
+      pts: ring(W * widthAt(t), Math.max(sill, archLift(t)), beltAt(t), round),
+    });
+  }
+  paint.loft(bodyRings, WHITE, { capStart: true, capEnd: true });
+
+  // --- greenhouse ----------------------------------------------------------
+  const c0 = 0.5 + spec.cab[0], c1 = 0.5 + spec.cab[1];
+  const gw = boxy >= 2 ? 0.985 : boxy === 1 ? 0.93 : 0.88;
+  const cabRings = spec.cargo ? [
+    { z: zAt(c0), pts: ring(W * gw * 0.94, belt - 0.02, belt + 0.06, 0.1) },
+    { z: zAt(c0 + 0.02), pts: ring(W * gw, belt - 0.02, roof - 0.02, 0.14) },
+    { z: zAt(c1 - 0.05), pts: ring(W * gw, belt - 0.02, roof, 0.14) },
+    { z: zAt(c1 - 0.015), pts: ring(W * gw * 0.95, belt - 0.02, roof - 0.08, 0.12) },
+    { z: zAt(c1), pts: ring(W * gw * 0.82, belt - 0.02, belt + 0.22, 0.1) },
+  ] : [
+    { z: zAt(c0), pts: ring(W * gw * 0.80, belt - 0.03, belt + 0.05, 0.1) },
+    { z: zAt(c0 + (boxy ? 0.03 : 0.075)), pts: ring(W * gw * 0.93, belt - 0.03, roof - 0.04, 0.13) },
+    { z: zAt(c0 + 0.17), pts: ring(W * gw, belt - 0.03, roof, 0.14) },
+    { z: zAt(c1 - 0.15), pts: ring(W * gw, belt - 0.03, roof, 0.14) },
+    { z: zAt(c1 - (boxy ? 0.03 : 0.085)), pts: ring(W * gw * 0.94, belt - 0.03, roof - 0.05, 0.13) },
+    { z: zAt(c1), pts: ring(W * gw * 0.78, belt - 0.03, belt + (boxy ? 0.3 : 0.12), 0.1) },
+  ];
+  // Cars get a glass greenhouse with a painted roof skin over it. Vans, trucks
+  // and buses are painted boxes with glazing cut into them instead -- lofting
+  // those in glass turned the whole upper body into one dark slab.
+  const glassCab = boxy < 2;
+  if (glassCab) {
+    trim.loft(cabRings, GLASS, { capStart: false, capEnd: false });
+    const roofRings = cabRings.slice(1, -1).map((r0) => {
+      const topY = Math.max.apply(null, r0.pts.map((p) => p[1]));
+      return { z: r0.z, pts: ring(Math.abs(r0.pts[5][0]) * 0.998, topY - 0.075, topY + 0.006, 0.04) };
+    });
+    if (roofRings.length > 1) paint.loft(roofRings, WHITE, { capStart: true, capEnd: true });
   } else {
-    const cabL = (spec.cab[1] - spec.cab[0]) * L;
-    const cabC = ((spec.cab[0] + spec.cab[1]) / 2) * L;
-    // lower mass with a slight taper
-    body.box(0, floor, 0, W, spec.bodyH * 0.55, L, 0, white);
-    body.box(0, floor + spec.bodyH * 0.55, 0, W * 0.99, spec.bodyH * 0.45, L * 0.985, 0, white);
-    if (spec.bed) {
-      body.box(0, floor + spec.bodyH, -L * 0.22, W * 0.98, 0.44, L * 0.42, 0, white);
-      det.box(0, floor + spec.bodyH + 0.02, -L * 0.22, W * 0.8, 0.06, L * 0.36, 0, TRIM);
-    }
-    if (spec.boxy) {
-      det.box(0, floor + spec.bodyH * 0.62, L / 2 + 0.01, W * 0.86, spec.bodyH * 0.3, 0.06, 0, GLASSC);
-      for (const sx of [-1, 1]) det.box(sx * (W / 2 + 0.01), floor + spec.bodyH * 0.62, L * 0.16, 0.06, spec.bodyH * 0.26, L * 0.34, 0, GLASSC);
-    } else {
-      body.box(0, floor + spec.bodyH, cabC, W * 0.9, spec.cabH, cabL, 0, white);
-      // glass
-      det.box(0, floor + spec.bodyH + spec.cabH * 0.5, cabC + cabL / 2 + 0.005, W * 0.82, spec.cabH * 0.66, 0.06, 0, GLASSC);
-      det.box(0, floor + spec.bodyH + spec.cabH * 0.5, cabC - cabL / 2 - 0.005, W * 0.8, spec.cabH * 0.6, 0.06, 0, GLASSC);
-      for (const sx of [-1, 1]) {
-        det.box(sx * (W * 0.45 + 0.005), floor + spec.bodyH + spec.cabH * 0.52, cabC, 0.05, spec.cabH * 0.56, cabL * 0.86, 0, GLASSC);
-        det.box(sx * (W * 0.5 + 0.06), floor + spec.bodyH + spec.cabH * 0.45, cabC + cabL * 0.42, 0.16, 0.11, 0.24, 0, TRIM);
-      }
-      det.box(0, floor + spec.bodyH + spec.cabH, cabC, W * 0.86, 0.05, cabL * 0.94, 0, TRIM);
-    }
-    if (spec.spoiler) {
-      det.box(0, floor + spec.bodyH + 0.18, -L * 0.46, W * 0.8, 0.06, 0.28, 0, TRIM);
-      for (const sx of [-1, 1]) det.box(sx * W * 0.32, floor + spec.bodyH, -L * 0.46, 0.07, 0.2, 0.2, 0, TRIM);
-    }
-    // bumpers, lights, grille
-    det.box(0, floor + 0.12, L / 2 + 0.02, W * 0.96, 0.26, 0.1, 0, TRIM);
-    det.box(0, floor + 0.12, -L / 2 - 0.02, W * 0.96, 0.26, 0.1, 0, TRIM);
-    for (const sx of [-1, 1]) {
-      det.box(sx * W * 0.32, floor + spec.bodyH * 0.62, L / 2 + 0.01, W * 0.26, 0.16, 0.07, 0, LIGHT);
-      det.box(sx * W * 0.32, floor + spec.bodyH * 0.62, -L / 2 - 0.01, W * 0.26, 0.16, 0.07, 0, TAIL);
-    }
-    det.box(0, floor + spec.bodyH * 0.5, L / 2 + 0.01, W * 0.38, 0.2, 0.06, 0, BLACK);
-    if (spec.taxi) {
-      det.box(0, floor + spec.bodyH + spec.cabH + 0.05, cabC, 0.9, 0.24, 0.34, 0, [1, 0.85, 0.15]);
-    }
-    if (spec.police) {
-      det.box(0, floor + spec.bodyH + spec.cabH + 0.05, cabC + 0.1, 1.15, 0.16, 0.28, 0, TRIM);
-      det.box(-0.3, floor + spec.bodyH + spec.cabH + 0.13, cabC + 0.1, 0.5, 0.14, 0.3, 0, [0.15, 0.3, 1.0]);
-      det.box(0.3, floor + spec.bodyH + spec.cabH + 0.13, cabC + 0.1, 0.5, 0.14, 0.3, 0, [1.0, 0.15, 0.15]);
+    paint.loft(cabRings, WHITE, { capStart: true, capEnd: true });
+    // windscreen raked into the painted cab front
+    const fz = cabRings[cabRings.length - 1].z;
+    const fw = Math.abs(cabRings[cabRings.length - 2].pts[2][0]);
+    trim.box(0, belt + 0.16, fz - 0.1, fw * 1.72, (roof - belt) * 0.62, 0.1, 0, GLASS);
+    if (!spec.cargo && !spec.bus) {
+      const bz2 = cabRings[0].z;
+      trim.box(0, belt + 0.3, bz2 + 0.08, fw * 1.5, (roof - belt) * 0.44, 0.08, 0, GLASS);
     }
   }
 
-  // wheels
-  const wheels = [];
-  const wx = W / 2 - 0.12;
-  const wz = L * (spec.bus || spec.cargo ? 0.33 : 0.31);
-  const tyreW = spec.bus || spec.cargo ? 0.34 : 0.26;
-  wheels.push([-wx, wr, wz], [wx, wr, wz], [-wx, wr, -wz], [wx, wr, -wz]);
-  if (spec.bus || (spec.cargo && spec.len > 7)) wheels.push([-wx, wr, -wz + 1.0], [wx, wr, -wz + 1.0]);
+  // --- cargo box / pickup bed ---------------------------------------------
+  if (spec.cargo) {
+    const bz0 = zAt(0.015), bz1 = zAt(c0 - 0.005);
+    paint.loft([
+      { z: bz0, pts: ring(W * 1.005, sill + 0.05, belt + spec.cargo, 0.1) },
+      { z: bz1, pts: ring(W * 1.005, sill + 0.05, belt + spec.cargo, 0.1) },
+    ], WHITE, { capStart: true, capEnd: true });
+    matte.box(0, belt + spec.cargo, (bz0 + bz1) / 2, W * 2.04, 0.09, bz1 - bz0, 0, PLASTIC);
+    matte.box(0, sill + 0.1, bz0 + 0.05, W * 1.86, belt + spec.cargo - sill - 0.3, 0.06, 0, [0.28, 0.29, 0.3]);
+  }
+  if (spec.bed) {
+    const bz0 = zAt(0.03), bz1 = zAt(c0 - 0.02);
+    for (const sx of [-1, 1]) paint.box(sx * (W - 0.07), belt, (bz0 + bz1) / 2, 0.13, 0.44, bz1 - bz0, 0, WHITE);
+    paint.box(0, belt, bz0 + 0.07, W * 2 - 0.14, 0.44, 0.13, 0, WHITE);
+    matte.box(0, belt - 0.02, (bz0 + bz1) / 2, W * 1.84, 0.05, bz1 - bz0 - 0.12, 0, [0.16, 0.17, 0.18]);
+  }
 
-  // Traffic cars bake their wheels into the detail mesh: one extra draw call per
-  // car instead of five. Only the player's car gets steerable wheel meshes.
-  const detWheels = new Builder(false);
-  detWheels.pos = det.pos.slice();
-  detWheels.nor = det.nor.slice();
-  detWheels.col = det.col.slice();
-  detWheels.idx = det.idx.slice();
-  detWheels.useUV = false;
-  for (const [ox, oy, oz] of wheels) addWheel(detWheels, ox, oy, oz, wr, tyreW);
+  // --- wheels + arch flares -----------------------------------------------
+  const wx = W - (boxy >= 2 ? 0.10 : 0.05);
+  const front = zAt(frontT), rear = zAt(rearT);
+  const tw = boxy >= 2 ? 0.32 : 0.24;
+  const wheels = [[-wx, wr, front], [wx, wr, front], [-wx, wr, rear], [wx, wr, rear]];
+  if (spec.bus || (spec.cargo && L > 7)) wheels.push([-wx, wr, rear + 1.05], [wx, wr, rear + 1.05]);
+  // dark wheel wells so you never see daylight through an arch
+  for (const [ax, , az] of wheels) {
+    const sx = Math.sign(ax);
+    matte.box(ax - sx * 0.22, wr + 0.16, az, 0.22, wr * 1.3, wr * 1.9, 0, [0.035, 0.04, 0.045]);
+  }
 
-  const wb = new Builder(false);
-  addWheel(wb, 0, 0, 0, wr, tyreW);
+  // --- lamps, grille, bumpers, trim ---------------------------------------
+  const nz = L / 2, tz = -L / 2;
+  const lampY = boxy >= 2 ? sill + 0.44 : sill + 0.34;
+  if (!spec.bus) {
+    const nw = W * widthAt(0.97), tw2 = W * widthAt(0.03);
+    for (const sx of [-1, 1]) {
+      // dark housing, then an inset lens, so the lamp reads even on a white car
+      matte.box(sx * nw * 0.62, lampY, zAt(0.968), nw * 0.54, 0.23, 0.14, 0, [0.05, 0.055, 0.06]);
+      trim.box(sx * nw * 0.62, lampY + 0.005, zAt(0.982), nw * 0.44, 0.16, 0.09, 0, LAMP);
+      matte.box(sx * tw2 * 0.62, lampY, zAt(0.032), tw2 * 0.56, 0.23, 0.14, 0, [0.05, 0.055, 0.06]);
+      trim.box(sx * tw2 * 0.62, lampY + 0.005, zAt(0.018), tw2 * 0.46, 0.17, 0.09, 0, TAILC);
+      trim.box(sx * tw2 * 0.88, lampY + 0.005, zAt(0.02), tw2 * 0.16, 0.11, 0.07, 0, AMBER);
+      trim.box(sx * nw * 0.92, lampY - 0.03, zAt(0.974), nw * 0.12, 0.08, 0.07, 0, AMBER);
+    }
+    // grille between the lamps, plus a lower intake under the bumper
+    matte.box(0, lampY - 0.02, zAt(0.976), nw * 0.78, 0.2, 0.1, 0, [0.045, 0.05, 0.055]);
+    for (let i = 0; i < 3; i++) trim.box(0, lampY - 0.07 + i * 0.07, zAt(0.984), nw * 0.74, 0.024, 0.035, 0, CHROME);
+    matte.box(0, sill + 0.13, zAt(0.972), nw * 1.1, 0.14, 0.1, 0, [0.05, 0.055, 0.06]);
+    matte.box(0, sill + 0.04, zAt(0.958), nw * 1.86, 0.22, 0.26, 0, PLASTIC);
+    matte.box(0, sill + 0.04, zAt(0.042), tw2 * 1.86, 0.22, 0.26, 0, PLASTIC);
+    trim.box(0, sill + 0.19, zAt(0.995), 0.44, 0.15, 0.03, 0, PLATE);
+    trim.box(0, sill + 0.19, zAt(0.005), 0.44, 0.15, 0.03, 0, PLATE);
+    matte.prism(W * 0.5, sill + 0.02, tz + 0.05, 0.055, 0.16, 6, [0.3, 0.31, 0.33]);
+  } else {
+    trim.box(0, belt + 0.55, nz - 0.03, W * 1.7, 1.05, 0.08, 0, GLASS);
+    trim.box(0, belt + 0.55, tz + 0.03, W * 1.7, 0.95, 0.08, 0, GLASS);
+    for (const sx of [-1, 1]) {
+      trim.box(sx * W * 0.6, sill + 0.3, nz - 0.02, W * 0.5, 0.24, 0.08, 0, LAMP);
+      trim.box(sx * W * 0.6, sill + 0.3, tz + 0.02, W * 0.5, 0.24, 0.08, 0, TAILC);
+    }
+    matte.box(0, sill - 0.03, 0, W * 2.03, 0.18, L * 0.94, 0, PLASTIC);
+    matte.box(0, roof - 0.08, zAt(0.35), W * 1.4, 0.24, 2.4, 0, [0.24, 0.26, 0.28]);
+  }
+
+  // glazing bands for the shapes that skip a proper greenhouse
+  if (boxy >= 2 && !spec.cargo) {
+    for (const sx of [-1, 1]) trim.box(sx * (W + 0.006), belt + 0.44, zAt(0.5), 0.03, 0.8, L * 0.72, 0, GLASS);
+  }
+  if (spec.bus) {
+    for (const sx of [-1, 1]) trim.box(sx * (W + 0.008), belt + 0.66, 0, 0.03, 1.1, L * 0.9, 0, GLASS);
+  }
+
+  if (!spec.bus) {
+    for (const sx of [-1, 1]) {
+      // mirror tucked onto the shoulder at the base of the A-pillar
+      const mz = zAt(c1 - 0.055);
+      matte.box(sx * (W + 0.03), belt + 0.02, mz, 0.08, 0.05, 0.07, 0, PLASTIC);
+      paint.box(sx * (W + 0.095), belt + 0.035, mz, 0.13, 0.11, 0.075, 0, WHITE);
+      // shut lines and a side rubbing strip
+      matte.box(sx * (W + 0.003), (sill + belt) / 2 + 0.05, zAt(c1 - 0.03), 0.01, belt - sill - 0.18, 0.022, 0, [0.16, 0.17, 0.18]);
+      matte.box(sx * (W + 0.003), (sill + belt) / 2 + 0.05, zAt(c0 + 0.17), 0.01, belt - sill - 0.18, 0.022, 0, [0.16, 0.17, 0.18]);
+    }
+  }
+
+  if (spec.spoiler) {
+    paint.box(0, belt + 0.17, tz + 0.3, W * 1.6, 0.06, 0.3, 0, WHITE);
+    for (const sx of [-1, 1]) paint.box(sx * W * 0.62, belt + 0.02, tz + 0.3, 0.07, 0.17, 0.2, 0, WHITE);
+  }
+  if (spec.taxi) {
+    trim.box(0, roof + 0.03, zAt(0.5), 0.88, 0.22, 0.3, 0, [1.0, 0.78, 0.06]);
+    matte.box(0, roof + 0.01, zAt(0.5), 0.92, 0.03, 0.34, 0, PLASTIC);
+  }
+  if (spec.emergency) {
+    trim.box(0, belt + spec.cargo + 0.03, zAt(0.24), 1.2, 0.14, 0.34, 0, TAILC);
+    matte.box(0, belt + spec.cargo + 0.01, zAt(0.24), 1.3, 0.05, 0.4, 0, PLASTIC);
+  }
+
+  const clone = (base) => {
+    const b = new Builder(false);
+    b.pos = base.pos.slice(); b.nor = base.nor.slice();
+    b.col = base.col.slice(); b.idx = base.idx.slice();
+    return b;
+  };
+  const trimW = clone(trim), matteW = clone(matte);
+  const sink = new Builder(false);
+  for (const [ax, ay, az] of wheels) addWheel(trimW, matteW, ax, ay, az, wr, tw);
+  const wt = new Builder(false), wm = new Builder(false);
+  addWheel(wt, wm, 0, 0, 0, wr, tw);
 
   return {
-    bodyGeo: body.build(),
-    detGeo: det.build(),
-    detWheelsGeo: detWheels.build(),
-    wheelGeo: wb.build(),
+    paintGeo: paint.build(),
+    trimGeo: trim.build(),
+    matteGeo: matte.build(),
+    trimGeoW: trimW.build(),
+    matteGeoW: matteW.build(),
+    wheelTrim: wt.build(),
+    wheelMatte: wm.build(),
     wheels,
     spec,
     wheelR: wr,
   };
-}
-
-function addWheel(b, cx, cy, cz, r, w) {
-  const sides = 9;
-  for (let i = 0; i < sides; i++) {
-    const a0 = (i / sides) * Math.PI * 2, a1 = ((i + 1) / sides) * Math.PI * 2;
-    const y0 = Math.cos(a0) * r, z0 = Math.sin(a0) * r;
-    const y1 = Math.cos(a1) * r, z1 = Math.sin(a1) * r;
-    const ny = Math.cos((a0 + a1) / 2), nz = Math.sin((a0 + a1) / 2);
-    b.quad([cx - w / 2, cy + y0, cz + z0], [cx + w / 2, cy + y0, cz + z0],
-      [cx + w / 2, cy + y1, cz + z1], [cx - w / 2, cy + y1, cz + z1],
-      [0, ny, nz], [0, 0, 1, 0, 1, 1, 0, 1], BLACK);
-    b.tri([cx + w / 2 + 0.001, cy + y0 * 0.62, cz + z0 * 0.62], [cx + w / 2 + 0.001, cy + y1 * 0.62, cz + z1 * 0.62], [cx + w / 2 + 0.001, cy, cz], [1, 0, 0], CHROME);
-    b.tri([cx - w / 2 - 0.001, cy + y1 * 0.62, cz + z1 * 0.62], [cx - w / 2 - 0.001, cy + y0 * 0.62, cz + z0 * 0.62], [cx - w / 2 - 0.001, cy, cz], [-1, 0, 0], CHROME);
-  }
 }
 
 let CACHE = null;
@@ -171,10 +312,20 @@ export function vehicleAssets() {
   for (const k of Object.keys(TYPES)) types[k] = buildType(TYPES[k]);
   CACHE = {
     types,
-    detMat: new THREE.MeshLambertMaterial({ vertexColors: true }),
-    wheelMat: new THREE.MeshLambertMaterial({ vertexColors: true }),
+    trimMat: new THREE.MeshStandardMaterial({
+      vertexColors: true, metalness: 0.88, roughness: 0.16, envMapIntensity: 1.7,
+    }),
+    matteMat: new THREE.MeshStandardMaterial({
+      vertexColors: true, metalness: 0.05, roughness: 0.86, envMapIntensity: 0.55,
+    }),
   };
   return CACHE;
+}
+
+export function paintMaterial(color) {
+  return new THREE.MeshStandardMaterial({
+    color, metalness: 0.5, roughness: 0.26, envMapIntensity: 1.5,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -188,29 +339,18 @@ export class Vehicle {
     this.t = t;
     this.spec = t.spec;
     this.color = color;
-    this.detailedWheels = !!opts.detailedWheels;
+    this.detailedWheels = false;
 
     this.group = new THREE.Group();
-    this.bodyMat = new THREE.MeshLambertMaterial({ color });
-    const bodyMesh = new THREE.Mesh(t.bodyGeo, this.bodyMat);
-    const detMesh = new THREE.Mesh(this.detailedWheels ? t.detGeo : t.detWheelsGeo, A.detMat);
-    bodyMesh.castShadow = detMesh.castShadow = true;
-    this.detMesh = detMesh;
+    this.bodyMat = paintMaterial(color);
+    const paintMesh = new THREE.Mesh(t.paintGeo, this.bodyMat);
+    this.trimMesh = new THREE.Mesh(t.trimGeoW, A.trimMat);
+    this.matteMesh = new THREE.Mesh(t.matteGeoW, A.matteMat);
+    paintMesh.castShadow = this.trimMesh.castShadow = this.matteMesh.castShadow = true;
     this.tilt = new THREE.Group();
-    this.tilt.add(bodyMesh, detMesh);
+    this.tilt.add(paintMesh, this.trimMesh, this.matteMesh);
     this.group.add(this.tilt);
-
     this.wheelMeshes = [];
-    if (this.detailedWheels) {
-      for (const [wx, wy, wz] of t.wheels) {
-        const m = new THREE.Mesh(t.wheelGeo, A.wheelMat);
-        m.position.set(wx, wy, wz);
-        m.castShadow = true;
-        m.userData.front = wz > 0;
-        this.tilt.add(m);
-        this.wheelMeshes.push(m);
-      }
-    }
 
     this.x = 0; this.y = 0; this.z = 0;
     this.heading = 0;
@@ -223,6 +363,7 @@ export class Vehicle {
     this.vy = 0;
     this.wheelSpin = 0;
     this.skid = 0;
+    this.lift = 0;
     this.radius = Math.max(t.spec.len, t.spec.wid) * 0.42;
     this.halfLen = t.spec.len / 2;
     this.halfWid = t.spec.wid / 2;
@@ -234,15 +375,19 @@ export class Vehicle {
     if (this.detailedWheels === on) return;
     this.detailedWheels = on;
     const A = vehicleAssets();
-    this.detMesh.geometry = on ? this.t.detGeo : this.t.detWheelsGeo;
+    this.trimMesh.geometry = on ? this.t.trimGeo : this.t.trimGeoW;
+    this.matteMesh.geometry = on ? this.t.matteGeo : this.t.matteGeoW;
     if (on) {
       for (const [wx, wy, wz] of this.t.wheels) {
-        const m = new THREE.Mesh(this.t.wheelGeo, A.wheelMat);
-        m.position.set(wx, wy, wz);
-        m.castShadow = true;
-        m.userData.front = wz > 0;
-        this.tilt.add(m);
-        this.wheelMeshes.push(m);
+        const g = new THREE.Group();
+        const a = new THREE.Mesh(this.t.wheelTrim, A.trimMat);
+        const b = new THREE.Mesh(this.t.wheelMatte, A.matteMat);
+        a.castShadow = b.castShadow = true;
+        g.add(a, b);
+        g.position.set(wx, wy, wz);
+        g.userData.front = wz > 0;
+        this.tilt.add(g);
+        this.wheelMeshes.push(g);
       }
     } else {
       for (const m of this.wheelMeshes) this.tilt.remove(m);
@@ -253,7 +398,8 @@ export class Vehicle {
   place(x, z, heading) {
     this.x = x; this.z = z;
     this.heading = heading;
-    this.y = this.city.groundAt(x, z, null);
+    this.lift = this.city.roadLift(x, z);
+    this.y = this.city.groundAt(x, z, null, this.lift);
     this.sync();
   }
 
@@ -272,6 +418,9 @@ export class Vehicle {
     const hand = input.handbrake || 0;
     const steerIn = clamp(input.steer || 0, -1, 1);
 
+    // One paved-surface query per body per frame, reused by all seven ground
+    // samples below -- the scan is too expensive to repeat per wheel.
+    this.lift = this.city.roadLift(this.x, this.z);
     const sp = Math.abs(this.vLong);
     // Steering authority falls off with speed so the car stays controllable.
     const maxSteer = lerp(0.62, 0.16, clamp(sp / 34, 0, 1));
@@ -288,8 +437,8 @@ export class Vehicle {
       else acc -= spec.acc * 0.55 * brake * (1 - clamp(-this.vLong / (top * 0.42), 0, 1));
     }
     // slope
-    const gy = this.city.groundAt(this.x, this.z, this.y + 0.6);
-    const ahead = this.city.groundAt(this.x + this.forward.x * 3, this.z + this.forward.z * 3, this.y + 2.5);
+    const gy = this.city.groundAt(this.x, this.z, this.y + 0.6, this.lift);
+    const ahead = this.city.groundAt(this.x + this.forward.x * 3, this.z + this.forward.z * 3, this.y + 2.5, this.lift);
     acc -= clamp((ahead - gy) / 3, -0.7, 0.7) * 9.0;
 
     acc -= this.vLong * Math.abs(this.vLong) * 0.0016; // aero
@@ -324,7 +473,7 @@ export class Vehicle {
     this.z = G.clampToMap(this.z);
 
     // vertical: follow ground, with a little air time over crests
-    const target = this.city.groundAt(this.x, this.z, this.y + 1.2);
+    const target = this.city.groundAt(this.x, this.z, this.y + 1.2, this.lift);
     if (this.y > target + 0.25) {
       this.vy -= 22 * dt;
       this.y += this.vy * dt;
@@ -338,10 +487,10 @@ export class Vehicle {
     }
 
     // body attitude
-    const fh = this.city.groundAt(this.x + f.x * this.halfLen, this.z + f.z * this.halfLen, this.y + 1.5);
-    const bh = this.city.groundAt(this.x - f.x * this.halfLen, this.z - f.z * this.halfLen, this.y + 1.5);
-    const lh = this.city.groundAt(this.x + rx * this.halfWid, this.z + rz * this.halfWid, this.y + 1.5);
-    const rh = this.city.groundAt(this.x - rx * this.halfWid, this.z - rz * this.halfWid, this.y + 1.5);
+    const fh = this.city.groundAt(this.x + f.x * this.halfLen, this.z + f.z * this.halfLen, this.y + 1.5, this.lift);
+    const bh = this.city.groundAt(this.x - f.x * this.halfLen, this.z - f.z * this.halfLen, this.y + 1.5, this.lift);
+    const lh = this.city.groundAt(this.x + rx * this.halfWid, this.z + rz * this.halfWid, this.y + 1.5, this.lift);
+    const rh = this.city.groundAt(this.x - rx * this.halfWid, this.z - rz * this.halfWid, this.y + 1.5, this.lift);
     const tgtPitch = Math.atan2(bh - fh, this.halfLen * 2) - clamp(acc, -12, 12) * 0.0045;
     const tgtRoll = Math.atan2(rh - lh, this.halfWid * 2) + clamp(this.vLat, -9, 9) * 0.016;
     this.pitch = lerp(this.pitch, tgtPitch, 1 - Math.exp(-10 * dt));

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -1,15 +1,15 @@
-// Scene construction: sky, terrain, water, streamed city chunks, distant
-// skyline and the hand-built landmarks.
+// Scene construction: sky + image-based lighting, terrain, water, streamed city
+// chunks, distant skyline and the hand-built landmarks.
 
 import * as THREE from './three.js';
 import * as G from './geo.js';
-import { CHUNK } from './citygen.js';
+import { CHUNK, ROAD_LIFT, NODE_LIFT, WALK_LIFT } from './citygen.js';
 import { Builder } from './build.js';
-import { hash2, clamp, lerp, distToSeg } from './util.js';
+import { hash2, clamp, lerp } from './util.js';
 
-const ROAD_Y = 0.22;
-const NODE_Y = 0.3;
-const WALK_Y = 0.44;
+const ROAD_Y = ROAD_LIFT;
+const NODE_Y = NODE_LIFT;
+const WALK_Y = WALK_LIFT;
 
 const NEAR_R = 2; // chunks of full detail around the player
 const MID_R = 4; // chunks that keep roads only
@@ -23,8 +23,12 @@ function tint(seed, base, spread) {
   ];
 }
 
-const GREY = [0.62, 0.62, 0.62];
-const DARK = [0.3, 0.31, 0.33];
+const DARK = [0.26, 0.27, 0.29];
+const TRIM = [0.55, 0.55, 0.56];
+const AWNING = [
+  [0.55, 0.12, 0.12], [0.12, 0.28, 0.5], [0.14, 0.34, 0.22],
+  [0.42, 0.34, 0.16], [0.2, 0.2, 0.24], [0.5, 0.42, 0.3],
+];
 
 // ---------------------------------------------------------------------------
 
@@ -33,18 +37,39 @@ export class World {
     this.scene = scene;
     this.city = city;
     this.tx = tx;
+    this.renderer = opts.renderer;
     this.shadows = opts.shadows !== false;
     this.chunks = new Map();
-    this.pending = [];
+
+    const surf = (s, o = {}) => {
+      const m = new THREE.MeshStandardMaterial({
+        map: s.map,
+        normalMap: s.normalMap || null,
+        roughnessMap: s.roughnessMap || null,
+        vertexColors: true,
+        roughness: o.roughness != null ? o.roughness : 1,
+        metalness: o.metalness != null ? o.metalness : 0,
+        envMapIntensity: o.env != null ? o.env : 1,
+      });
+      if (s.emissiveMap) {
+        m.emissiveMap = s.emissiveMap;
+        m.emissive = new THREE.Color(0xffffff);
+        m.emissiveIntensity = o.emissive != null ? o.emissive : 0.45;
+      }
+      if (m.normalMap) m.normalScale = new THREE.Vector2(o.ns || 1, o.ns || 1);
+      return m;
+    };
+
     this.mats = {
-      road: new THREE.MeshLambertMaterial({ map: tx.road, vertexColors: true }),
-      walk: new THREE.MeshLambertMaterial({ map: tx.sidewalk, vertexColors: true }),
-      glass: new THREE.MeshLambertMaterial({ map: tx.glass, vertexColors: true }),
-      masonry: new THREE.MeshLambertMaterial({ map: tx.masonry, vertexColors: true }),
-      industrial: new THREE.MeshLambertMaterial({ map: tx.industrial, vertexColors: true }),
-      house: new THREE.MeshLambertMaterial({ map: tx.house, vertexColors: true }),
-      flat: new THREE.MeshLambertMaterial({ vertexColors: true }),
-      far: new THREE.MeshLambertMaterial({ vertexColors: true }),
+      road: surf(tx.road, { env: 0.9, ns: 0.7 }),
+      walk: surf(tx.sidewalk, { env: 0.85, ns: 0.8 }),
+      glass: surf(tx.glass, { env: 1.5, metalness: 0.18, ns: 1.1, emissive: 0.12 }),
+      masonry: surf(tx.masonry, { env: 1.05, ns: 1.0, emissive: 0.1 }),
+      industrial: surf(tx.industrial, { env: 1.0, metalness: 0.25, ns: 1.0 }),
+      house: surf(tx.house, { env: 0.95, ns: 1.0, emissive: 0.1 }),
+      flat: new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.82, metalness: 0.04, envMapIntensity: 1.0 }),
+      glow: new THREE.MeshBasicMaterial({ vertexColors: true, toneMapped: false }),
+      far: new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.85, metalness: 0.05, envMapIntensity: 0.95 }),
     };
     this.group = new THREE.Group();
     scene.add(this.group);
@@ -52,13 +77,14 @@ export class World {
 
   // --- static scenery -------------------------------------------------------
 
+  /** Sky doubles as the background and as the diffuse+specular IBL source. */
   buildSky() {
-    const geo = new THREE.SphereGeometry(7200, 32, 20);
-    const mat = new THREE.MeshBasicMaterial({ map: this.tx.sky, side: THREE.BackSide, fog: false, depthWrite: false });
-    const sky = new THREE.Mesh(geo, mat);
-    sky.renderOrder = -1000;
-    this.scene.add(sky);
-    this.sky = sky;
+    this.scene.background = this.tx.sky;
+    const pmrem = new THREE.PMREMGenerator(this.renderer);
+    pmrem.compileEquirectangularShader();
+    this.envRT = pmrem.fromEquirectangular(this.tx.sky);
+    this.scene.environment = this.envRT.texture;
+    pmrem.dispose();
   }
 
   *buildTerrain() {
@@ -66,7 +92,11 @@ export class World {
     const N = G.HF_N, S = G.HF_STEP, H = G.MAP_HALF;
     const TILES = 8;
     const per = Math.ceil((N - 1) / TILES);
-    const mat = new THREE.MeshLambertMaterial({ map: this.tx.ground, vertexColors: true });
+    const mat = new THREE.MeshStandardMaterial({
+      map: this.tx.ground.map, normalMap: this.tx.ground.normalMap,
+      vertexColors: true, roughness: 0.94, metalness: 0, envMapIntensity: 1.0,
+      normalScale: new THREE.Vector2(0.3, 0.3),
+    });
     this.terrainGroup = new THREE.Group();
     this.scene.add(this.terrainGroup);
     for (let tz = 0; tz < TILES; tz++) {
@@ -88,12 +118,12 @@ export class World {
             uv[(j * w + i) * 2] = x / 13;
             uv[(j * w + i) * 2 + 1] = z / 13;
             let c;
-            const d = G.districtAt(x, z);
-            if (y < 1.2) c = [1.0, 0.9, 0.66];
-            else if (G.inPark(x, z)) c = [0.5, 0.78, 0.36];
-            else if (d) c = d.style === 'house' ? [0.55, 0.68, 0.42] : [0.56, 0.56, 0.54];
-            else c = [0.5, 0.72, 0.34];
-            const n = hash2(gi, gj) * 0.12 + 0.94;
+            const dist = G.districtAt(x, z);
+            if (y < 1.2) c = [0.94, 0.86, 0.66];
+            else if (G.inPark(x, z)) c = [0.42, 0.66, 0.3];
+            else if (dist) c = dist.style === 'house' ? [0.48, 0.6, 0.37] : [0.56, 0.56, 0.55];
+            else c = [0.42, 0.62, 0.28];
+            const n = hash2(gi, gj) * 0.14 + 0.93;
             col[k] = c[0] * n; col[k + 1] = c[1] * n; col[k + 2] = c[2] * n;
           }
         }
@@ -122,17 +152,18 @@ export class World {
   buildWater() {
     const geo = new THREE.PlaneGeometry(G.MAP_HALF * 2.6, G.MAP_HALF * 2.6, 1, 1);
     geo.rotateX(-Math.PI / 2);
-    const t = this.tx.water;
-    t.repeat.set(220, 220);
-    const mat = new THREE.MeshPhongMaterial({
-      map: t, color: 0x8fb6cc, specular: 0xcfe6f2, shininess: 90,
-      transparent: true, opacity: 0.94,
+    const n = this.tx.water.normalMap;
+    n.repeat.set(520, 520);
+    const mat = new THREE.MeshStandardMaterial({
+      color: 0x2c4d63, normalMap: n, roughness: 0.09, metalness: 0.25,
+      envMapIntensity: 1.6, normalScale: new THREE.Vector2(0.55, 0.55),
     });
     const m = new THREE.Mesh(geo, mat);
     m.position.y = 0;
     m.renderOrder = -5;
     this.scene.add(m);
     this.water = m;
+    this.waterNormal = n;
   }
 
   /** Every tall building in the city as one cheap silhouette mesh. */
@@ -142,15 +173,22 @@ export class World {
       if (bd.h < 30) continue;
       const v = 0.86 + hash2(bd.seed, 17) * 0.26;
       const col = bd.style === 'tower'
-        ? [0.6 * v, 0.63 * v, 0.67 * v]
-        : [0.66 * v, 0.62 * v, 0.55 * v];
+        ? [0.5 * v, 0.54 * v, 0.58 * v]
+        : [0.56 * v, 0.52 * v, 0.46 * v];
       const s = 0.985;
-      b.box(bd.x, bd.y - 2, bd.z, bd.w * s, bd.h + 2, bd.d * s, bd.rot, col, { top: true });
+      b.box(bd.x, bd.y - 2, bd.z, bd.w * s, bd.h + 2, bd.d * s, bd.rot, col, { top: true, ao: 0.3 });
     }
     const m = new THREE.Mesh(b.build(), this.mats.far);
     m.frustumCulled = false;
     this.scene.add(m);
     this.skyline = m;
+  }
+
+  animate(dt, t) {
+    if (this.waterNormal) {
+      this.waterNormal.offset.x = (t * 0.004) % 1;
+      this.waterNormal.offset.y = (t * 0.0026) % 1;
+    }
   }
 
   // --- chunk streaming ------------------------------------------------------
@@ -179,7 +217,6 @@ export class World {
         this.chunks.delete(key);
       }
     }
-    // Build the nearest out-of-date chunks first.
     const todo = [];
     for (const c of this.chunks.values()) if (c.lod !== c.wantLod) todo.push(c);
     todo.sort((a, b) => a.dist - b.dist);
@@ -210,6 +247,7 @@ export class World {
     const road = new Builder(true);
     const walk = new Builder(true);
     const flat = new Builder(false);
+    const glow = new Builder(false);
     const bl = {
       glass: new Builder(true), masonry: new Builder(true),
       industrial: new Builder(true), house: new Builder(true),
@@ -229,13 +267,13 @@ export class World {
         const n = city.nodes[ni];
         if (!own(n.x, n.z)) continue;
         nodesDone.add(ni);
-        this.meshNode(road, flat, ni, n, lod);
+        this.meshNode(road, flat, ni, n, lod, walk);
       }
     }
 
     if (lod === 1) {
-      for (const bi of ch.buildings) this.meshBuilding(bl, flat, city.buildings[bi]);
-      this.meshProps(flat, ch, cx, cz);
+      for (const bi of ch.buildings) this.meshBuilding(bl, flat, glow, city.buildings[bi]);
+      this.meshProps(flat, glow, ch, cx, cz);
     }
 
     const grp = new THREE.Group();
@@ -249,6 +287,7 @@ export class World {
     add(road, this.mats.road, false, true);
     add(walk, this.mats.walk, false, true);
     add(flat, this.mats.flat, true, true);
+    add(glow, this.mats.glow, false, false);
     add(bl.glass, this.mats.glass, true, true);
     add(bl.masonry, this.mats.masonry, true, true);
     add(bl.industrial, this.mats.industrial, true, true);
@@ -285,29 +324,37 @@ export class World {
       );
     }
     if (e.elev) {
-      // deck edge beams + pillars
-      const bcol = [0.66, 0.66, 0.64];
+      const bcol = [0.62, 0.62, 0.6];
+      const along = Math.atan2(e.dx, e.dz);
       for (let s = 0; s <= steps; s++) {
         const t = s / steps;
         const x = lerp(a.x, b.x, t), z = lerp(a.z, b.z, t), y = lerp(a.y, b.y, t);
         for (const sg of [-1, 1]) {
-          flat.box(x + px * hw * sg, y - 0.1, z + pz * hw * sg, 0.6, 1.0, e.len / steps + 0.5,
-            Math.atan2(e.dx, e.dz), bcol);
+          flat.box(x + px * hw * sg, y - 0.1, z + pz * hw * sg, 0.55, 1.05, e.len / steps + 0.5, along, bcol);
+          flat.box(x + px * (hw - 0.25) * sg, y + 0.95, z + pz * (hw - 0.25) * sg, 0.13, 0.5,
+            e.len / steps + 0.5, along, [0.7, 0.71, 0.72]);
         }
       }
       const gy = G.terrainHeight((a.x + b.x) / 2, (a.z + b.z) / 2);
       const my = (a.y + b.y) / 2;
       if (my - gy > 5) {
-        flat.prism((a.x + b.x) / 2, gy - 1, (a.z + b.z) / 2, 1.6, my - gy - 0.6, 6, [0.6, 0.6, 0.58]);
+        flat.prism((a.x + b.x) / 2, gy - 1, (a.z + b.z) / 2, 1.7, my - gy - 1.6, 6, [0.58, 0.58, 0.56]);
+        flat.box((a.x + b.x) / 2, my - 1.6, (a.z + b.z) / 2, hw * 1.5, 1.1, 2.4, along, [0.54, 0.54, 0.52]);
       }
     } else if (lod === 1 && (e.cls === 'st' || e.cls === 'art' || e.cls === 'res')) {
       const sw = e.cls === 'art' ? 3.2 : 2.6;
+      // Stop short of each intersection: a strip run end to end would march
+      // straight across the cross street. The corner is filled by meshNode.
+      const ta = this.nodeRadius(e.a) / e.len;
+      const tb = 1 - this.nodeRadius(e.b) / e.len;
+      if (tb - ta < 0.06) return;
+      const span = tb - ta;
       for (const sg of [-1, 1]) {
         const ox = px * sg, oz = pz * sg;
-        const wsteps = Math.max(1, Math.round(e.len / 24));
+        const wsteps = Math.max(1, Math.round((e.len * span) / 24));
         let vv = 0;
         for (let s = 0; s < wsteps; s++) {
-          const t0 = s / wsteps, t1 = (s + 1) / wsteps;
+          const t0 = ta + (s / wsteps) * span, t1 = ta + ((s + 1) / wsteps) * span;
           const x0 = lerp(a.x, b.x, t0), z0 = lerp(a.z, b.z, t0);
           const x1 = lerp(a.x, b.x, t1), z1 = lerp(a.z, b.z, t1);
           const i0x = x0 + ox * hw, i0z = z0 + oz * hw;
@@ -316,35 +363,52 @@ export class World {
           const o1x = x1 + ox * (hw + sw), o1z = z1 + oz * (hw + sw);
           if (!G.isBuildable(o0x, o0z) && !G.isBuildable(o1x, o1z)) continue;
           const y = (x, z) => G.terrainHeight(x, z) + WALK_Y;
-          const seg = e.len / wsteps;
+          const seg = (e.len * span) / wsteps;
           const v0 = vv, v1 = vv + seg / sw;
           vv = v1;
           const q = sg > 0
             ? [[i0x, y(i0x, i0z), i0z], [o0x, y(o0x, o0z), o0z], [o1x, y(o1x, o1z), o1z], [i1x, y(i1x, i1z), i1z]]
             : [[o0x, y(o0x, o0z), o0z], [i0x, y(i0x, i0z), i0z], [i1x, y(i1x, i1z), i1z], [o1x, y(o1x, o1z), o1z]];
           walk.quad(q[0], q[1], q[2], q[3], [0, 1, 0], [0, v0, 1, v0, 1, v1, 0, v1], [1, 1, 1]);
-          // curb face
           const cy0 = G.terrainHeight(i0x, i0z), cy1 = G.terrainHeight(i1x, i1z);
-          const cc = [0.78, 0.78, 0.76];
+          const cc = [0.72, 0.72, 0.7];
+          const ccLo = [0.4, 0.4, 0.39];
           if (sg > 0) {
             flat.quad([i0x, cy0 + ROAD_Y, i0z], [i1x, cy1 + ROAD_Y, i1z],
-              [i1x, cy1 + WALK_Y, i1z], [i0x, cy0 + WALK_Y, i0z], [-ox, 0, -oz], [0, 0, 1, 0, 1, 1, 0, 1], cc);
+              [i1x, cy1 + WALK_Y, i1z], [i0x, cy0 + WALK_Y, i0z], [-ox, 0, -oz],
+              [0, 0, 1, 0, 1, 1, 0, 1], [ccLo, ccLo, cc, cc]);
           } else {
             flat.quad([i1x, cy1 + ROAD_Y, i1z], [i0x, cy0 + ROAD_Y, i0z],
-              [i0x, cy0 + WALK_Y, i0z], [i1x, cy1 + WALK_Y, i1z], [-ox, 0, -oz], [0, 0, 1, 0, 1, 1, 0, 1], cc);
+              [i0x, cy0 + WALK_Y, i0z], [i1x, cy1 + WALK_Y, i1z], [-ox, 0, -oz],
+              [0, 0, 1, 0, 1, 1, 0, 1], [ccLo, ccLo, cc, cc]);
           }
         }
       }
     }
   }
 
-  meshNode(road, flat, ni, n, lod) {
+  /** Half-size of the paved square drawn at an intersection. */
+  nodeRadius(ni) {
+    const n = this.city.nodes[ni];
+    let hw = 0;
+    for (const ei of n.e) {
+      const e = this.city.edges[ei];
+      if (e.hw > hw) hw = e.hw;
+    }
+    return hw;
+  }
+
+  meshNode(road, flat, ni, n, lod, walk) {
     const city = this.city;
     let hw = 0;
     let rot = 0;
+    let sw = 0;
     for (const ei of n.e) {
       const e = city.edges[ei];
       if (e.hw > hw) { hw = e.hw; rot = Math.atan2(e.dx, -e.dz); }
+      if (e.cls === 'st' || e.cls === 'art' || e.cls === 'res') {
+        sw = Math.max(sw, e.cls === 'art' ? 3.2 : 2.6);
+      }
     }
     if (hw <= 0) return;
     const c = Math.cos(rot), s = Math.sin(rot);
@@ -358,11 +422,40 @@ export class World {
       ys.push(n.elev ? n.y + 0.07 : G.terrainHeight(x, z) + NODE_Y);
     }
     road.flat(pts, ys, [1, 1, 1], [0.18, 0.62, 0.34, 0.62, 0.34, 0.76, 0.18, 0.76]);
+
+    if (lod !== 1 || sw <= 0 || n.elev || !walk) return;
+    // Square ring of pavement around the junction; its inner edge lines up with
+    // the crossing square and its outer edge meets the trimmed street strips.
+    const P = (lx, lz) => [n.x + lx * c - lz * s, n.z + lx * s + lz * c];
+    const wy = (x, z) => G.terrainHeight(x, z) + WALK_Y;
+    const ry = (x, z) => G.terrainHeight(x, z) + ROAD_Y;
+    const cc = [0.72, 0.72, 0.7], ccLo = [0.4, 0.4, 0.39];
+    const side = (ax, az, bx, bz, nx, nz) => {
+      // inner edge a->b, pushed out by sw to make the outer edge
+      const [i0x, i0z] = P(ax, az), [i1x, i1z] = P(bx, bz);
+      const [o0x, o0z] = P(ax + nx * sw, az + nz * sw);
+      const [o1x, o1z] = P(bx + nx * sw, bz + nz * sw);
+      if (!G.isBuildable(o0x, o0z) && !G.isBuildable(o1x, o1z)) return;
+      walk.quad(
+        [i0x, wy(i0x, i0z), i0z], [o0x, wy(o0x, o0z), o0z],
+        [o1x, wy(o1x, o1z), o1z], [i1x, wy(i1x, i1z), i1z],
+        [0, 1, 0], [0, 0, 1, 0, 1, 1, 0, 1], [1, 1, 1]);
+      const wn = [-(nx * c - nz * s), 0, -(nx * s + nz * c)];
+      flat.quad(
+        [i0x, ry(i0x, i0z), i0z], [i1x, ry(i1x, i1z), i1z],
+        [i1x, wy(i1x, i1z), i1z], [i0x, wy(i0x, i0z), i0z],
+        wn, [0, 0, 1, 0, 1, 1, 0, 1], [ccLo, ccLo, cc, cc]);
+    };
+    const R = hw;
+    side(-R, R, R, R, 0, 1);
+    side(R, -R, -R, -R, 0, -1);
+    side(R, R, R, -R, 1, 0);
+    side(-R, -R, -R, R, -1, 0);
   }
 
   // --- buildings ------------------------------------------------------------
 
-  meshBuilding(bl, flat, bd) {
+  meshBuilding(bl, flat, glow, bd) {
     const seed = bd.seed;
     let target, col, uS = 14, vS = 13.6;
     switch (bd.style) {
@@ -378,117 +471,158 @@ export class World {
         target = bl.masonry; col = tint(seed, [0.82, 0.55, 0.44], 0.34); uS = 12; vS = 12;
         break;
       case 'lowrise':
-        if (hash2(seed, 11) > 0.62) { target = bl.glass; col = tint(seed, [0.84, 0.9, 0.94], 0.3); }
-        else { target = bl.masonry; col = tint(seed, [0.9, 0.84, 0.74], 0.36); }
+        if (hash2(seed, 11) > 0.62) { target = bl.glass; col = tint(seed, [0.88, 0.94, 1.0], 0.3); }
+        else { target = bl.masonry; col = tint(seed, [0.92, 0.86, 0.76], 0.36); }
         break;
       case 'industrial':
-        target = bl.industrial; col = tint(seed, [0.82, 0.84, 0.84], 0.3); uS = 16; vS = 16;
+        target = bl.industrial; col = tint(seed, [0.84, 0.86, 0.86], 0.3); uS = 16; vS = 16;
         break;
       default:
-        target = bl.house; col = tint(seed, [0.92, 0.9, 0.86], 0.36); uS = 0; vS = 0;
+        target = bl.house; col = tint(seed, [0.94, 0.92, 0.88], 0.36); uS = 0; vS = 0;
     }
 
     if (bd.kind) return this.meshLandmarkTower(bl, flat, bd, col);
 
     const base = bd.y - 2;
+    const cs = Math.cos(bd.rot), sn = Math.sin(bd.rot);
+    const off = (lx, lz) => [bd.x + lx * cs - lz * sn, bd.z + lx * sn + lz * cs];
+
     if (bd.style === 'house') {
       const wallH = bd.h * 0.72;
-      target.box(bd.x, base, bd.z, bd.w, wallH + 2, bd.d, bd.rot, col, { top: false, uScale: 0, vScale: 0 });
-      const rc = tint(seed, [0.42, 0.36, 0.34], 0.16);
-      flat.cone(bd.x, base + wallH + 2, bd.z, Math.max(bd.w, bd.d) * 0.72, bd.h * 0.42, 4, rc);
-      if (hash2(seed, 21) > 0.75) flat.box(bd.x + bd.w * 0.25, base + wallH + 2, bd.z, 1.1, bd.h * 0.5, 1.1, 0, rc);
+      target.box(bd.x, base, bd.z, bd.w, wallH + 2, bd.d, bd.rot, col, { top: false, uScale: 0, vScale: 0, ao: 0.3 });
+      const rc = tint(seed, [0.36, 0.31, 0.29], 0.14);
+      flat.box(bd.x, base + wallH + 2, bd.z, bd.w + 0.7, 0.26, bd.d + 0.7, bd.rot, rc);
+      flat.cone(bd.x, base + wallH + 2.26, bd.z, Math.max(bd.w, bd.d) * 0.74, bd.h * 0.42, 4, rc);
+      if (hash2(seed, 21) > 0.7) {
+        const [px, pz] = off(bd.w * 0.26, 0);
+        flat.box(px, base + wallH + 2, pz, 1.0, bd.h * 0.5, 1.0, bd.rot, [0.4, 0.29, 0.25]);
+      }
+      const [sx, sz] = off(0, bd.d / 2 + 0.5);
+      flat.box(sx, base + 1.6, sz, 2.0, 0.22, 1.2, bd.rot, [0.62, 0.6, 0.57]);
       return;
     }
 
-    // Stack up to three masses with setbacks so towers get a silhouette.
+    const dense = bd.style !== 'industrial';
+    const plinthH = dense ? Math.min(5.2, bd.h * 0.3) : 0;
     let y = base;
     let remaining = bd.h + 2;
+
+    if (plinthH > 2) {
+      // ground-floor storefront: darker glazing under a cornice
+      const sc = [col[0] * 0.5, col[1] * 0.54, col[2] * 0.6];
+      bl.glass.box(bd.x, y, bd.z, bd.w + 0.3, plinthH, bd.d + 0.3, bd.rot, sc,
+        { uScale: 9, vScale: 9, top: false, ao: 0.5 });
+      flat.box(bd.x, y + plinthH, bd.z, bd.w + 1.0, 0.5, bd.d + 1.0, bd.rot, TRIM);
+      if (hash2(seed, 41) > 0.55) {
+        const ac = AWNING[Math.floor(hash2(seed, 42) * AWNING.length)];
+        const [ax, az] = off(0, bd.d / 2 + 0.9);
+        flat.box(ax, y + plinthH - 1.4, az, bd.w * 0.62, 0.22, 1.8, bd.rot, ac);
+      }
+      y += plinthH + 0.5;
+      remaining -= plinthH + 0.5;
+    }
+
     let w = bd.w, d = bd.d;
     const tiers = bd.h > 100 ? 3 : bd.h > 55 ? 2 : 1;
     for (let t = 0; t < tiers; t++) {
       const frac = t === tiers - 1 ? 1 : t === 0 ? 0.62 : 0.6;
       const hh = remaining * frac;
-      target.box(bd.x, y, bd.z, w, hh, d, bd.rot, col, { uScale: uS, vScale: vS, top: false, vOff: (y - base) / (vS || 1) });
-      // roof slab
-      flat.box(bd.x, y + hh, bd.z, w + 0.6, 0.7, d + 0.6, bd.rot, DARK);
+      target.box(bd.x, y, bd.z, w, hh, d, bd.rot, col,
+        { uScale: uS, vScale: vS, top: false, vOff: (y - base) / (vS || 1), ao: t === 0 ? 0.22 : 0 });
       y += hh;
       remaining -= hh;
-      w *= 0.78; d *= 0.78;
+      if (t < tiers - 1) {
+        flat.box(bd.x, y, bd.z, w + 0.8, 0.55, d + 0.8, bd.rot, TRIM);
+        y += 0.55;
+        w *= 0.78; d *= 0.78;
+      }
     }
-    // rooftop clutter
-    const rc = [0.45, 0.46, 0.47];
+
+    // cornice, roof deck, then a parapet wall standing above it
+    flat.box(bd.x, y, bd.z, w + 1.1, 0.55, d + 1.1, bd.rot, TRIM);
+    flat.box(bd.x, y + 0.55, bd.z, w + 0.5, 0.28, d + 0.5, bd.rot, [0.33, 0.34, 0.35]);
+    flat.box(bd.x, y + 0.55, bd.z, w + 0.55, 1.15, d + 0.55, bd.rot, DARK, { top: false });
+    y += 0.83;
+
+    const rc = [0.4, 0.41, 0.42];
     const n = 1 + Math.floor(hash2(seed, 31) * 3);
     for (let i = 0; i < n; i++) {
-      const ox = (hash2(seed, 40 + i) - 0.5) * w * 0.6;
-      const oz = (hash2(seed, 50 + i) - 0.5) * d * 0.6;
-      const c = Math.cos(bd.rot), s = Math.sin(bd.rot);
-      flat.box(bd.x + ox * c - oz * s, y + 0.7, bd.z + ox * s + oz * c,
-        1.6 + hash2(seed, 60 + i) * 3, 1.2 + hash2(seed, 70 + i) * 2.6, 1.6 + hash2(seed, 80 + i) * 3, bd.rot, rc);
+      const ox = (hash2(seed, 40 + i) - 0.5) * w * 0.55;
+      const oz = (hash2(seed, 50 + i) - 0.5) * d * 0.55;
+      const [rx, rz] = off(ox, oz);
+      flat.box(rx, y, rz, 1.6 + hash2(seed, 60 + i) * 3, 1.2 + hash2(seed, 70 + i) * 2.6,
+        1.6 + hash2(seed, 80 + i) * 3, bd.rot, rc);
     }
-    if (bd.h > 70 && hash2(seed, 91) > 0.5) {
-      flat.prism(bd.x, y + 0.7, bd.z, 0.35, 6 + hash2(seed, 92) * 14, 4, [0.35, 0.36, 0.38]);
+    if (bd.h > 26 && hash2(seed, 85) > 0.55) {
+      const [bx, bz] = off(w * 0.22, -d * 0.2);
+      flat.box(bx, y, bz, Math.min(6, w * 0.3), 3.2, Math.min(5, d * 0.28), bd.rot, [0.46, 0.46, 0.47]);
+    }
+    if (bd.h > 70 && hash2(seed, 91) > 0.45) {
+      const mastH = 8 + hash2(seed, 92) * 16;
+      flat.prism(bd.x, y, bd.z, 0.28, mastH, 4, [0.32, 0.33, 0.35]);
+      glow.box(bd.x, y + mastH, bd.z, 0.5, 0.5, 0.5, 0, [1.0, 0.22, 0.15]);
     }
   }
 
   meshLandmarkTower(bl, flat, bd, col) {
     const base = bd.y - 2;
     if (bd.kind === 'columbia') {
-      const dark = [0.26, 0.28, 0.32];
+      const dark = [0.24, 0.26, 0.3];
       const c = Math.cos(bd.rot), s = Math.sin(bd.rot);
       const lobes = [[0, 0, 1.0, 1.0], [-14, 10, 0.72, 0.86], [14, -10, 0.6, 0.7]];
       for (const [ox, oz, sc, hf] of lobes) {
-        bl.glass.box(bd.x + ox * c - oz * s, base, bd.z + ox * s + oz * c,
-          bd.w * sc, (bd.h + 2) * hf, bd.d * sc, bd.rot, dark, { uScale: 13, vScale: 13, top: false });
-        flat.box(bd.x + ox * c - oz * s, base + (bd.h + 2) * hf, bd.z + ox * s + oz * c,
-          bd.w * sc + 0.8, 1.2, bd.d * sc + 0.8, bd.rot, [0.2, 0.21, 0.24]);
+        const x = bd.x + ox * c - oz * s, z = bd.z + ox * s + oz * c;
+        bl.glass.box(x, base, z, bd.w * sc, (bd.h + 2) * hf, bd.d * sc, bd.rot, dark,
+          { uScale: 13, vScale: 13, top: false, ao: 0.3 });
+        flat.box(x, base + (bd.h + 2) * hf, z, bd.w * sc + 0.9, 1.3, bd.d * sc + 0.9, bd.rot, [0.18, 0.19, 0.22]);
       }
-      flat.prism(bd.x, base + bd.h + 2, bd.z, 0.4, 22, 4, [0.3, 0.3, 0.32]);
+      flat.prism(bd.x, base + bd.h + 3, bd.z, 0.4, 22, 4, [0.3, 0.3, 0.32]);
       return;
     }
     if (bd.kind === 'smith') {
       const white = [1.05, 1.02, 0.96];
-      bl.masonry.box(bd.x, base, bd.z, bd.w * 1.5, 22, bd.d * 1.5, bd.rot, white, { uScale: 12, vScale: 12, top: false });
-      flat.box(bd.x, base + 22, bd.z, bd.w * 1.5 + 1, 1, bd.d * 1.5 + 1, bd.rot, [0.8, 0.79, 0.75]);
-      bl.masonry.box(bd.x, base + 23, bd.z, bd.w, bd.h - 45, bd.d, bd.rot, white, { uScale: 11, vScale: 11, top: false });
-      flat.box(bd.x, base + bd.h - 22, bd.z, bd.w + 1.4, 1.4, bd.d + 1.4, bd.rot, [0.8, 0.79, 0.75]);
-      flat.cone(bd.x, base + bd.h - 21, bd.z, bd.w * 0.72, 20, 4, [0.55, 0.6, 0.58]);
+      bl.masonry.box(bd.x, base, bd.z, bd.w * 1.5, 22, bd.d * 1.5, bd.rot, white, { uScale: 12, vScale: 12, top: false, ao: 0.35 });
+      flat.box(bd.x, base + 22, bd.z, bd.w * 1.5 + 1.2, 1.1, bd.d * 1.5 + 1.2, bd.rot, [0.78, 0.77, 0.73]);
+      bl.masonry.box(bd.x, base + 23.1, bd.z, bd.w, bd.h - 45, bd.d, bd.rot, white, { uScale: 11, vScale: 11, top: false });
+      flat.box(bd.x, base + bd.h - 22, bd.z, bd.w + 1.6, 1.5, bd.d + 1.6, bd.rot, [0.78, 0.77, 0.73]);
+      flat.cone(bd.x, base + bd.h - 20.5, bd.z, bd.w * 0.72, 20, 4, [0.5, 0.56, 0.55]);
       flat.prism(bd.x, base + bd.h - 2, bd.z, 0.3, 12, 4, [0.4, 0.42, 0.44]);
       return;
     }
     if (bd.kind === 'wamu') {
-      const c2 = [0.72, 0.66, 0.58];
+      const c2 = [0.74, 0.68, 0.6];
       let y = base, w = bd.w, d = bd.d, h = bd.h + 2;
       for (let t = 0; t < 4; t++) {
         const hh = h * (t === 3 ? 1 : 0.34);
-        bl.masonry.box(bd.x, y, bd.z, w, hh, d, bd.rot, c2, { uScale: 12, vScale: 12, top: false });
-        flat.box(bd.x, y + hh, bd.z, w + 0.5, 0.8, d + 0.5, bd.rot, DARK);
-        y += hh; h -= hh; w *= 0.84; d *= 0.84;
+        bl.masonry.box(bd.x, y, bd.z, w, hh, d, bd.rot, c2, { uScale: 12, vScale: 12, top: false, ao: t === 0 ? 0.28 : 0 });
+        flat.box(bd.x, y + hh, bd.z, w + 0.8, 0.7, d + 0.8, bd.rot, TRIM);
+        y += hh + 0.7; h -= hh; w *= 0.84; d *= 0.84;
         if (h < 6) break;
       }
       flat.prism(bd.x, y, bd.z, 0.35, 16, 4, [0.4, 0.4, 0.42]);
       return;
     }
-    // generic hand-placed tower
     const target = bd.kind === 'stone' ? bl.masonry : bl.glass;
     let y = base, h = bd.h + 2, w = bd.w, d = bd.d;
     for (let t = 0; t < 3; t++) {
       const hh = t === 2 ? h : h * 0.5;
-      target.box(bd.x, y, bd.z, w, hh, d, bd.rot, col, { uScale: 13, vScale: 13, top: false });
-      flat.box(bd.x, y + hh, bd.z, w + 0.6, 0.9, d + 0.6, bd.rot, DARK);
-      y += hh; h -= hh; w *= 0.86; d *= 0.86;
+      target.box(bd.x, y, bd.z, w, hh, d, bd.rot, col, { uScale: 13, vScale: 13, top: false, ao: t === 0 ? 0.28 : 0 });
+      flat.box(bd.x, y + hh, bd.z, w + 0.8, 0.6, d + 0.8, bd.rot, TRIM);
+      y += hh + 0.6; h -= hh; w *= 0.86; d *= 0.86;
       if (h < 8) break;
     }
+    flat.box(bd.x, y, bd.z, w + 0.5, 1.1, d + 0.5, bd.rot, DARK, { top: false });
     flat.prism(bd.x, y, bd.z, 0.3, 10, 4, [0.4, 0.4, 0.42]);
   }
 
   // --- street furniture -----------------------------------------------------
 
-  meshProps(flat, ch, cx, cz) {
+  meshProps(flat, glow, ch, cx, cz) {
     const city = this.city;
     const own = (x, z) => Math.floor(x / CHUNK) === cx && Math.floor(z / CHUNK) === cz;
-    const poleCol = [0.36, 0.38, 0.4];
-    const lampCol = [0.9, 0.88, 0.72];
-    const trunk = [0.36, 0.28, 0.2];
+    const poleCol = [0.28, 0.3, 0.32];
+    const lampCol = [1.0, 0.94, 0.76];
+    const trunk = [0.32, 0.25, 0.18];
 
     for (const ei of ch.edges) {
       const e = city.edges[ei];
@@ -499,6 +633,7 @@ export class World {
       const px = -e.dz, pz = e.dx;
       const spacing = e.cls === 'res' ? 34 : 30;
       const count = Math.floor(e.len / spacing);
+      const along = Math.atan2(e.dx, e.dz);
       for (let i = 1; i <= count; i++) {
         const t = i / (count + 1);
         const x = lerp(a.x, b.x, t), z = lerp(a.z, b.z, t);
@@ -508,28 +643,44 @@ export class World {
         const oz = z + pz * sg * (e.hw + 1.4);
         if (!G.isBuildable(ox, oz)) continue;
         const gy = G.terrainHeight(ox, oz) + WALK_Y;
-        if (h < 0.5) {
-          // street light
-          flat.prism(ox, gy, oz, 0.13, 7.4, 5, poleCol);
-          const ax = -px * sg * 1.6, az = -pz * sg * 1.6;
-          flat.box(ox + ax / 2, gy + 7.2, oz + az / 2, 1.9, 0.24, 0.24, Math.atan2(-px * sg, -pz * sg), poleCol);
-          flat.box(ox + ax, gy + 6.95, oz + az, 0.8, 0.32, 0.5, Math.atan2(-px * sg, -pz * sg), lampCol);
-        } else if (h < 0.86) {
-          // street tree
-          const th = 4 + h * 5;
-          flat.prism(ox, gy, oz, 0.22 + h * 0.1, th * 0.55, 5, trunk);
-          const g = [0.24 + h * 0.2, 0.44 + h * 0.22, 0.2 + h * 0.14];
-          flat.cone(ox, gy + th * 0.45, oz, 1.5 + h * 1.4, th * 0.5, 6, g);
-          flat.cone(ox, gy + th * 0.75, oz, 1.1 + h * 1.1, th * 0.45, 6, g);
-        } else if (h < 0.9) {
-          flat.prism(ox, gy, oz, 0.22, 0.85, 6, [0.8, 0.2, 0.16]); // hydrant
-          flat.box(ox, gy + 0.85, oz, 0.5, 0.2, 0.5, 0, [0.8, 0.2, 0.16]);
-        } else if (h < 0.94 && e.cls === 'art') {
-          // bus shelter
-          const rot = Math.atan2(e.dx, e.dz);
-          flat.box(ox, gy, oz, 3.4, 0.12, 1.5, rot, [0.5, 0.52, 0.55]);
-          flat.box(ox - px * sg * 0.6, gy, oz - pz * sg * 0.6, 3.4, 2.5, 0.12, rot, [0.72, 0.82, 0.88]);
-          flat.box(ox, gy + 2.5, oz, 3.6, 0.14, 1.7, rot, [0.4, 0.42, 0.45]);
+        const armRot = Math.atan2(-px * sg, -pz * sg);
+        if (h < 0.42) {
+          // street light: base, tapered mast, cranked arm, lit lens
+          flat.box(ox, gy, oz, 0.42, 0.22, 0.42, armRot, [0.24, 0.25, 0.27]);
+          flat.prism(ox, gy + 0.2, oz, 0.115, 6.4, 8, poleCol);
+          flat.prism(ox - px * sg * 0.28, gy + 6.6, oz - pz * sg * 0.28, 0.1, 0.9, 6, poleCol);
+          flat.box(ox - px * sg * 1.0, gy + 7.4, oz - pz * sg * 1.0, 1.9, 0.16, 0.16, armRot, poleCol);
+          flat.box(ox - px * sg * 1.85, gy + 7.15, oz - pz * sg * 1.85, 0.85, 0.26, 0.42, armRot, [0.3, 0.31, 0.33]);
+          glow.box(ox - px * sg * 1.85, gy + 7.06, oz - pz * sg * 1.85, 0.7, 0.1, 0.34, armRot, lampCol);
+        } else if (h < 0.84) {
+          // street tree in a grate, three canopy layers
+          const th = 4.5 + h * 5;
+          flat.box(ox, gy - 0.02, oz, 1.5, 0.06, 1.5, armRot, [0.3, 0.3, 0.31]);
+          flat.prism(ox, gy, oz, 0.26 + h * 0.1, th * 0.5, 6, trunk);
+          flat.prism(ox, gy + th * 0.42, oz, 0.16, th * 0.28, 5, trunk);
+          const g = [0.2 + h * 0.16, 0.4 + h * 0.2, 0.16 + h * 0.12];
+          const gd = [g[0] * 0.72, g[1] * 0.72, g[2] * 0.72];
+          flat.cone(ox, gy + th * 0.4, oz, 1.7 + h * 1.4, th * 0.42, 7, gd);
+          flat.cone(ox, gy + th * 0.62, oz, 1.5 + h * 1.2, th * 0.42, 7, g);
+          flat.cone(ox, gy + th * 0.84, oz, 1.0 + h * 0.9, th * 0.38, 6, g);
+        } else if (h < 0.88) {
+          flat.prism(ox, gy, oz, 0.2, 0.55, 8, [0.72, 0.16, 0.12]);
+          flat.prism(ox, gy + 0.55, oz, 0.15, 0.24, 8, [0.72, 0.16, 0.12]);
+          flat.box(ox, gy + 0.3, oz, 0.62, 0.14, 0.2, armRot, [0.72, 0.16, 0.12]);
+        } else if (h < 0.92) {
+          flat.prism(ox, gy, oz, 0.34, 0.95, 8, [0.24, 0.28, 0.26]);
+          flat.prism(ox, gy + 0.95, oz, 0.37, 0.1, 8, [0.16, 0.18, 0.17]);
+        } else if (h < 0.955 && e.cls !== 'res') {
+          flat.box(ox, gy, oz, 1.9, 0.1, 0.55, along, [0.34, 0.24, 0.16]);
+          flat.box(ox, gy + 0.1, oz, 1.9, 0.32, 0.5, along, [0.38, 0.27, 0.18]);
+          for (const s2 of [-0.8, 0.8]) {
+            flat.box(ox + Math.sin(along) * s2, gy, oz + Math.cos(along) * s2, 0.1, 0.42, 0.5, along, [0.25, 0.26, 0.27]);
+          }
+        } else if (e.cls === 'art') {
+          flat.box(ox, gy, oz, 3.4, 0.1, 1.5, along, [0.4, 0.42, 0.45]);
+          flat.box(ox - px * sg * 0.62, gy, oz - pz * sg * 0.62, 3.4, 2.5, 0.08, along, [0.62, 0.74, 0.8]);
+          flat.box(ox, gy + 2.5, oz, 3.7, 0.16, 1.8, along, [0.3, 0.32, 0.35]);
+          glow.box(ox + px * sg * 0.5, gy + 1.7, oz + pz * sg * 0.5, 0.9, 1.2, 0.06, along, [0.8, 0.86, 0.95]);
         }
       }
       // traffic signals at busy corners
@@ -541,14 +692,18 @@ export class World {
           const oz = n.z + pz * (e.hw + 1.6) - e.dz * (e.hw + 1.4);
           if (!G.isBuildable(ox, oz)) continue;
           const gy = G.terrainHeight(ox, oz) + WALK_Y;
-          flat.prism(ox, gy, oz, 0.14, 6, 5, poleCol);
-          const rot = Math.atan2(e.dx, e.dz);
-          flat.box(ox + e.dx * 2.2, gy + 5.7, oz + e.dz * 2.2, 0.35, 0.35, 4.6, rot, poleCol);
-          const hx = ox + e.dx * 4.2, hz = oz + e.dz * 4.2;
-          flat.box(hx, gy + 4.4, hz, 0.5, 1.35, 0.4, rot, [0.2, 0.22, 0.24]);
-          flat.box(hx, gy + 5.35, hz, 0.56, 0.3, 0.44, rot, [0.9, 0.16, 0.12]);
-          flat.box(hx, gy + 4.95, hz, 0.56, 0.3, 0.44, rot, [0.85, 0.7, 0.14]);
-          flat.box(hx, gy + 4.55, hz, 0.56, 0.3, 0.44, rot, [0.16, 0.8, 0.3]);
+          flat.box(ox, gy, oz, 0.5, 0.25, 0.5, along, [0.24, 0.25, 0.27]);
+          flat.prism(ox, gy + 0.22, oz, 0.13, 5.9, 8, poleCol);
+          flat.box(ox + e.dx * 2.2, gy + 5.75, oz + e.dz * 2.2, 0.28, 0.28, 4.6, along, poleCol);
+          const hx = ox + e.dx * 4.3, hz = oz + e.dz * 4.3;
+          flat.box(hx, gy + 4.3, hz, 0.52, 1.5, 0.42, along, [0.16, 0.18, 0.2]);
+          const lens = (yy, c) => {
+            flat.box(hx + e.dx * 0.16, gy + yy + 0.16, hz + e.dz * 0.16, 0.5, 0.06, 0.44, along, [0.1, 0.11, 0.12]);
+            glow.box(hx + e.dx * 0.24, gy + yy, hz + e.dz * 0.24, 0.3, 0.3, 0.1, along, c);
+          };
+          lens(5.4, [1.0, 0.14, 0.1]);
+          lens(5.0, [0.85, 0.68, 0.12]);
+          lens(4.6, [0.16, 0.9, 0.32]);
         }
       }
     }
@@ -559,15 +714,17 @@ export class World {
       const hx = hash2(cx * 71 + i, cz * 131 + 7);
       const hz = hash2(cx * 37 + i, cz * 53 + 13);
       const x = x0 + hx * CHUNK, z = z0 + hz * CHUNK;
-      const p = G.inPark(x, z);
-      if (!p) continue;
+      if (!G.inPark(x, z)) continue;
       const h = hash2(Math.round(x), Math.round(z));
       const gy = G.terrainHeight(x, z);
-      const th = 6 + h * 7;
-      flat.prism(x, gy, z, 0.3 + h * 0.2, th * 0.5, 5, trunk);
-      const g = [0.2 + h * 0.18, 0.42 + h * 0.24, 0.18 + h * 0.14];
-      flat.cone(x, gy + th * 0.4, z, 2.2 + h * 2, th * 0.55, 7, g);
-      flat.cone(x, gy + th * 0.75, z, 1.7 + h * 1.6, th * 0.5, 7, g);
+      const th = 7 + h * 7;
+      flat.prism(x, gy, z, 0.34 + h * 0.2, th * 0.46, 6, trunk);
+      flat.prism(x, gy + th * 0.4, z, 0.2, th * 0.3, 5, trunk);
+      const g = [0.17 + h * 0.15, 0.38 + h * 0.22, 0.14 + h * 0.12];
+      const gd = [g[0] * 0.7, g[1] * 0.7, g[2] * 0.7];
+      flat.cone(x, gy + th * 0.34, z, 2.4 + h * 2, th * 0.42, 7, gd);
+      flat.cone(x, gy + th * 0.58, z, 2.1 + h * 1.7, th * 0.44, 7, g);
+      flat.cone(x, gy + th * 0.82, z, 1.4 + h * 1.2, th * 0.4, 6, g);
     }
   }
 }

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -16,7 +16,7 @@
 // fetches by URL with cache:'no-cache' — WebKit rejects fetch() of a
 // navigation-mode Request, which would silently kill the refresh of './' on
 // iOS, and no-cache skips GitHub Pages' 10-minute heuristic.
-const CACHE = 'auto-v3';
+const CACHE = 'auto-v4';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];


### PR DESCRIPTION
Complete rendering and modelling overhaul, plus the two bugs spotted in playtest.

## Rendering

- **PBR surfaces everywhere.** Every texture is now a set — albedo + normal + roughness (+ emissive for lit windows). Normals are sobel'd from a purpose-drawn *height* pass rather than from the albedo, so window reveals read as real recesses instead of dark paint.
- **Image-based lighting.** The procedural sky is now equirectangular, serves as `scene.background`, and goes through `PMREMGenerator` into `scene.environment`. The analytic lights are just a key and a fill. ACES filmic tone mapping on top.
- **New `postfx.js`** — bloom, FXAA, colour grade, vignette. Deliberately *not* three's `EffectComposer`: no addon files to vendor, and every render target stays `UnsignedByteType`, because half-float targets render black on iOS.
- **Adaptive quality.** I can't profile your phone from here, so the game profiles itself and steps `high → medium → low`. Manual override added to the pause menu.

## Vehicles

Bodies are lofted through 26 sampled cross-sections with computed smooth normals, and the profile **arches up over each wheel** — without that cut the tyres just intersect a straight sill and the whole car reads as a toy. Three shared geometries per type: `paint` (tinted per instance), `trim` (glass, chrome, lamp lenses, rims) and `matte` (tyres, bumpers, arch liners), plus recessed lamps with dark housings, grille, plates, mirrors, shut lines and exhaust.

Vans, trucks and buses are **painted** bodies with glazing cut in — lofting those in glass turned the entire upper body into one dark slab.

## Characters

Rebuilt as `SkinnedMesh`es on an 18-bone skeleton: still one draw call each, but with elbows, knees and a spine that actually bend. The gait is procedural — hip swing with knee flex through the swing phase, counter-rotating chest, level head, breathing idle, per-person gait/swing variation.

The non-obvious term is the **hip scissor drop**: `hips.y` falls by `legLen * (1 - cos(stride))` as the legs open. Without it the planted foot sinks through the ground and the figure looks like it's floating — which is exactly how the first version looked.

## Bugs from playtest

- **Cars sank into the ground.** Roads render at `terrain + 0.22` and sidewalks at `+0.44`, but `groundAt()` returned bare terrain, so everything sat 22–44 cm *under* the surface it was standing on. `ROAD_LIFT`/`WALK_LIFT` are now shared constants and `city.roadLift()` feeds the vehicle, pedestrian and player ground queries — computed once per body per frame, not once per wheel sample.
- **Sidewalks crossed roads.** Each edge drew its strips end to end, so at every junction the pavement marched straight across the cross street. Strips now stop at `nodeRadius` and the corner is filled by a ring drawn per junction, with curbs.

## Verification

Agentic pass over CDP: a 12-location street-level sweep (downtown, Belltown, waterfront, Uptown, SoDo, Capitol Hill, Ballard, First Hill, West Seattle, Pioneer Square, Queen Anne, U-District), vehicle and character showrooms from multiple azimuths and elevations, plus driving, walking, police response and a chase stress run — no console errors. ~300 draw calls / 317k triangles during a chase at high quality.

`apps/auto/CLAUDE.md` documents the pipeline, the model construction rules and the height-surface contract. SW cache bumped to `auto-v4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzbBgfdZ4DFiYRkp5Dx7Gh