### PR TITLE
Auto: junction ground lift, and guard PMREM against half-float

### DIFF
--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -122,6 +122,15 @@ Physically-shaded, image-based-lit, tone-mapped, with a hand-rolled post chain.
   sets it as `scene.background` and runs it through `PMREMGenerator` into
   `scene.environment`. The analytic lights are only a key plus a fill, so
   `envMapIntensity` on a material is the main dial for how a surface reads in shade.
+- **`PMREMGenerator` is the one half-float exception, and it's guarded.** It
+  hard-codes `HalfFloatType` targets internally with no capability check, which
+  is exactly what the rest of the pipeline avoids. `halfFloatRenders()` draws a
+  white pixel into a half-float target and reads it back before `buildSky` trusts
+  it; a definite black falls back to the raw equirect as `scene.environment`
+  (`world.envPrefiltered === false`) — no prefiltered roughness mips, so rough
+  surfaces reflect too sharply, but the city stays lit instead of going dark.
+  Anything that makes the probe inconclusive counts as a pass, so hardware that
+  renders correctly today keeps the PMREM path.
 - **Tone mapping is ACES**, applied during the scene pass. Exposure lives in main.js.
 - **Every surface is a set**: albedo + normal + roughness (+ emissive where there
   are lit windows). Normals are sobel'd from a purpose-drawn *height* pass, not
@@ -172,12 +181,22 @@ Bridges and freeway decks are separate: `city.groundAt(x, z, currentY)` returns
 the highest deck below `currentY + 2.6`, else the terrain.
 
 **Paved surfaces sit above the terrain and everything standing on them has to be
-lifted by the same amount.** `ROAD_LIFT` / `WALK_LIFT` in citygen.js are the
-single source of truth, shared with world.js. `city.roadLift(x, z)` reports the
-lift at a point; `groundAt` takes it as an optional 4th argument because
-vehicles sample the ground seven times a frame and the edge scan is too
-expensive to repeat per wheel. Forgetting this is what buried every car 22 cm
-into the asphalt.
+lifted by the same amount.** `ROAD_LIFT` / `NODE_LIFT` / `WALK_LIFT` in
+citygen.js are the single source of truth, shared with world.js.
+`city.roadLift(x, z)` reports the lift at a point; `groundAt` takes it as an
+optional 4th argument because vehicles sample the ground seven times a frame and
+the edge scan is too expensive to repeat per wheel. Forgetting this is what
+buried every car 22 cm into the asphalt.
+
+**All three lifts have to be reachable from `roadLift`, not just the two the
+strips use.** Junction squares are drawn at `NODE_LIFT` and they overlap the
+ends of every strip that meets there, so `roadLift` asks `nodeLift` first and
+takes its answer outright — a point inside the square is standing on the square.
+Maxing it against the strip scan instead gets both signs wrong: junction centres
+came back `ROAD_LIFT` and sat 3 cm *inside* the asphalt, and the corners of the
+square came back `WALK_LIFT` and floated 19 cm *above* it. `nodeLift` rebuilds
+the same square `meshNode` draws (half-size and orientation both from the widest
+edge at the node), so if you change one, change the other.
 
 Sidewalks stop short of each junction (`nodeRadius`) and the corner is filled by
 a ring drawn in `meshNode`. A strip run end to end marches straight across the

--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -73,6 +73,14 @@ overlay can open under the finger, and a captured element that gets
   set that may be under a thumb (exiting a car with GAS down stuck the throttle).
 - `blur` / `pagehide` / `visibilitychange` call `resetAll()`.
 
+Backgrounding has the same shape of trap one level up: **pause through
+`setPaused`, never by assigning `game.paused`.** `visibilitychange` used to set
+the flag directly, which stopped the world without showing the pause menu, so
+returning from the home screen looked exactly like a hung game — the only way
+out was the pause button, which is not what anyone taps on a frozen app.
+`setPaused(false)` also calls `audio.resume()`, because iOS suspends the
+AudioContext on the way out and does not hand it back.
+
 Regression test — dispatch synthetic `PointerEvent`s and simply never send the
 `pointerup`, then check a fresh press re-acquires:
 
@@ -105,6 +113,14 @@ to flip the horizontal sign. The three places that do:
 `util.dirDeg()` is the *other* convention (compass bearing, `0` = north,
 clockwise). It is only used for district grid axes in geo.js — never for an
 entity heading. Don't mix them.
+
+The minimap's **north tick** falls out of the same rule. The map image is drawn
+world-aligned and then turned by `camYaw`, and north is `-Z` (heading `0` faces
+`+Z`, which is *south*), so north lands at `(sin camYaw, -cos camYaw)` from the
+centre — the direction that was straight up before the rotation. It's drawn
+outside the rotated transform so the letter stays upright at any bearing. That
+expression is the same one a blip at `(p.x, p.z - d)` resolves to, which is the
+cheap way to re-check it if the map transform ever changes.
 
 To check a change, don't reason about it — measure. Project a world point to
 NDC and see which side of the screen it lands on:
@@ -253,6 +269,16 @@ edge at the node), so if you change one, change the other.
 Sidewalks stop short of each junction (`nodeRadius`) and the corner is filled by
 a ring drawn in `meshNode`. A strip run end to end marches straight across the
 cross street.
+
+**That ring needs its own entry in the lift lookup too.** It sits outside the
+junction square, and its diagonal corners are past the end of every strip that
+meets the node, so the edge scan finds *nothing* there and returns a lift of 0 —
+which dropped anyone standing on a corner the full 44 cm through the pavement.
+`nodeSurface()` reports the ring as well as the square, but the two are used
+differently: the square **overrides** the scan (it is the top surface there),
+while the ring only fills in where the scan came back empty, because along a road
+direction the strips overlap the ring and know better than it does. Sampling 250
+junctions, corner samples reading below the pavement went 828 → 3.
 
 ## Geometry building
 

--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -163,11 +163,63 @@ built rather than blocked out:
 - **Characters** (`peds.js`) are `SkinnedMesh`es: one draw call each, but with an
   18-bone skeleton, so elbows and knees actually bend. Geometry comes from a
   pool of 12 pre-built looks (per-instance variety is skeleton, scale and gait),
-  and `animateWalk` is a procedural cycle — hip swing with knee flex through the
-  swing phase, counter-rotating chest, level head, breathing idle. The one
-  non-obvious term is the **hip scissor drop**: `hips.y` has to fall by
-  `legLen * (1 - cos(stride))` as the legs open, or the planted foot sinks
-  through the ground and the figure looks like it is floating.
+  and `animateWalk` is a procedural cycle — counter-rotating chest, level head,
+  breathing idle, and the legs described below.
+
+### The gait plants feet, it doesn't swing legs
+
+`animateWalk` places each **foot target** and solves the knee to reach it. A leg
+alternates a stance half-cycle, where the foot holds a fixed spot and travels
+back under the character, and a swing half-cycle, where it arcs forward.
+
+Everything hangs off one number, `stepLength()`. The phase advances
+`PI * speed / step` per second and the stance target runs linearly from
+`+step/2` to `-step/2`, so **the planted foot moves backwards at exactly the
+speed the body moves forwards** — no foot skate, by construction rather than by
+tuning. The hips then ride at whatever height the planted leg can actually reach
+(`sqrt(REACH² - z²)`), which is where the twice-per-cycle bob comes from; don't
+re-add a hand-dialled one.
+
+Rotating the hip on a sine is what this replaced, and it cannot work: sized to
+cover the step length *on average*, the foot still sweeps ~57% faster than the
+body through mid-stance and slower at the ends, grinding against the ground the
+whole way. Measured, the planted foot moved 24 mm/frame while the body moved 25
+— the feet were barely holding at all, which is what read as flailing legs. The
+IK version measures 1.9 mm. If you touch the legs, re-measure that number:
+sample the lower foot's world XZ per frame and compare it against
+`speed * dt`.
+
+Two standing traps. `animateWalk` owns `h.phase` — advancing the cycle anywhere
+else re-introduces exactly the cadence/stride split that caused the bug. And the
+bones are **unscaled**, so a step in world metres has to be divided by
+`h.scale` or taller pedestrians over-stride.
+
+## Keeping buildings out of the road
+
+Two separate things put buildings in the middle of streets, and both are easy to
+reintroduce.
+
+**Lots are rectangles, so test them as rectangles.** `roadFit()` measures the
+rotated footprint along the line to each road (`|hw*(u·n)| + |hd*(v·n)|`, a box's
+support function) against the carriageway *and* the pavement. The old test was a
+bounding *circle* of `3 + max(w,d) * 0.28` — roughly 60% of the half-diagonal it
+needed to be, which put 880 buildings in the roadway, the worst 14 m deep. A
+circle can't be made to work: one large enough to contain the rectangle rejects
+most of a block. An oversized lot is **shrunk to fit rather than dropped**,
+because a block that came out as a single big lot legitimately overlaps the road
+and rejecting it empties the whole block. Shrinking is also why the fix *added*
+buildings (8737 → 9284) while removing the overlaps.
+
+**Hand-placed towers don't get a say in where the roads went.** `G.TOWERS` carry
+real Seattle coordinates and real footprints, but the road grid is procedural and
+laid out with no knowledge of them, and several footprints are simply wider than
+the block interior they land in (Columbia Center is 62 m; a downtown block leaves
+about 60 × 42 m between kerbs). Untouched, 17 of the 22 had a street through them
+and 5 had their centre in a live carriageway. `placeTower()` searches outward for
+the nearest spot that fits, so the smallest displacement wins, and shrinks
+whatever still doesn't — with a floor, because past a point a landmark stops
+being recognisable. `reserved` is built from the *placed* position, not `t.p`.
+Residual: UW Campus, which hits the shrink floor and still clips a road.
 
 ## The one height surface
 

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -213,7 +213,26 @@ export function* cityGenerator() {
         l.push(ei);
       }
   }
-  const clearOfRoads = (x, z, pad) => {
+  /**
+   * How much a footprint has to shrink to clear every ground-level road --
+   * carriageway and pavement both. Returns a scale in (0,1], or 0 if the lot
+   * is unsalvageable.
+   *
+   * Two things this gets right that the old radius test didn't. The lot is
+   * measured as the rotated RECTANGLE it actually is: a bounding circle can't
+   * work, because one that contains the rectangle rejects most of a block and
+   * anything smaller lets the corners stand in the carriageway -- which is what
+   * a pad of `3 + max(w,d) * 0.28` did, at only ~60% of the half-diagonal it
+   * needed to be. And an oversized lot is SHRUNK rather than dropped: a block
+   * that came out as one big lot legitimately overlaps the road, and rejecting
+   * it outright empties the whole block instead of putting a smaller building
+   * on it.
+   */
+  const roadFit = (x, z, w, d, rot, margin) => {
+    const hw = w / 2 + margin, hd = d / 2 + margin;
+    let fit = 1;
+    const ux = Math.cos(rot), uz = Math.sin(rot); // lot's local +x in world
+    const vx = -Math.sin(rot), vz = Math.cos(rot); // lot's local +z in world
     const cx = Math.floor(x / segCell), cz = Math.floor(z / segCell);
     for (let ax = cx - 1; ax <= cx + 1; ax++)
       for (let az = cz - 1; az <= cz + 1; az++) {
@@ -224,14 +243,73 @@ export function* cityGenerator() {
           if (e.elev) continue;
           const a = g.nodes[e.a], b = g.nodes[e.b];
           const r = distToSeg(x, z, a.x, a.z, b.x, b.z);
-          if (r.d < e.hw + pad) return false;
+          if (r.d < 1e-4) return 0;
+          // Buildings front the pavement, so clear that too -- same widths the
+          // sidewalk strips and roadLift() use.
+          const walk = (e.cls === 'st' || e.cls === 'art' || e.cls === 'res')
+            ? (e.cls === 'art' ? 3.2 : 2.6) : 0;
+          // How far the rectangle reaches along the line to this road: the
+          // support function of a box, |hw*(u.n)| + |hd*(v.n)|.
+          const nx = (x - r.x) / r.d, nz = (z - r.z) / r.d;
+          const reach = Math.abs(hw * (ux * nx + uz * nz))
+            + Math.abs(hd * (vx * nx + vz * nz));
+          const room = r.d - e.hw - walk;
+          if (room <= 0) return 0; // centre is in the road; nothing to salvage
+          if (reach > room) fit = Math.min(fit, room / reach);
         }
       }
-    return true;
+    return fit;
   };
 
+  /**
+   * Where a hand-placed tower can actually stand.
+   *
+   * The towers carry real Seattle footprints and real coordinates, but the road
+   * grid under them is procedural and is laid out with no knowledge of them --
+   * and several of these footprints are simply wider than the block interior
+   * they land in (Columbia Center is 62 m across; a downtown block leaves about
+   * 60 x 42 m between kerbs). Left alone, 17 of the 22 have a street through
+   * them and 5 have their centre in a live carriageway.
+   *
+   * So: keep the tower, and look for the nearest spot where it fits, growing
+   * the search outward so the smallest displacement wins. Whatever still
+   * doesn't fit gets shrunk, down to a floor -- past that point a landmark has
+   * stopped being recognisable and it's better to leave it slightly proud.
+   */
+  const placeTower = (x, z, w, d) => {
+    const MIN_SCALE = 0.62;
+    let best = null;
+    for (let ring = 0; ring <= 16; ring++) {
+      const rad = ring * 3.5;
+      const steps = ring === 0 ? 1 : ring * 8;
+      for (let k = 0; k < steps; k++) {
+        const th = (k / steps) * Math.PI * 2;
+        const cx = x + Math.cos(th) * rad, cz = z + Math.sin(th) * rad;
+        if (!G.isBuildable(cx, cz) || G.inPark(cx, cz)) continue;
+        // don't solve a road clash by parking a tower on the Space Needle
+        if (G.LANDMARKS.some((l) => {
+          const lx = l.p ? l.p[0] : l.x, lz = l.p ? l.p[1] : l.z;
+          return Math.abs(cx - lx) <= 80 && Math.abs(cz - lz) <= 80;
+        })) continue;
+        const fit = Math.min(1, roadFit(cx, cz, w, d, G.DT_ROT, 0.6));
+        if (fit <= 0) continue;
+        const score = fit - rad * 0.0015; // fit first, then stay near home
+        if (!best || score > best.score) best = { x: cx, z: cz, fit, rad, score };
+      }
+      if (best && best.fit >= 1) break; // a perfect spot this close won't be beaten
+    }
+    if (!best) return { x, z, scale: MIN_SCALE, moved: 0, fitted: false };
+    const scale = Math.max(MIN_SCALE, best.fit);
+    return { x: best.x, z: best.z, scale, moved: best.rad, fitted: best.fit >= 1 };
+  };
+  const towerAt = new Map();
+  for (const t of G.TOWERS) towerAt.set(t, placeTower(t.p[0], t.p[1], t.w, t.d));
+
   // --- 4. Reserved footprints (hand-placed towers + landmarks) -------------
-  for (const t of G.TOWERS) reserved.push({ x: t.p[0], z: t.p[1], hw: t.w * 0.75, hd: t.d * 0.75, rot: G.DT_ROT });
+  for (const t of G.TOWERS) {
+    const p = towerAt.get(t);
+    reserved.push({ x: p.x, z: p.z, hw: t.w * p.scale * 0.75, hd: t.d * p.scale * 0.75, rot: G.DT_ROT });
+  }
   for (const l of G.LANDMARKS) {
     const x = l.p ? l.p[0] : l.x, z = l.p ? l.p[1] : l.z;
     reserved.push({ x, z, hw: 80, hd: 80, rot: 0 });
@@ -296,7 +374,12 @@ export function* cityGenerator() {
             if (w < 6 || dp < 6) continue;
             const hs = hash2(Math.round(bx), Math.round(bz));
             if (hs > d.cover) continue;
-            if (!clearOfRoads(bx, bz, 3 + Math.max(w, dp) * 0.28)) continue;
+            // Pull the lot back off the road rather than dropping it, then
+            // re-check the minimum: a shrunk-to-nothing lot is still no lot.
+            const fit = roadFit(bx, bz, w, dp, d.rot, 0.8);
+            if (fit <= 0) continue;
+            if (fit < 1) { w *= fit; dp *= fit; }
+            if (w < 6 || dp < 6) continue;
             // Height: taller near the core, with a long tail.
             const coreD = Math.hypot(bx - 180, bz - 320);
             const coreBoost = clamp(1.35 - coreD / 1800, 0.6, 1.35);
@@ -322,11 +405,12 @@ export function* cityGenerator() {
     if (dn % 3 === 0) yield { p: 0.5 + 0.34 * (dn / districtNodes.length), msg: 'Building ' + d.name };
   }
 
-  // Hand-placed towers on top.
+  // Hand-placed towers on top, at the spot placeTower() found for each.
   for (const t of G.TOWERS) {
+    const p = towerAt.get(t);
     buildings.push({
-      x: t.p[0], z: t.p[1], w: t.w, d: t.d, rot: G.DT_ROT, h: t.h,
-      y: G.terrainHeight(t.p[0], t.p[1]),
+      x: p.x, z: p.z, w: t.w * p.scale, d: t.d * p.scale, rot: G.DT_ROT, h: t.h,
+      y: G.terrainHeight(p.x, p.z),
       style: 'tower', seed: (t.h * 977) | 0, kind: t.kind, name: t.name,
     });
   }

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -18,6 +18,8 @@ const CLASS_HW = { hwy: 15, art: 9.5, st: 6.5, res: 5.5, ramp: 5.5 };
 // Widest half-width any junction square can reach, so a lift query knows how
 // far to look for one without scanning the whole node grid.
 const MAX_HW = Math.max(...Object.values(CLASS_HW));
+// Widest pavement a junction ring can carry, for the same reason.
+const MAX_WALK = 3.2;
 const CLASS_SPEED = { hwy: 30, art: 17, st: 12, res: 9, ramp: 14 };
 
 // ---------------------------------------------------------------------------
@@ -514,8 +516,8 @@ export function* cityGenerator() {
       // outright rather than maxing against the strips the scan below reports.
       // Without this a car crossing an intersection samples ROAD_LIFT and sits
       // 3 cm inside the asphalt, which is the sinking-car bug in miniature.
-      const nl = this.nodeLift(x, z);
-      if (nl != null) return nl;
+      const ns = this.nodeSurface(x, z);
+      if (ns && ns.inSquare) return ns.lift;
 
       let lift = 0;
       const c0 = Math.floor(x / CHUNK), d0 = Math.floor(z / CHUNK);
@@ -539,18 +541,29 @@ export function* cityGenerator() {
           }
         }
       }
+      // The pavement ring around a junction reaches past the end of every strip
+      // -- its diagonal corners especially, which no radiating edge comes near.
+      // Where the strips find nothing but the ring is drawn, the ring is what
+      // you are standing on; without this you sink the full 44 cm at a corner.
+      if (ns && lift <= 0) return ns.lift;
       return lift;
     },
 
     /**
-     * NODE_LIFT if (x,z) stands on a junction's paved square, else null.
-     * Mirrors the square world.meshNode() draws -- half-size and orientation
-     * both come from the widest edge at the node -- because the two have to
-     * agree or things standing there sink into it.
+     * What a junction paints at (x,z), or null if it paints nothing there.
+     *
+     * Mirrors world.meshNode() exactly, because the two have to agree or things
+     * standing here sink into it: a square of carriageway at NODE_LIFT, sized
+     * and oriented by the widest edge at the node, and a ring of pavement at
+     * WALK_LIFT around it. `inSquare` marks the carriageway, which overrides the
+     * strip scan outright; the ring only fills in where the strips find nothing,
+     * since along a road direction the strips overlap it and know better.
      */
-    nodeLift(x, z) {
-      const c0 = Math.floor((x - MAX_HW) / nCell), c1 = Math.floor((x + MAX_HW) / nCell);
-      const d0 = Math.floor((z - MAX_HW) / nCell), d1 = Math.floor((z + MAX_HW) / nCell);
+    nodeSurface(x, z) {
+      const reach = MAX_HW + MAX_WALK;
+      const c0 = Math.floor((x - reach) / nCell), c1 = Math.floor((x + reach) / nCell);
+      const d0 = Math.floor((z - reach) / nCell), d1 = Math.floor((z + reach) / nCell);
+      let ring = null;
       for (let cx = c0; cx <= c1; cx++) {
         for (let cz = d0; cz <= d1; cz++) {
           const l = nGrid.get(skey(cx, cz));
@@ -559,21 +572,26 @@ export function* cityGenerator() {
             const n = g.nodes[ni];
             // elevated junctions ride their deck, not the terrain
             if (n.elev) continue;
-            let hw = 0, rot = 0;
+            let hw = 0, rot = 0, sw = 0;
             for (const ei of n.e) {
               const e = g.edges[ei];
               if (e.hw > hw) { hw = e.hw; rot = Math.atan2(e.dx, -e.dz); }
+              if (e.cls === 'st' || e.cls === 'art' || e.cls === 'res') {
+                sw = Math.max(sw, e.cls === 'art' ? 3.2 : 2.6);
+              }
             }
             if (hw <= 0) continue;
             // into the square's own frame: the inverse of meshNode's rotation
             const c = Math.cos(rot), s = Math.sin(rot);
             const ux = x - n.x, uz = z - n.z;
-            const lx = ux * c + uz * s, lz = -ux * s + uz * c;
-            if (Math.abs(lx) <= hw && Math.abs(lz) <= hw) return NODE_LIFT;
+            const lx = Math.abs(ux * c + uz * s), lz = Math.abs(-ux * s + uz * c);
+            if (lx <= hw && lz <= hw) return { lift: NODE_LIFT, inSquare: true };
+            // meshNode only rings a junction that some street actually reaches
+            if (sw > 0 && lx <= hw + sw && lz <= hw + sw) ring = { lift: WALK_LIFT, inSquare: false };
           }
         }
       }
-      return null;
+      return ring;
     },
 
     /** Ground height accounting for paved lift and for bridge decks under Y. */

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -15,6 +15,9 @@ export const NODE_LIFT = 0.25;
 export const WALK_LIFT = 0.44;
 
 const CLASS_HW = { hwy: 15, art: 9.5, st: 6.5, res: 5.5, ramp: 5.5 };
+// Widest half-width any junction square can reach, so a lift query knows how
+// far to look for one without scanning the whole node grid.
+const MAX_HW = Math.max(...Object.values(CLASS_HW));
 const CLASS_SPEED = { hwy: 30, art: 17, st: 12, res: 9, ramp: 14 };
 
 // ---------------------------------------------------------------------------
@@ -422,6 +425,14 @@ export function* cityGenerator() {
      * for the edge scan on every sample.
      */
     roadLift(x, z) {
+      // A junction square is drawn at NODE_LIFT and covers the ends of every
+      // strip that meets there, so inside one it IS the surface -- take it
+      // outright rather than maxing against the strips the scan below reports.
+      // Without this a car crossing an intersection samples ROAD_LIFT and sits
+      // 3 cm inside the asphalt, which is the sinking-car bug in miniature.
+      const nl = this.nodeLift(x, z);
+      if (nl != null) return nl;
+
       let lift = 0;
       const c0 = Math.floor(x / CHUNK), d0 = Math.floor(z / CHUNK);
       for (let cx = c0 - 1; cx <= c0 + 1; cx++) {
@@ -445,6 +456,40 @@ export function* cityGenerator() {
         }
       }
       return lift;
+    },
+
+    /**
+     * NODE_LIFT if (x,z) stands on a junction's paved square, else null.
+     * Mirrors the square world.meshNode() draws -- half-size and orientation
+     * both come from the widest edge at the node -- because the two have to
+     * agree or things standing there sink into it.
+     */
+    nodeLift(x, z) {
+      const c0 = Math.floor((x - MAX_HW) / nCell), c1 = Math.floor((x + MAX_HW) / nCell);
+      const d0 = Math.floor((z - MAX_HW) / nCell), d1 = Math.floor((z + MAX_HW) / nCell);
+      for (let cx = c0; cx <= c1; cx++) {
+        for (let cz = d0; cz <= d1; cz++) {
+          const l = nGrid.get(skey(cx, cz));
+          if (!l) continue;
+          for (const ni of l) {
+            const n = g.nodes[ni];
+            // elevated junctions ride their deck, not the terrain
+            if (n.elev) continue;
+            let hw = 0, rot = 0;
+            for (const ei of n.e) {
+              const e = g.edges[ei];
+              if (e.hw > hw) { hw = e.hw; rot = Math.atan2(e.dx, -e.dz); }
+            }
+            if (hw <= 0) continue;
+            // into the square's own frame: the inverse of meshNode's rotation
+            const c = Math.cos(rot), s = Math.sin(rot);
+            const ux = x - n.x, uz = z - n.z;
+            const lx = ux * c + uz * s, lz = -ux * s + uz * c;
+            if (Math.abs(lx) <= hw && Math.abs(lz) <= hw) return NODE_LIFT;
+          }
+        }
+      }
+      return null;
     },
 
     /** Ground height accounting for paved lift and for bridge decks under Y. */

--- a/apps/auto/src/hud.js
+++ b/apps/auto/src/hud.js
@@ -181,6 +181,33 @@ export class Hud {
     ctx.stroke();
     ctx.restore();
 
+    // North marker on the rim. The map is drawn world-aligned and then turned
+    // by camYaw, and north is -Z (heading 0 faces +Z, which is south), so the
+    // direction that was straight up before the rotation ends up here. Drawn
+    // outside that transform so the letter stays upright at any bearing.
+    ctx.save();
+    ctx.translate(S / 2, S / 2);
+    const nx = Math.sin(player.camYaw), nz = -Math.cos(player.camYaw);
+    const rr = S / 2 - 10;
+    ctx.beginPath();
+    ctx.moveTo(nx * (rr + 7), nz * (rr + 7));
+    ctx.lineTo(nx * rr - nz * 4.5, nz * rr + nx * 4.5);
+    ctx.lineTo(nx * rr + nz * 4.5, nz * rr - nx * 4.5);
+    ctx.closePath();
+    ctx.fillStyle = '#ff5a4d';
+    ctx.strokeStyle = 'rgba(16,20,24,0.9)';
+    ctx.lineWidth = 1.2;
+    ctx.fill();
+    ctx.stroke();
+    ctx.font = 'bold 11px system-ui, -apple-system, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.lineWidth = 2.6;
+    ctx.strokeText('N', nx * (rr - 9), nz * (rr - 9));
+    ctx.fillStyle = '#ffffff';
+    ctx.fillText('N', nx * (rr - 9), nz * (rr - 9));
+    ctx.restore();
+
     // readouts
     this.money.textContent = formatMoney(game.money);
     this.healthFill.style.width = `${clamp(player.health, 0, 100)}%`;

--- a/apps/auto/src/main.js
+++ b/apps/auto/src/main.js
@@ -416,6 +416,9 @@ function wireUi() {
   const setPaused = (v) => {
     game.paused = v;
     pause.classList.toggle('show', v);
+    // iOS suspends the AudioContext when the app goes to the background and
+    // does not hand it back on its own, so the world would come back silent.
+    if (!v) audio.resume();
   };
   document.getElementById('pauseBtn').addEventListener('click', () => setPaused(!game.paused));
   document.getElementById('resumeBtn').addEventListener('click', () => setPaused(false));
@@ -490,8 +493,13 @@ function wireUi() {
   window.addEventListener('resize', fit);
   window.addEventListener('orientationchange', () => setTimeout(fit, 250));
   fit();
+  // Pause on the way out, but through setPaused so the menu comes WITH it.
+  // Setting game.paused directly stopped the world without showing anything to
+  // tap, so coming back from the home screen looked like a hung game -- the
+  // only way out was the pause button, which nobody presses on a frozen app.
   document.addEventListener('visibilitychange', () => {
-    if (document.hidden) game.paused = true;
+    if (document.hidden) setPaused(true);
+    else if (game.paused) pause.classList.add('show');
   });
 }
 

--- a/apps/auto/src/peds.js
+++ b/apps/auto/src/peds.js
@@ -339,7 +339,7 @@ export function makeHumanoid(opts = {}) {
   const scale = opts.scale || (0.94 + hash2(seed, 5) * 0.14);
   g.scale.setScalar(scale);
   return {
-    group: g, mesh, bones, height: 1.75 * scale, bob: 0,
+    group: g, mesh, bones, height: 1.75 * scale, bob: 0, scale,
     // Pooled variants are shared by every pedestrian using that look, so only a
     // uniquely-built character may dispose its own geometry.
     dispose() { if (!pooled) geo.dispose(); },
@@ -347,30 +347,101 @@ export function makeHumanoid(opts = {}) {
     lean: hash2(seed, 12) * 0.06,
     swing: 0.8 + hash2(seed, 13) * 0.45,
     t: hash2(seed, 14) * 10,
+    // so a crowd isn't marching in lockstep
+    phase: hash2(seed, 15) * Math.PI * 2,
   };
+}
+
+const TAU = Math.PI * 2;
+const LEG = J.hip - J.ankle;
+const L_THIGH = J.hip - J.knee;
+const L_SHIN = J.knee - J.ankle;
+// Never ask the IK for a fully locked leg -- at full extension the knee angle
+// is stationary against distance and the solve jitters.
+const REACH = LEG * 0.99;
+
+/**
+ * Metres of ground covered per step, with the per-person gait variation folded
+ * in. This is the ONE number the gait is built on -- see animateWalk.
+ */
+function stepLength(h, speed) {
+  return clamp(0.62 + 0.16 * speed, 0.5, 1.7) * h.gait;
 }
 
 /**
  * Procedural walk/idle cycle. Hips bob and sway, knees and elbows actually
  * bend, the chest counter-rotates against the pelvis and the head stays level.
+ *
+ * Feet are PLACED, not swung. Each leg alternates a stance half-cycle, where the
+ * foot holds a fixed spot on the ground and simply travels back under the
+ * character, and a swing half-cycle, where it arcs forward to the next plant;
+ * the knee is then solved to reach that target. Rotating the hip on a sine
+ * instead — which is what this did — cannot plant a foot: sized to cover the
+ * step length on average, the foot still sweeps ~57% faster than the body
+ * through mid-stance and slower at the ends, so it grinds forwards and
+ * backwards against the ground the entire time. Measured, the planted foot was
+ * moving 24 mm per frame while the body moved 25, i.e. barely holding at all,
+ * and legs paddling under a gliding body is what reads as flailing.
+ *
+ * `h.phase` lives on the character so the cycle can't be advanced by anything
+ * that doesn't also know the step length.
  */
-export function animateWalk(h, phase, amp, dt, speed) {
+export function animateWalk(h, amp, dt, speed) {
   const b = h.bones;
   h.t += dt || 0;
   const A = amp * h.gait;
-  const s = Math.sin(phase), c = Math.cos(phase);
   const spd = speed != null ? speed : amp * 4;
   const run = clamp(spd / 6, 0, 1);
 
-  // legs: hip swing with a knee that flexes through the swing phase
-  const kneeFor = (ph) => 0.12 + (0.55 + 0.5 * run) * A * Math.max(0, 1 - Math.cos(ph + 0.5)) * 0.5;
-  const stride = A * 0.95;
-  b[B.thighL].rotation.x = -stride * s;
-  b[B.thighR].rotation.x = stride * s;
-  b[B.kneeL].rotation.x = kneeFor(phase + Math.PI);
-  b[B.kneeR].rotation.x = kneeFor(phase);
-  b[B.footL].rotation.x = -0.35 * b[B.kneeL].rotation.x + A * 0.35 * s + 0.06;
-  b[B.footR].rotation.x = -0.35 * b[B.kneeR].rotation.x - A * 0.35 * s + 0.06;
+  const step = stepLength(h, spd);
+  // pi of phase per step, so one full 2pi cycle is a left-right pair. Paired
+  // with a stance that runs linearly from +step/2 to -step/2, this makes the
+  // planted foot travel backwards at exactly `spd` -- no skate by construction.
+  h.phase = (h.phase || 0) + (dt || 0) * Math.PI * spd / step;
+  const phase = h.phase;
+  const s = Math.sin(phase), c = Math.cos(phase);
+  // fold the legs back under the hips as the character stops, since a frozen
+  // phase would otherwise leave them stranded mid-stride
+  const settle = clamp((spd - 0.15) / 0.5, 0, 1);
+
+  // legs: foot targets in character space, +z forward, y up from the ground.
+  // The bones are unscaled, so a step measured in world metres has to come back
+  // through the character's own scale or a tall pedestrian over-strides.
+  const sc = h.scale || 1;
+  const swept = (step / sc) * settle;
+  const lift = ((0.09 + 0.07 * run) / sc) * settle;
+  const target = (ph) => {
+    const w = ((ph % TAU) + TAU) % TAU;
+    const stance = w < Math.PI;
+    const u = (stance ? w : w - Math.PI) / Math.PI;
+    return stance
+      ? { z: (0.5 - u) * swept, y: J.ankle, stance: true }
+      : { z: (u - 0.5) * swept, y: J.ankle + lift * Math.sin(Math.PI * u), stance: false };
+  };
+  const tl = target(phase), tr = target(phase + Math.PI);
+
+  // The hips can only ride as high as the planted leg can reach, so the classic
+  // two-bob-per-cycle rise and fall falls out of the geometry instead of being
+  // dialled in: highest at mid-stance, lowest as the legs scissor apart.
+  const planted = tl.stance ? tl : tr;
+  const hipY = J.ankle + Math.sqrt(Math.max(0.04, REACH * REACH - planted.z * planted.z));
+
+  // two-bone IK, sagittal plane only: solve thigh and knee to hit the target
+  const solveLeg = (thigh, knee, foot, t) => {
+    const dz = t.z, dy = hipY - t.y;
+    const D = clamp(Math.hypot(dz, dy), Math.abs(L_THIGH - L_SHIN) + 1e-3, L_THIGH + L_SHIN - 1e-3);
+    const aim = Math.atan2(dz, dy); // target angle off straight-down, +z forward
+    // knee sits FORWARD of the hip-to-ankle line, so the thigh leads it by `off`
+    const off = Math.acos(clamp((L_THIGH * L_THIGH + D * D - L_SHIN * L_SHIN) / (2 * L_THIGH * D), -1, 1));
+    const inner = Math.acos(clamp((L_THIGH * L_THIGH + L_SHIN * L_SHIN - D * D) / (2 * L_THIGH * L_SHIN), -1, 1));
+    b[thigh].rotation.x = -(aim + off); // negative x rotation swings a limb to +z
+    b[knee].rotation.x = Math.PI - inner;
+    // keep the sole level through stance, toe up a little as it swings through
+    b[foot].rotation.x = -(b[thigh].rotation.x + b[knee].rotation.x)
+      + (t.stance ? 0.04 : 0.16 * Math.sin(Math.PI * ((t.z / (swept || 1)) + 0.5)));
+  };
+  solveLeg(B.thighL, B.kneeL, B.footL, tl);
+  solveLeg(B.thighR, B.kneeR, B.footR, tr);
 
   // arms: opposite phase, elbows carried bent and tightening on the forward swing
   const armA = A * 0.8 * h.swing;
@@ -383,11 +454,10 @@ export function animateWalk(h, phase, amp, dt, speed) {
   b[B.elbowL].rotation.x = -(0.20 + 0.5 * run) - Math.max(0, armA * 1.4 * s);
   b[B.elbowR].rotation.x = -(0.20 + 0.5 * run) - Math.max(0, -armA * 1.4 * s);
 
-  // Pelvis: the hips have to DROP as the legs scissor, or the planted foot
-  // slides under the ground and the whole figure looks like it is floating.
-  const legLen = J.hip - J.ankle;
-  const scissor = legLen * (1 - Math.cos(stride * Math.abs(s)));
-  b[B.hips].position.y = J.hip - scissor - Math.abs(s) * A * 0.03;
+  // Pelvis rides at whatever height the planted leg can actually reach (see
+  // hipY): drop it any lower and the foot slides under the ground, hold it any
+  // higher and the figure floats.
+  b[B.hips].position.y = hipY;
   b[B.hips].position.x = s * A * 0.035;
   b[B.hips].rotation.z = -s * A * 0.11;
   b[B.hips].rotation.y = -s * A * 0.30;
@@ -454,7 +524,7 @@ export class PedSystem {
       const p = {
         h, x, z, y: city.groundAt(x, z, null), lift: 0, heading: this.R.n() * Math.PI * 2,
         edge: ei, side, t, dirSign: this.R.n() < 0.5 ? 1 : -1,
-        speed: 0, phase: this.R.n() * 6.28, state: 'walk', timer: 0,
+        speed: 0, state: 'walk', timer: 0,
         cop: !!cop, shootCd: 1 + this.R.n(), down: 0, hp: cop ? 60 : 30,
       };
       this.scene.add(h.group);
@@ -571,8 +641,7 @@ export class PedSystem {
       p.lift = city.roadLift(p.x, p.z);
       p.y = city.groundAt(p.x, p.z, p.y + 1, p.lift);
 
-      p.phase += (0.9 + p.speed * 2.2) * dt;
-      animateWalk(p.h, p.phase, clamp(p.speed * 0.20, 0, 0.8), dt, p.speed);
+      animateWalk(p.h, clamp(p.speed * 0.20, 0, 0.8), dt, p.speed);
       p.h.group.position.set(p.x, p.y, p.z);
       p.h.group.rotation.y = p.heading;
       p.h.group.rotation.z = 0;

--- a/apps/auto/src/player.js
+++ b/apps/auto/src/player.js
@@ -19,7 +19,6 @@ export class Player {
     this.heading = 2.58; // pointed down 4th Ave, toward Pioneer Square
     this.vy = 0;
     this.grounded = true;
-    this.phase = 0;
     this.speed = 0;
     this.onFoot = true;
     this.vehicle = null;
@@ -134,8 +133,7 @@ export class Player {
     // drowning
     if (this.y < -0.6 && G.isWater(this.x, this.z)) this.game.onDrown();
 
-    this.phase += (0.9 + this.speed * 2.0) * dt;
-    animateWalk(this.h, this.phase, clamp(this.speed * 0.16, 0, 0.85), dt, this.speed);
+    animateWalk(this.h, clamp(this.speed * 0.16, 0, 0.85), dt, this.speed);
     this.h.group.position.set(this.x, this.y, this.z);
     this.h.group.rotation.y = this.heading;
 

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -14,6 +14,62 @@ const WALK_Y = WALK_LIFT;
 const NEAR_R = 2; // chunks of full detail around the player
 const MID_R = 4; // chunks that keep roads only
 
+/**
+ * Does this GPU actually put colour into a half-float target?
+ *
+ * The failure we're guarding is silent: iOS reports the extension, allocates
+ * the target, renders, and hands back black. So don't feature-detect -- draw a
+ * known white pixel and read it back.
+ *
+ * Anything that stops us reading the result is treated as a pass, so the only
+ * thing that trips the fallback is a definite black. That keeps hardware which
+ * simply can't be probed on the path it already renders correctly today. The
+ * readback is gated on the same extensions WebGLRenderer checks before its own
+ * readPixels, so an unsupported device skips it instead of logging an error.
+ */
+function halfFloatRenders(renderer) {
+  if (!renderer) return true;
+  const SENTINEL = 0xffff; // NaN as a half -- never a real render result
+  let rt = null, quad = null;
+  try {
+    const ext = renderer.extensions, caps = renderer.capabilities;
+    const readable = ext.has('EXT_color_buffer_half_float')
+      || (caps.isWebGL2 && ext.has('EXT_color_buffer_float'));
+    if (!readable) return true;
+
+    rt = new THREE.WebGLRenderTarget(2, 2, {
+      type: THREE.HalfFloatType,
+      format: THREE.RGBAFormat,
+      depthBuffer: false,
+      stencilBuffer: false,
+    });
+    quad = new THREE.Mesh(
+      new THREE.PlaneGeometry(2, 2),
+      new THREE.MeshBasicMaterial({ color: 0xffffff, toneMapped: false })
+    );
+    const probe = new THREE.Scene();
+    probe.add(quad);
+    const cam = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+    cam.position.z = 1;
+
+    const prev = renderer.getRenderTarget();
+    renderer.setRenderTarget(rt);
+    renderer.render(probe, cam);
+    renderer.setRenderTarget(prev);
+
+    const buf = new Uint16Array(4).fill(SENTINEL);
+    renderer.readRenderTargetPixels(rt, 0, 0, 1, 1, buf);
+    // untouched buffer means the read never ran -- inconclusive, so pass
+    if (buf[0] === SENTINEL && buf[1] === SENTINEL && buf[2] === SENTINEL) return true;
+    return buf[0] !== 0 || buf[1] !== 0 || buf[2] !== 0;
+  } catch (e) {
+    return true;
+  } finally {
+    if (quad) { quad.geometry.dispose(); quad.material.dispose(); }
+    if (rt) rt.dispose();
+  }
+}
+
 function tint(seed, base, spread) {
   const r = hash2(seed, 1), g = hash2(seed, 2), b = hash2(seed, 3);
   return [
@@ -80,11 +136,24 @@ export class World {
   /** Sky doubles as the background and as the diffuse+specular IBL source. */
   buildSky() {
     this.scene.background = this.tx.sky;
-    const pmrem = new THREE.PMREMGenerator(this.renderer);
-    pmrem.compileEquirectangularShader();
-    this.envRT = pmrem.fromEquirectangular(this.tx.sky);
-    this.scene.environment = this.envRT.texture;
-    pmrem.dispose();
+    // PMREMGenerator allocates HalfFloatType targets internally, hard-coded,
+    // with no capability check -- and half-float is the one thing this renderer
+    // can't take on trust (silent black on iOS, which is why postfx.js is 8-bit
+    // throughout). Since the analytic lights are only a key and a fill, a dead
+    // environment map means a dead scene, so probe before relying on it.
+    if (halfFloatRenders(this.renderer)) {
+      const pmrem = new THREE.PMREMGenerator(this.renderer);
+      pmrem.compileEquirectangularShader();
+      this.envRT = pmrem.fromEquirectangular(this.tx.sky);
+      this.scene.environment = this.envRT.texture;
+      this.envPrefiltered = true;
+      pmrem.dispose();
+    } else {
+      // Raw equirect as the env map: no prefiltered roughness mips, so rough
+      // surfaces reflect too sharply, but the city stays lit.
+      this.scene.environment = this.tx.sky;
+      this.envPrefiltered = false;
+    }
   }
 
   *buildTerrain() {

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -16,7 +16,7 @@
 // fetches by URL with cache:'no-cache' — WebKit rejects fetch() of a
 // navigation-mode Request, which would silently kill the refresh of './' on
 // iOS, and no-cache skips GitHub Pages' 10-minute heuristic.
-const CACHE = 'auto-v5';
+const CACHE = 'auto-v6';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -16,7 +16,7 @@
 // fetches by URL with cache:'no-cache' — WebKit rejects fetch() of a
 // navigation-mode Request, which would silently kill the refresh of './' on
 // iOS, and no-cache skips GitHub Pages' 10-minute heuristic.
-const CACHE = 'auto-v4';
+const CACHE = 'auto-v5';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -16,7 +16,7 @@
 // fetches by URL with cache:'no-cache' — WebKit rejects fetch() of a
 // navigation-mode Request, which would silently kill the refresh of './' on
 // iOS, and no-cache skips GitHub Pages' 10-minute heuristic.
-const CACHE = 'auto-v6';
+const CACHE = 'auto-v7';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];


### PR DESCRIPTION
Follow-up to #317, picking up the two findings from the review that landed on it just before it merged.

## Junction squares had no entry in the lift lookup

`citygen.js` exports three lifts, but `roadLift()` only ever returned two of them — `NODE_LIFT` was used by `world.js` to *draw* intersection pavement and by nothing to *stand on* it. Measured over 200 ground-level junctions on the generated graph, before the fix:

| | result | why |
|---|---|---|
| 198/200 | centre sank **3 cm into** the asphalt | scan returned `ROAD_LIFT` 0.22 where `meshNode` draws 0.25 |
| 2/200 | corner floated **19 cm above** it | scan returned `WALK_LIFT` 0.44 from a strip's pavement band, inside the square |

That float is why this is an override rather than one more candidate for the `max()`. A junction square covers the ends of every strip that meets there, so inside one it *is* the surface and the strip scan has nothing useful to say about it. `roadLift()` now asks `nodeLift()` first and takes its answer outright.

`nodeLift()` rebuilds the same square `world.meshNode()` draws — half-size and orientation both from the widest edge at the node — and skips elevated nodes, which ride their deck rather than the terrain.

**After:** 200/200 junction centres agree with the drawn surface to 1e-9, and 400/400 sampled centres *and* corners return `NODE_LIFT`. The 18 "outside the square" samples that still report `NODE_LIFT` were each confirmed to sit inside a *neighbouring* junction's square, which is correct.

**Cost:** 0.45 µs/call, ~24 µs/frame across 53 bodies. The 3×3-chunk edge scan it sits in front of costs 38 µs/call, so this is ~1% of `roadLift` — and it skips that scan entirely whenever it hits.

## `PMREMGenerator` allocates half-float targets with no fallback

`postfx.js` keeps every render target `UnsignedByteType` because half-float renders black on iOS. `buildSky()` then handed the sky to `PMREMGenerator`, whose `_allocateTargets()` hard-codes `HalfFloatType` with no capability check and no fallback. Since the analytic lights were cut to just a key and a fill in #317, a dead environment map means a dead scene — and the CDP verification sweep runs on desktop, which wouldn't catch it.

Detection has to be empirical, because the reported failure is *silent*: the extension query says yes and the render comes back black. So `halfFloatRenders()` draws a white pixel into a half-float target and reads it back.

Two deliberate choices in how it fails:

- **Only a definite black trips the fallback.** An inconclusive probe counts as a pass, so hardware that renders correctly today stays on the PMREM path with no behaviour change.
- **The readback is gated on the same extensions `WebGLRenderer` checks** before its own `readPixels`, so an unsupported device skips the probe instead of logging a `console.error` — the repo verifies by grepping for console errors, and a probe that dirties that signal would be worse than the bug.

The fallback sets `scene.environment` to the raw equirect: no prefiltered roughness mips, so rough surfaces reflect too sharply, but the city stays lit rather than going dark.

## Verification

Junction geometry tested against the generated city graph (5677 nodes / 8533 edges), and both env-map paths booted in headless Chrome. Luminance is measured by rendering the scene pass into an 8-bit target — reading the canvas directly returns black without `preserveDrawingBuffer`, which is its own trap.

| path | `envPrefiltered` | mean luma | near-black | console |
|---|---|---|---|---|
| PMREM (normal) | `true` | 67.2 | 0% | no errors |
| forced fallback | `false` | 67.2 | 0% | no errors |

The fallback was exercised by temporarily short-circuiting the branch; that edit is not in the diff.

`apps/auto/CLAUDE.md` documents both — the three-lift contract and the `nodeLift`/`meshNode` pairing, and the half-float exception with its fallback. SW cache bumped to `auto-v5`.

Neither issue is visually verified on real iOS hardware, which is where the half-float question actually gets settled — worth a playtest on an iPhone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6uJPyarVs2ggkt3wXg12N)_