### PR TITLE
Auto: stop the player spawning inside a building

### DIFF
--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -226,6 +226,17 @@ because a block that came out as a single big lot legitimately overlaps the road
 and rejecting it empties the whole block. Shrinking is also why the fix *added*
 buildings (8737 → 9284) while removing the overlaps.
 
+**Nothing may stand where the player is put down.** `G.KEEP_CLEAR` (spawn and
+the hospital respawn) is enforced by a filter pass at the end of the building
+step. This used to hold by luck — `SPAWN` sits on a block edge — until lots
+started being shrunk to fit rather than dropped, which put a tower back on 4th &
+Olive and left the player permanently jammed. `player.blocked()` also lets you
+move when you are *already* inside a footprint: refusing every direction is how
+that failure presents, and it looks exactly like the walk animation playing
+while nobody moves. Clipping out beats being stuck. Note the symptom gives no
+visual clue — 1.5 m inside a footprint edge you are flush against the facade
+with pavement in front of you, which reads as standing on the street.
+
 **Hand-placed towers don't get a say in where the roads went.** `G.TOWERS` carry
 real Seattle coordinates and real footprints, but the road grid is procedural and
 laid out with no knowledge of them, and several footprints are simply wider than
@@ -335,12 +346,18 @@ camera, renderer, controls, audio, pickups, G, THREE }`. Useful moves:
 __dbg.game.paused = true;                    // freeze and fly the camera
 __dbg.player.enterVehicle(__dbg.traffic.nearestEnterable(x, z, 400));
 __dbg.controls.btn.gas = true;               // drive
-__dbg.controls.stick.y = -1;                 // walk
 __dbg.game.addHeat(400);                     // summon the police
 ```
 
 Note SwiftShader runs at ~5 fps, and `dt` is clamped to 0.06 s, so game time
 advances far slower than wall-clock — measure displacement, not elapsed seconds.
+Ten wall-clock seconds of walking is only a few metres; don't read that as stuck.
+
+**To walk, send real keys** (`page.keyboard.down('w')`). Assigning
+`__dbg.controls.stick.y` does nothing: `read()` opens with
+`if (this._stickId === null && ...) this.releaseStick()`, the anti-latch guard
+from the stuck-stick fix, so a stick set without a live pointer is zeroed on the
+very next frame. This silently reads as "the player can't move."
 
 ## Offline
 

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -417,6 +417,25 @@ export function* cityGenerator() {
     });
   }
 
+  // Nothing may stand where the player gets put down. This used to hold by
+  // luck -- SPAWN sits on a block edge -- until lots started being shrunk to
+  // fit instead of dropped, which put a tower back on 4th & Olive. Inside a
+  // footprint, blocked() refuses every direction and the player is stuck for
+  // good, walking on the spot.
+  const CLEAR = 2.2; // player's collision half-width, plus room to turn around
+  for (let bi = buildings.length - 1; bi >= 0; bi--) {
+    const bd = buildings[bi];
+    const c = Math.cos(-bd.rot), s = Math.sin(-bd.rot);
+    for (const p of G.KEEP_CLEAR) {
+      const dx = p.x - bd.x, dz = p.z - bd.z;
+      const lx = dx * c - dz * s, lz = dx * s + dz * c;
+      if (Math.abs(lx) < bd.w / 2 + CLEAR && Math.abs(lz) < bd.d / 2 + CLEAR) {
+        buildings.splice(bi, 1);
+        break;
+      }
+    }
+  }
+
   yield { p: 0.88, msg: 'Indexing the city' };
 
   // --- 6. Chunk index ------------------------------------------------------

--- a/apps/auto/src/geo.js
+++ b/apps/auto/src/geo.js
@@ -648,6 +648,13 @@ export const RAMPS = [
 ];
 
 export const SPAWN = { x: 60, z: -20 }; // 4th & Olive: clear of buildings, on the block edge
+export const RESPAWN = { x: 1050, z: 300 }; // Harborview
+/**
+ * Points the player gets put down on. citygen removes any building covering
+ * one: land inside a footprint and `player.blocked()` refuses every direction,
+ * which reads in-game as the walk animation playing while nobody moves.
+ */
+export const KEEP_CLEAR = [SPAWN, RESPAWN];
 
 export function clampToMap(v) {
   return clamp(v, -MAP_HALF + 40, MAP_HALF - 40);

--- a/apps/auto/src/main.js
+++ b/apps/auto/src/main.js
@@ -22,7 +22,7 @@ const loadMsg = document.getElementById('loadMsg');
 const loading = document.getElementById('loading');
 
 const STAR_POINTS = [0, 30, 90, 190, 340, 560];
-const HOSPITAL = { x: 1050, z: 300 };
+const HOSPITAL = G.RESPAWN; // kept clear of buildings by citygen, via G.KEEP_CLEAR
 
 class Game {
   constructor() {

--- a/apps/auto/src/player.js
+++ b/apps/auto/src/player.js
@@ -109,7 +109,12 @@ export class Player {
     this.speed = damp(this.speed, target, 9, dt);
     const nx = this.x + Math.sin(this.heading) * this.speed * dt;
     const nz = this.z + Math.cos(this.heading) * this.speed * dt;
-    if (!this.blocked(nx, nz)) {
+    // If we're already standing inside geometry -- put down in it, dumped out
+    // of a car into it, knocked into it -- then refusing to move traps the
+    // player permanently, walking on the spot with every direction blocked.
+    // Clipping out is always better than being stuck, so let them walk.
+    const stuck = this.blocked(this.x, this.z);
+    if (stuck || !this.blocked(nx, nz)) {
       this.x = G.clampToMap(nx);
       this.z = G.clampToMap(nz);
     } else if (!this.blocked(nx, this.z)) this.x = G.clampToMap(nx);

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -16,7 +16,7 @@
 // fetches by URL with cache:'no-cache' — WebKit rejects fetch() of a
 // navigation-mode Request, which would silently kill the refresh of './' on
 // iOS, and no-cache skips GitHub Pages' 10-minute heuristic.
-const CACHE = 'auto-v7';
+const CACHE = 'auto-v8';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];


### PR DESCRIPTION
Fixes the walk-in-place regression reported after #318 merged. New branch off `master`, since #318 is already in.

## What was happening

`updateFoot()` sets `this.speed` *before* it tries to move, and movement is gated on `blocked()`. So when every direction is blocked, the gait plays at full speed while `x`/`z` never change. Walking on the spot is precisely the signature of "stuck inside a footprint".

That's what had happened. `G.SPAWN` is 4th & Olive, and its comment — *"clear of buildings, on the block edge"* — was true by luck, not by construction. #318 changed oversized lots from being **dropped** to being **shrunk to fit**, which put back a 26.4 × 20.5 × 53 m tower whose footprint covers the spawn.

Confirmed against the merged build:

| check | result |
|---|---|
| `player.blocked(x, z)` at spawn | `true` |
| spawn inside footprint | `true`, 1.54 m in from the nearest edge |
| view from 78 m up | player occluded by that tower's roof |

**Why it didn't look like being inside a building.** 1.5 m inside the edge puts you flush against the facade with pavement in front of you — it reads as standing on the street. The collision box gives no visual cue whatsoever. Worth recording, because the symptom actively misdirects.

## Fixes

**1. Keep the drop-off points clear.** `G.KEEP_CLEAR` lists the points the player is put down on — `SPAWN` and the hospital respawn, which `main.js` now takes from geo instead of keeping its own copy. `citygen` drops any building covering one, with 2.2 m of margin for the player's collision half-width plus room to turn. One building removed.

**2. `blocked()` no longer traps.** This is the class of bug rather than the instance: if the player is *already* inside a footprint — spawned into it, dumped out of a car into it, knocked into it — movement is now allowed so they can walk out. Refusing every direction is unrecoverable, and clipping out of a wall is strictly better than a game that can't be played.

## Verification

Reproduced on the merged build, then confirmed fixed on this one:

| | before | after |
|---|---|---|
| `blocked()` at spawn | `true` | `false` |
| walk from spawn | 0 m | 3.5 m at 3.3 m/s |
| dropped inside a wall | 0 m | 4.6 m, walks free |

## Also: a docs trap

CLAUDE.md told you to drive the player in tests with `__dbg.controls.stick.y = -1`. That silently does nothing — `read()` opens with the anti-latch guard from the stuck-stick fix, which zeroes a stick with no live pointer behind it on the very next frame. It presents as a player who can't move, and it cost a wrong reading here before I caught it. Replaced with real key events, and noted alongside the existing SwiftShader warning that a few metres per ten wall-clock seconds is normal, not stuck.

SW cache bumped to `auto-v8`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6uJPyarVs2ggkt3wXg12N)_