### PR TITLE
Auto: show the build number on the launch screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,20 @@ The version is displayed in the Home Screen header as `v1`, `v2`, etc.
 
 Location: `<h1>Feed <span class="version">vX</span></h1>`
 
+## Auto App
+
+### Version Management
+
+**IMPORTANT:** Increment the build number in `/apps/auto/index.html` once per
+change, and move `CACHE` in `/apps/auto/sw.js` to match.
+
+The build number is displayed on the launch screen, so a player can say which
+build they are running — the first thing worth knowing when a fix looks like it
+didn't land, because a stale service worker is indistinguishable from one.
+
+Location: `<div id="build">vX</div>`, paired with `const CACHE = 'auto-vX';`.
+See `apps/auto/CLAUDE.md` for why these are deliberately two literals.
+
 ## Photos App
 
 ### Known Limitations

--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -268,6 +268,45 @@ split leaves behind.
 To check both at once, count ground-level segment intersections whose edges
 share no node. It must be zero.
 
+## Parks
+
+**The block grid does not run through a park.** Buildings already skipped them,
+so paving one produced a green rectangle with streets crossing it and nothing on
+them — a road to nowhere. `citygen` skips park ground for both node placement
+and `link()`. Hand-drawn arterials and highways in step 2 still go where they
+are drawn, which is correct: Aurora really does cut through Woodland Park.
+
+Tree scatter is *candidates per chunk*, filtered by `inPark`. At 46 a
+chunk-sized park got one tree per 60 m and read as bare ground; it is 230 now.
+If you add a large park, check it doesn't look empty.
+
+## How closely this matches real Seattle
+
+Downtown is good and the outskirts are not, and the error is not a uniform
+scale, so relative geography breaks down as you go out. Measured against real
+lat/lon converted about Westlake Center:
+
+| landmark | error | | landmark | error |
+|---|---|---|---|---|
+| Pike Place Market | 165 m | | Gas Works Park | 518 m |
+| Seattle Central Library | 205 m | | Husky Stadium | 1399 m |
+| Space Needle | 274 m | | Alki Beach | 2664 m |
+| Lumen Field | 414 m | | Green Lake Park | 3029 m |
+| Kerry Park | 594 m | | Seward Park | 4250 m |
+
+The game/real distance ratio averages 0.76 but ranges **0.55 to 1.16** — so it
+isn't a deliberate uniform compression, it's drift. `MAP_HALF` is 5200 m and
+Seward Park is genuinely 9.3 km out, so 1:1 will never fit; a *consistent* scale
+would still fix the relative layout.
+
+Known concrete errors, worth fixing before anything subtler: **Elliott Ave W and
+Alaskan Way both run through the Seattle Center campus**, which sits about a
+kilometre inland from either. Mercer St and Queen Anne Ave N cross it too, where
+they should bound it — the real campus is 74 acres enclosed by Mercer, Denny
+Way, 1st Ave N and 5th Ave N, with no through streets at all. Repairing this
+means editing the `ARTERIALS` polylines, and they are chained into bridges and
+ramps, so it wants doing as its own careful pass rather than as a side effect.
+
 ## Keeping buildings out of the road
 
 Two separate things put buildings in the middle of streets, and both are easy to

--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -205,10 +205,68 @@ IK version measures 1.9 mm. If you touch the legs, re-measure that number:
 sample the lower foot's world XZ per frame and compare it against
 `speed * dt`.
 
-Two standing traps. `animateWalk` owns `h.phase` — advancing the cycle anywhere
-else re-introduces exactly the cadence/stride split that caused the bug. And the
-bones are **unscaled**, so a step in world metres has to be divided by
-`h.scale` or taller pedestrians over-stride.
+**Ground contact is capped, and that is what makes running work.** The hips can
+only ride as high as the planted leg reaches, so a stance spanning `c` forces
+them down to `sqrt(REACH² - (c/2)²)`. Letting stance grow with the step wrecked
+the run: at 6.4 m/s the step hit 1.64 m and the hips fell **63 cm** every
+stride — the character dropped into the splits twice a second, which is what
+"walking is janky, running is jankier" was. `CONTACT_MAX` holds the bob at about
+14 cm at every speed; past a jog the step outgrows contact, the duty factor
+falls below a half and a flight phase opens. Extra speed buys cadence and air,
+not a wider split — which is what people actually do.
+
+**Pose the pelvis before solving the legs, and aim through its inverse.** It
+sways, rolls and twists, and the hip sockets ride with it: a 0.09 rad roll lifts
+one socket by most of a centimetre. Solving against a character-space target and
+then moving the pelvis underneath left the foot floating and creeping. Related:
+`REACH_PLANT` is deliberately shorter than `REACH`, because a leg solved to
+exactly its reach is pushed past the IK clamp by that same socket rise and comes
+up short, lifting the planted foot clear of the ground.
+
+Three standing traps. `animateWalk` owns `h.phase` — advancing the cycle
+anywhere else re-introduces exactly the cadence/stride split that caused the
+original bug. The bones are **unscaled**, so a step in world metres has to be
+divided by `h.scale` or taller pedestrians over-stride. And when measuring
+skate, read `h.contact` (0 left, 1 right, −1 airborne) rather than guessing
+stance from foot height: a flight phase is not a foot sliding, and counting it
+as one buries the real number. Current figures, per frame at 60 fps:
+
+| speed | planted foot moves | body moves | skate | airborne |
+|---|---|---|---|---|
+| 1.5 m/s | 1.4 mm | 25 mm | 5.7% | 0% |
+| 4.2 m/s | 10.2 mm | 70 mm | 14.6% | 18% |
+| 7.5 m/s | 21.6 mm | 125 mm | 17.3% | 40% |
+
+The residual is the pelvis's lateral shift and yaw, which a sagittal two-bone
+solve cannot absorb; closing it needs a 3-DOF hip.
+
+## One grid per patch of ground, and no crossing without a junction
+
+Two rules keep the street network coherent. Both were absent, and together they
+made the map read as scribble.
+
+**Exactly one district owns any point.** The polygons in geo.js are hand-drawn
+and 25 of the 32 overlap something — Belltown is 62% covered by Uptown and South
+Lake Union. Overlap is harmless where neighbours share a street angle and fatal
+where they don't: downtown runs 58° off true north and its neighbours run true,
+so laying both grids on the same block gives two sets of streets meeting at 58°.
+`districtOwner()` resolves it — **the smallest polygon covering a point wins**,
+which matches how the data is drawn (a specific neighbourhood sitting inside a
+sprawling one should keep its own grid). Ties fall back to declaration order so
+the result never depends on sort stability. Node placement, `link()` and the
+building block centres all consult it.
+
+**Every ground-level crossing gets a node.** `planarize()` splits each pair of
+crossing edges and puts a junction at the intersection. Without it an arterial
+drawn through a district's grid simply passed over it: **896 crossings carried
+no node**, which is why roads looked stacked rather than connected, and why
+traffic could never turn off an arterial. Elevated edges are skipped — a bridge
+over a street is a crossing that is *supposed* to have no junction. It rebuilds
+through `addEdge`, which recomputes headings and drops the sub-4 m slivers a
+split leaves behind.
+
+To check both at once, count ground-level segment intersections whose edges
+share no node. It must be zero.
 
 ## Keeping buildings out of the road
 
@@ -247,6 +305,26 @@ the nearest spot that fits, so the smallest displacement wins, and shrinks
 whatever still doesn't — with a floor, because past a point a landmark stops
 being recognisable. `reserved` is built from the *placed* position, not `t.p`.
 Residual: UW Campus, which hits the shrink floor and still clips a road.
+
+## Vehicles
+
+**A collision lasts many frames — damage it once.** The contact pair stays
+overlapping and closing for several frames and the damage call ran on every one,
+so a 20 m/s shunt cost 14 health per frame and destroyed a 100-health car in
+about an eighth of a second. Any real impact detonated on contact.
+`Vehicle.hitCd` debounces it; scripted damage (gunfire) passes `force` and
+bypasses it. `collideWithBuildings` had the identical shape of bug on the player
+side — holding the throttle into a wall killed the player in about a sixth of a
+second — and `player.crashCd` does the same job there. **Anything driven by
+sustained contact needs this**; per-frame is never the right cadence for it.
+
+**Steer outside the spin.** A wheel carries a roll on X and a steer on Y, and
+Euler order decides which is applied in whose frame. The default `XYZ` builds
+`Rx·Ry`: the wheel is steered and then rolled about the *car's* X axis rather
+than its own axle, so a turned front wheel tumbles instead of rolling — the axle
+tilts off horizontal by `asin(sin(steer)·sin(spin))`, about 30° at half lock.
+That is the wheel wobble. `rotation.order = 'YXZ'` gives `Ry·Rx`: roll on the
+axle, then steer the lot.
 
 ## The one height surface
 

--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -299,13 +299,36 @@ isn't a deliberate uniform compression, it's drift. `MAP_HALF` is 5200 m and
 Seward Park is genuinely 9.3 km out, so 1:1 will never fit; a *consistent* scale
 would still fix the relative layout.
 
-Known concrete errors, worth fixing before anything subtler: **Elliott Ave W and
-Alaskan Way both run through the Seattle Center campus**, which sits about a
-kilometre inland from either. Mercer St and Queen Anne Ave N cross it too, where
-they should bound it — the real campus is 74 acres enclosed by Mercer, Denny
-Way, 1st Ave N and 5th Ave N, with no through streets at all. Repairing this
-means editing the `ARTERIALS` polylines, and they are chained into bridges and
-ramps, so it wants doing as its own careful pass rather than as a side effect.
+**Seattle Center has been rebuilt from real coordinates** and is the worked
+example of how to fix a district. Everything there was placed by converting
+lat/lon about Westlake Center (`M_LON = 111320·cos 47.61°`):
+
+- Needle, MoPOP and the Arena sat 140–290 m west of true, which is what put
+  Climate Pledge Arena on the Elliott Bay shoreline. They are now at their
+  converted positions.
+- The campus rect is set off the four streets that bound it: 1st Ave N
+  (x −1396), 5th Ave N (−735), Denny Way (z −790), Mercer St (−1469).
+- Mercer St was drawn at z ≈ −1085, nearly 400 m south of true, so it ran past
+  the Space Needle instead of bounding the campus. Denny Way was ~200 m south.
+- **Alaskan Way's north end was `[-1150,-1000]` — the Space Needle.** A seawall
+  road terminating in the middle of the campus, and why MoPOP had a street
+  through it. Elliott Ave W cut the same corner about 400 m inland of the real
+  road.
+- The shore itself drifted east going north, ~450 m of it by Seattle Center,
+  leaving metres of land between 1st Ave N and the bay. Pulled back west.
+
+Result: no edge of any class crosses the campus, MoPOP is 134 m from the nearest
+road, and the Arena is 570 m from the water against about 700 m in reality.
+
+**When you edit the shoreline, diff the land/water map, don't just spot-check
+it.** Sample a grid before and after and count points that flipped: the failure
+that matters is land becoming water (a doubled-back polygon swallowing a
+neighbourhood, which is how Magnolia disappeared). This edit flipped 0 points to
+water and 0.34 km² to land, which is the strip that should always have been
+there.
+
+The rest of the outskirts have not been touched and still carry the drift in the
+table above.
 
 ## Keeping buildings out of the road
 

--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -367,3 +367,18 @@ cache bumps, and URL-based `cache: 'no-cache'` revalidation (WebKit refuses to
 `fetch()` a navigation-mode Request). **Bump `CACHE` in sw.js on any deploy that
 must invalidate immediately.** Never add `vendor/` or `src/` to `SHELL`: a slow
 install is what pins iOS players to a stale worker forever.
+
+## Build number
+
+**`#build` on the launch screen and `CACHE` in sw.js go up together, once per
+change** — `v9` next to `auto-v9`. The point is that a player can read the
+number off the loading screen and say which build they are on, which is the
+first thing worth knowing when a fix appears to be missing: a stale service
+worker looks exactly like a fix that didn't work.
+
+They stay two literals on purpose. Sharing one constant means either the page
+fetching the number out of sw.js, or sw.js pulling it in with `importScripts` —
+and in that second case sw.js's own bytes never change, so the browser has no
+reason to install the new worker and the cache never turns over. **The byte
+change to sw.js is the update trigger**, so that file has to carry its own
+literal. Bump both, and keep the digits equal so a mismatch is obvious on sight.

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -321,7 +321,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v10</div>
+    <div id="build">v11</div>
   </div>
 
   <div id="rotate">

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -221,6 +221,12 @@
   #loadTrack { width: min(320px, 70%); height: 5px; border-radius: 3px; background: rgba(255,255,255,0.12); overflow: hidden; }
   #loadBar { height: 100%; width: 0%; background: linear-gradient(90deg, #6fd7a0, #7ec8f0); transition: width .25s; }
   #loadMsg { font-size: 12px; opacity: .6; height: 16px; }
+  /* Which build you're actually running — the first thing to check when a fix
+     seems to be missing, since a stale service worker looks exactly like that. */
+  #build {
+    position: absolute; bottom: calc(env(safe-area-inset-bottom) + 14px);
+    font-size: 11px; letter-spacing: .18em; opacity: .4;
+  }
 
   #rotate {
     position: absolute; inset: 0; z-index: 60; display: none;
@@ -314,6 +320,8 @@
     <h1>AUTO</h1>
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
+    <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
+    <div id="build">v9</div>
   </div>
 
   <div id="rotate">

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -321,7 +321,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v11</div>
+    <div id="build">v12</div>
   </div>
 
   <div id="rotate">

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -321,7 +321,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v9</div>
+    <div id="build">v10</div>
   </div>
 
   <div id="rotate">

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -107,6 +107,139 @@ function polyRangeAlong(poly, ox, oz, ax, az) {
   return { lo, hi };
 }
 
+function polyArea(p) {
+  let a = 0;
+  for (let i = 0, j = p.length - 1; i < p.length; j = i++) a += (p[j][0] + p[i][0]) * (p[j][1] - p[i][1]);
+  return Math.abs(a / 2);
+}
+
+/**
+ * Decide which district owns a patch of ground, so only one street grid is
+ * laid on it.
+ *
+ * The district polygons are hand-drawn and 25 of the 32 overlap something --
+ * Belltown is 62% covered by Uptown and South Lake Union. That is survivable
+ * where the neighbours share a street angle, and ruinous where they don't:
+ * downtown's grid runs 58 deg off true north and its neighbours' run true, so
+ * laying both over the same block gives two sets of streets crossing at 58 deg
+ * with no junctions. That is what makes the map read as scribble.
+ *
+ * The smallest polygon covering a point wins, which is the rule that matches
+ * how the data is drawn: a small specific neighbourhood sits inside a large
+ * sprawling one and should keep its own grid. Equal areas fall back to
+ * declaration order, so the result never depends on sort stability.
+ */
+function districtOwner() {
+  const bbox = (p) => {
+    let x0 = Infinity, x1 = -Infinity, z0 = Infinity, z1 = -Infinity;
+    for (const q of p) {
+      if (q[0] < x0) x0 = q[0];
+      if (q[0] > x1) x1 = q[0];
+      if (q[1] < z0) z0 = q[1];
+      if (q[1] > z1) z1 = q[1];
+    }
+    return { x0, x1, z0, z1 };
+  };
+  const meta = G.DISTRICTS.map((d, i) => ({ d, i, area: polyArea(d.poly), bb: bbox(d.poly) }));
+  // For each district, only the higher-priority districts it could overlap at
+  // all -- usually one or two, so this stays a couple of point-in-poly tests.
+  const rivals = new Map();
+  for (const m of meta) {
+    rivals.set(m.d, meta.filter((o) => o !== m
+      && (o.area < m.area || (o.area === m.area && o.i < m.i))
+      && o.bb.x0 <= m.bb.x1 && o.bb.x1 >= m.bb.x0
+      && o.bb.z0 <= m.bb.z1 && o.bb.z1 >= m.bb.z0).map((o) => o.d));
+  }
+  return (d, x, z) => {
+    for (const o of rivals.get(d)) if (G.pointInPolyCached(x, z, o)) return false;
+    return true;
+  };
+}
+
+/**
+ * Split every pair of crossing ground-level edges and put a node at the
+ * crossing.
+ *
+ * An arterial drawn straight through a district's street grid otherwise just
+ * passes over it -- 896 crossings carried no junction node at all, which is
+ * both why the map looked like roads stacked on each other and why traffic
+ * could never turn off an arterial. Elevated edges are left alone: a bridge
+ * over a street is a crossing that is supposed to have no junction.
+ */
+function planarize(g) {
+  const CELL = 120;
+  const gk = (a, b) => a * 100003 + b;
+  const grid = new Map();
+  for (let ei = 0; ei < g.edges.length; ei++) {
+    const e = g.edges[ei];
+    if (e.elev) continue;
+    const a = g.nodes[e.a], b = g.nodes[e.b];
+    const steps = Math.max(1, Math.ceil(e.len / CELL));
+    for (let s = 0; s <= steps; s++) {
+      const x = a.x + (b.x - a.x) * s / steps, z = a.z + (b.z - a.z) * s / steps;
+      const k = gk(Math.floor(x / CELL), Math.floor(z / CELL));
+      let l = grid.get(k);
+      if (!l) grid.set(k, (l = new Set()));
+      l.add(ei);
+    }
+  }
+  const splits = new Map();
+  const addSplit = (ei, t, ni) => {
+    let l = splits.get(ei);
+    if (!l) splits.set(ei, (l = []));
+    l.push({ t, ni });
+  };
+  const seen = new Set();
+  for (const list of grid.values()) {
+    const arr = [...list];
+    for (let i = 0; i < arr.length; i++) {
+      for (let j = i + 1; j < arr.length; j++) {
+        const ei = arr[i], ej = arr[j];
+        const pk = ei < ej ? ei * 100000 + ej : ej * 100000 + ei;
+        if (seen.has(pk)) continue;
+        seen.add(pk);
+        const e1 = g.edges[ei], e2 = g.edges[ej];
+        // already meeting at a node is a junction, not a crossing
+        if (e1.a === e2.a || e1.a === e2.b || e1.b === e2.a || e1.b === e2.b) continue;
+        const p = g.nodes[e1.a], q = g.nodes[e1.b];
+        const r = g.nodes[e2.a], s = g.nodes[e2.b];
+        const d1x = q.x - p.x, d1z = q.z - p.z;
+        const d2x = s.x - r.x, d2z = s.z - r.z;
+        const den = d1x * d2z - d1z * d2x;
+        if (Math.abs(den) < 1e-9) continue; // parallel
+        const t = ((r.x - p.x) * d2z - (r.z - p.z) * d2x) / den;
+        const u = ((r.x - p.x) * d1z - (r.z - p.z) * d1x) / den;
+        if (t <= 0 || t >= 1 || u <= 0 || u >= 1) continue;
+        // addNode snaps to an existing node within its tolerance, so crossings
+        // that land on top of one another become a single junction
+        const ni = g.addNode(p.x + d1x * t, p.z + d1z * t, null, false);
+        addSplit(ei, t, ni);
+        addSplit(ej, u, ni);
+      }
+    }
+  }
+  if (!splits.size) return 0;
+  const specs = [];
+  for (let ei = 0; ei < g.edges.length; ei++) {
+    const e = g.edges[ei];
+    const l = splits.get(ei);
+    if (!l) { specs.push([e.a, e.b, e.cls, e.name]); continue; }
+    l.sort((m, n) => m.t - n.t);
+    let prev = e.a;
+    for (const sp of l) {
+      if (sp.ni !== prev) specs.push([prev, sp.ni, e.cls, e.name]);
+      prev = sp.ni;
+    }
+    if (prev !== e.b) specs.push([prev, e.b, e.cls, e.name]);
+  }
+  // addEdge recomputes length/heading and drops the sub-4 m slivers a split can
+  // leave behind, so rebuild through it rather than patching the arrays.
+  g.edges = [];
+  for (const n of g.nodes) n.e = [];
+  for (const sp of specs) g.addEdge(sp[0], sp[1], sp[2], sp[3]);
+  return splits.size;
+}
+
 // ---------------------------------------------------------------------------
 
 export function* cityGenerator() {
@@ -118,6 +251,7 @@ export function* cityGenerator() {
   yield { p: 0.02, msg: 'Surveying Puget Sound' };
 
   // --- 1. District street grids -------------------------------------------
+  const owns = districtOwner();
   const districtNodes = [];
   let di = 0;
   for (const d of G.DISTRICTS) {
@@ -136,6 +270,7 @@ export function* cityGenerator() {
       for (let j = j0; j <= j1; j++) {
         const [x, z] = pos(i, j);
         if (!G.pointInPolyCached(x, z, d)) continue;
+        if (!owns(d, x, z)) continue; // a denser neighbour's grid holds this ground
         if (!G.isBuildable(x, z)) continue;
         ids[(i - i0) * nh + (j - j0)] = g.addNode(x, z, null, false);
       }
@@ -148,6 +283,7 @@ export function* cityGenerator() {
       const [x1, z1] = pos(i, j), [x2, z2] = pos(i2, j2);
       const mx = (x1 + x2) / 2, mz = (z1 + z2) / 2;
       if (!G.isBuildable(mx, mz)) return;
+      if (!owns(d, mx, mz)) return; // don't reach across into a neighbour's grid
       g.addEdge(a, c, cls, d.name);
     };
     const streetCls = d.style === 'house' ? 'res' : 'st';
@@ -197,6 +333,11 @@ export function* cityGenerator() {
 
   // Stitch elevated ramp ends into their decks and grounded ends into streets.
   yield { p: 0.46, msg: 'Welding the interchanges' };
+
+  // Every ground-level crossing becomes a real junction. Do this before the
+  // segment index below, which reads the final edge list.
+  planarize(g);
+  yield { p: 0.48, msg: 'Cutting the intersections' };
 
   // --- 3. Segment index for building rejection ----------------------------
   const segCell = 90;
@@ -359,6 +500,7 @@ export function* cityGenerator() {
       for (let j = j0; j < j1; j++) {
         const [cx, cz] = pos(i + 0.5, j + 0.5);
         if (!G.pointInPolyCached(cx, cz, d)) continue;
+        if (!owns(d, cx, cz)) continue; // blocks belong to whoever owns the grid
         if (!G.isBuildable(cx, cz)) continue;
         const [nu, nv] = pickLot(d.style);
         const lu = (halfU * 2) / nu, lv = (halfV * 2) / nv;

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -271,6 +271,7 @@ export function* cityGenerator() {
         const [x, z] = pos(i, j);
         if (!G.pointInPolyCached(x, z, d)) continue;
         if (!owns(d, x, z)) continue; // a denser neighbour's grid holds this ground
+        if (G.inPark(x, z)) continue; // parks aren't blocks; see the note in link()
         if (!G.isBuildable(x, z)) continue;
         ids[(i - i0) * nh + (j - j0)] = g.addNode(x, z, null, false);
       }
@@ -284,6 +285,12 @@ export function* cityGenerator() {
       const mx = (x1 + x2) / 2, mz = (z1 + z2) / 2;
       if (!G.isBuildable(mx, mz)) return;
       if (!owns(d, mx, mz)) return; // don't reach across into a neighbour's grid
+      // The block grid does not run through a park. Buildings already skip
+      // parks, so paving one left a green rectangle with streets crossing it and
+      // nothing on them -- a road to nowhere. The hand-drawn arterials and
+      // highways in step 2 still go where they are drawn, which is right:
+      // Aurora really does cut through Woodland Park.
+      if (G.inPark(mx, mz)) return;
       g.addEdge(a, c, cls, d.name);
     };
     const streetCls = d.style === 'house' ? 'res' : 'st';

--- a/apps/auto/src/geo.js
+++ b/apps/auto/src/geo.js
@@ -94,7 +94,11 @@ export const WATER = [
       // Magnolia's south shore into Smith Cove
       [-4020, -2800], [-3900, -2400], [-3700, -2050], [-3300, -1880], [-2900, -1820],
       [-2600, -1880], [-2350, -1960], [-2150, -2160], [-1990, -2300], [-1900, -2080],
-      [-1800, -1880], [-1650, -1620], [-1500, -1320], [-1350, -980], dtShore(-14), dtShore(-8),
+      // The Belltown-to-Interbay shore drifted progressively east going north --
+      // about 450 m of it by Seattle Center, which left only metres of land
+      // between 1st Ave N and the bay and put Climate Pledge Arena on the beach.
+      // Pulled back west; re-run the land/water probe in CLAUDE.md after editing.
+      [-1980, -1880], [-1930, -1620], [-1850, -1320], [-1650, -980], dtShore(-14), dtShore(-8),
       dtShore(0), dtShore(6), dtShore(12), dtShore(15.5),
       [-150, 1700], [-330, 2000], [-380, 2400], [-400, 3000], [-430, 3600],
       [-520, 4400], [-700, 5300], [-1750, 5300], [-1700, 4300], [-1750, 3400],
@@ -497,11 +501,21 @@ export const HIGHWAYS = [
 
 // Surface arterials that stitch the neighbourhoods together.
 export const ARTERIALS = [
-  { name: 'Denny Way', pts: [[-1650, -520], [-1100, -540], [-700, -560], [-330, -580], [200, -600], [700, -620], [1250, -640], [1900, -660], [2600, -680], [3250, -700]] },
-  { name: 'Mercer St', pts: [[-1700, -1080], [-1200, -1090], [-700, -1100], [-200, -1110], [300, -1120], [700, -1130]] },
-  { name: 'Elliott Ave W', pts: [[...dt(-1.6, -8)], [-1180, -900], [-1500, -1500], [-1750, -2100], [-1950, -2650], [-2100, -3050], [-2200, -3400]] },
+  // Denny Way and Mercer St are the south and north edges of Seattle Center, so
+  // where they sit decides whether the campus has streets through it. Both were
+  // drawn too far south -- Mercer by nearly 400 m, which ran it straight past
+  // the Space Needle. Placed from real latitudes: Denny at 5th Ave N is
+  // 47.6185, Mercer is 47.6246.
+  { name: 'Denny Way', pts: [[-1650, -700], [-1100, -740], [-700, -770], [-330, -790], [200, -810], [700, -830], [1250, -850], [1900, -870], [2600, -890], [3250, -910]] },
+  { name: 'Mercer St', pts: [[-1700, -1455], [-1200, -1462], [-700, -1469], [-200, -1476], [300, -1483], [700, -1490]] },
+  // Elliott Ave W hugs the waterfront below the Queen Anne bluff. It used to cut
+  // the corner at [-1180,-900], which is inside the Seattle Center campus and
+  // about 400 m inland of where the road actually is.
+  { name: 'Elliott Ave W', pts: [[...dt(-1.6, -8)], [-1430, -760], [-1520, -1150], [-1620, -1560], [-1760, -2000], [-1900, -2450], [-2060, -2950], [-2200, -3400]] },
   { name: '15th Ave W', pts: [[-2200, -3400], [-2600, -3480], [-3000, -3420], [-3450, -3280]] },
-  { name: 'Queen Anne Ave N', pts: [[-1230, -620], [-1240, -1100], [-1250, -1600], [-1260, -2100], [-1270, -2600], [-1280, -2900]] },
+  // Queen Anne Ave N runs up the west side of the campus, not through it: it is
+  // the block past 1st Ave N, which is the campus's own western boundary.
+  { name: 'Queen Anne Ave N', pts: [[-1440, -800], [-1445, -1100], [-1450, -1600], [-1460, -2100], [-1470, -2600], [-1480, -2900]] },
   { name: 'Westlake Ave N', pts: [[-260, -640], [-420, -1100], [-560, -1600], [-680, -2100], [-800, -2700], [-870, -3200], [-960, -3600]] },
   { name: 'Dexter Ave N', pts: [[-520, -640], [-560, -1200], [-600, -1900], [-640, -2600], [-680, -3300]] },
   { name: 'Fairview Ave N', pts: [[100, -640], [80, -1200], [60, -1700], [130, -2100]] },
@@ -520,7 +534,11 @@ export const ARTERIALS = [
   { name: 'S Spokane St', pts: [[-180, 2700], [200, 2690], [700, 2680], [1150, 2670]] },
   { name: 'S Lander St', pts: [[-260, 2200], [200, 2190], [700, 2180], [1150, 2170]] },
   { name: 'S Holgate St', pts: [[-300, 1800], [200, 1790], [700, 1780], [1150, 1770]] },
-  { name: 'Alaskan Way', pts: [[-1150, -1000], [...dt(-2.6, -8)], [...dt(-2.6, 0)], [...dt(-2.6, 8)], [...dt(-2.6, 15)], [-120, 1600]] },
+  // Alaskan Way is the waterfront road. Its north end was [-1150,-1000], which
+  // is the Space Needle -- a seawall road terminating in the middle of Seattle
+  // Center, and the reason MoPOP had a street through it. It now stops where
+  // the pier front does, by Broad St.
+  { name: 'Alaskan Way', pts: [[-1230, -560], [...dt(-2.6, -8)], [...dt(-2.6, 0)], [...dt(-2.6, 8)], [...dt(-2.6, 15)], [-120, 1600]] },
   { name: 'N 45th St', pts: [[-1700, -4180], [-1100, -4190], [-500, -4200], [200, -4210], [900, -4220], [1600, -4230], [2400, -4240]] },
   { name: 'N 34th St', pts: [[-1700, -3900], [-1300, -3890], [-1060, -3900], [-700, -3880], [-300, -3870], [200, -3860]] },
   { name: 'NW Market St', pts: [[-4300, -4080], [-3800, -4070], [-3450, -4060], [-3000, -4050], [-2600, -4040]] },
@@ -575,9 +593,13 @@ export const TOWERS = [
 ];
 
 export const LANDMARKS = [
-  { kind: 'spaceNeedle', name: 'Space Needle', x: -1150, z: -1010, rot: 0 },
-  { kind: 'mopop', name: 'MoPOP', x: -1015, z: -1090, rot: 0.4 },
-  { kind: 'arena', name: 'Climate Pledge Arena', x: -1340, z: -1160, rot: 0 },
+  // Seattle Center, placed from real coordinates about Westlake Center. The
+  // cluster used to sit 140-290 m west of true, which is what pushed the Arena
+  // onto the Elliott Bay shoreline. Needle 47.6205/-122.3493, MoPOP
+  // 47.6215/-122.3486, Arena 47.6219/-122.3539.
+  { kind: 'spaceNeedle', name: 'Space Needle', x: -856, z: -1013, rot: 0 },
+  { kind: 'mopop', name: 'MoPOP', x: -803, z: -1124, rot: 0.4 },
+  { kind: 'arena', name: 'Climate Pledge Arena', x: -1201, z: -1169, rot: 0 },
   { kind: 'spheres', name: 'The Spheres', x: -345, z: -905, rot: 0 },
   { kind: 'market', name: 'Pike Place Market', p: dt(1.35, 1.0), rot: DT_ROT },
   { kind: 'wheel', name: 'Seattle Great Wheel', p: dt(-3.1, 3.4), rot: DT_ROT },
@@ -598,10 +620,10 @@ export const LANDMARKS = [
 
 // Parks: rectangles that stay green and unbuilt.
 export const PARKS = [
-  // 74 acres bounded by Mercer, Denny Way, 1st Ave N and 5th Ave N, and a
-  // pedestrian campus -- no streets cross it. Sized to hold the Needle, MoPOP
-  // and the Arena, which all sit inside it.
-  { name: 'Seattle Center', x: -1180, z: -1075, w: 520, d: 450, rot: 0 },
+  // 74 acres, and a pedestrian campus -- no streets cross it. Placed off the
+  // four streets that bound it: 1st Ave N (x -1396) and 5th Ave N (x -735),
+  // Denny Way (z -790) and Mercer St (z -1469).
+  { name: 'Seattle Center', x: -1066, z: -1130, w: 640, d: 650, rot: 0 },
   { name: 'Myrtle Edwards Park', x: -1320, z: -1750, w: 180, d: 900, rot: 0.32 },
   { name: 'Volunteer Park', x: 1350, z: -1560, w: 340, d: 300, rot: 0 },
   { name: 'Cal Anderson Park', x: 900, z: -180, w: 180, d: 260, rot: 0 },
@@ -650,10 +672,10 @@ export const RAMPS = [
   { name: 'I-5 Ravenna Ramp', pts: [[1210, -4500], [980, -4460], [760, -4480, 40], [665, -4500, 56]] },
 ];
 
-// Pavement at the south edge of Seattle Center, 164 m from the Space Needle and
-// looking straight at it. Kept clear of buildings by KEEP_CLEAR below.
-export const SPAWN = { x: -1163, z: -846 };
-export const SPAWN_HEADING = 3.06; // faces the Needle; see HEADING_SENSE in CLAUDE.md
+// Pavement on the 5th Ave N side of Seattle Center, 181 m from the Space Needle
+// and looking straight at it. Kept clear of buildings by KEEP_CLEAR below.
+export const SPAWN = { x: -679, z: -1050 };
+export const SPAWN_HEADING = -1.36; // faces the Needle; see HEADING_SENSE in CLAUDE.md
 export const RESPAWN = { x: 1050, z: 300 }; // Harborview
 /**
  * Points the player gets put down on. citygen removes any building covering

--- a/apps/auto/src/geo.js
+++ b/apps/auto/src/geo.js
@@ -598,7 +598,10 @@ export const LANDMARKS = [
 
 // Parks: rectangles that stay green and unbuilt.
 export const PARKS = [
-  { name: 'Seattle Center', x: -1180, z: -1080, w: 420, d: 380, rot: 0 },
+  // 74 acres bounded by Mercer, Denny Way, 1st Ave N and 5th Ave N, and a
+  // pedestrian campus -- no streets cross it. Sized to hold the Needle, MoPOP
+  // and the Arena, which all sit inside it.
+  { name: 'Seattle Center', x: -1180, z: -1075, w: 520, d: 450, rot: 0 },
   { name: 'Myrtle Edwards Park', x: -1320, z: -1750, w: 180, d: 900, rot: 0.32 },
   { name: 'Volunteer Park', x: 1350, z: -1560, w: 340, d: 300, rot: 0 },
   { name: 'Cal Anderson Park', x: 900, z: -180, w: 180, d: 260, rot: 0 },
@@ -647,7 +650,10 @@ export const RAMPS = [
   { name: 'I-5 Ravenna Ramp', pts: [[1210, -4500], [980, -4460], [760, -4480, 40], [665, -4500, 56]] },
 ];
 
-export const SPAWN = { x: 60, z: -20 }; // 4th & Olive: clear of buildings, on the block edge
+// Pavement at the south edge of Seattle Center, 164 m from the Space Needle and
+// looking straight at it. Kept clear of buildings by KEEP_CLEAR below.
+export const SPAWN = { x: -1163, z: -846 };
+export const SPAWN_HEADING = 3.06; // faces the Needle; see HEADING_SENSE in CLAUDE.md
 export const RESPAWN = { x: 1050, z: 300 }; // Harborview
 /**
  * Points the player gets put down on. citygen removes any building covering

--- a/apps/auto/src/peds.js
+++ b/apps/auto/src/peds.js
@@ -353,20 +353,43 @@ export function makeHumanoid(opts = {}) {
 }
 
 const TAU = Math.PI * 2;
+// Scratch for the leg solve, reused so a crowd doesn't allocate per frame.
+const _v = new THREE.Vector3();
+const _w = new THREE.Vector3();
+const _inv = new THREE.Quaternion();
 const LEG = J.hip - J.ankle;
 const L_THIGH = J.hip - J.knee;
 const L_SHIN = J.knee - J.ankle;
 // Never ask the IK for a fully locked leg -- at full extension the knee angle
 // is stationary against distance and the solve jitters.
 const REACH = LEG * 0.99;
+// What the hips are allowed to assume the planted leg can span. It has to be
+// shorter than REACH, because the pelvis rolls and carries its sockets up with
+// it -- HIP_X * sin(roll) is nearly a centimetre at a sprint. Set the hips by
+// the full reach and that rise pushes the leg past its limit, so it comes up
+// short and the planted foot lifts clear of the ground.
+const REACH_PLANT = REACH - 0.014;
 
 /**
- * Metres of ground covered per step, with the per-person gait variation folded
+ * How far the hips travel per step, with the per-person gait variation folded
  * in. This is the ONE number the gait is built on -- see animateWalk.
  */
 function stepLength(h, speed) {
-  return clamp(0.62 + 0.16 * speed, 0.5, 1.7) * h.gait;
+  return clamp(0.62 + 0.14 * speed, 0.5, 1.9) * h.gait;
 }
+
+/**
+ * Longest the foot may stay on the ground in one stance.
+ *
+ * The hips can only ride as high as the planted leg reaches, so a stance that
+ * spans `c` forces them down to sqrt(REACH^2 - (c/2)^2). Letting the stance grow
+ * with the step is what wrecked the run: at 6.4 m/s the step reached 1.64 m and
+ * the hips fell 63 cm on every stride -- the character dropped into the splits
+ * twice a second. Capping it holds the bob at about 14 cm and the extra speed
+ * goes into cadence and a flight phase instead, which is what actually happens
+ * when a person speeds up.
+ */
+const CONTACT_MAX = 0.95;
 
 /**
  * Procedural walk/idle cycle. Hips bob and sway, knees and elbows actually
@@ -408,12 +431,18 @@ export function animateWalk(h, amp, dt, speed) {
   // The bones are unscaled, so a step measured in world metres has to come back
   // through the character's own scale or a tall pedestrian over-strides.
   const sc = h.scale || 1;
-  const swept = (step / sc) * settle;
+  // Ground contact is capped, so above a jog the step outgrows it and the duty
+  // factor falls below a half -- the legs stop overlapping and a flight phase
+  // opens up. Speeding up therefore buys cadence and air, not a wider split.
+  const contactW = Math.min(step, CONTACT_MAX);
+  const duty = clamp(contactW / (2 * step), 0.2, 0.5);
+  const swept = (contactW / sc) * settle;
   const lift = ((0.09 + 0.07 * run) / sc) * settle;
+  const stanceSpan = TAU * duty;
   const target = (ph) => {
     const w = ((ph % TAU) + TAU) % TAU;
-    const stance = w < Math.PI;
-    const u = (stance ? w : w - Math.PI) / Math.PI;
+    const stance = w < stanceSpan;
+    const u = stance ? w / stanceSpan : (w - stanceSpan) / (TAU - stanceSpan);
     return stance
       ? { z: (0.5 - u) * swept, y: J.ankle, stance: true }
       : { z: (u - 0.5) * swept, y: J.ankle + lift * Math.sin(Math.PI * u), stance: false };
@@ -422,13 +451,44 @@ export function animateWalk(h, amp, dt, speed) {
 
   // The hips can only ride as high as the planted leg can reach, so the classic
   // two-bob-per-cycle rise and fall falls out of the geometry instead of being
-  // dialled in: highest at mid-stance, lowest as the legs scissor apart.
-  const planted = tl.stance ? tl : tr;
-  const hipY = J.ankle + Math.sqrt(Math.max(0.04, REACH * REACH - planted.z * planted.z));
+  // dialled in: highest at mid-stance, lowest as the legs scissor apart. It has
+  // to come from the PLANTED foot -- take it from the airborne one and the
+  // stance leg is asked for a reach it hasn't got, and the foot skates instead.
+  const planted = tl.stance ? tl : (tr.stance ? tr : null);
+  // Which foot is bearing weight: 0 left, 1 right, -1 airborne. Only the gait
+  // regression test reads it -- measuring skate needs the model's own idea of
+  // stance, or a flight phase gets counted as a foot sliding. See CLAUDE.md.
+  h.contact = tl.stance ? 0 : (tr.stance ? 1 : -1);
+  const lowHip = J.ankle + Math.sqrt(Math.max(0.04, REACH_PLANT * REACH_PLANT - (swept * 0.5) * (swept * 0.5)));
+  let hipY;
+  if (planted) {
+    hipY = J.ankle + Math.sqrt(Math.max(0.04, REACH_PLANT * REACH_PLANT - planted.z * planted.z));
+  } else {
+    // Airborne: nothing pins the hips, so arc over the gap. Both ends of a
+    // flight phase are the fully-scissored pose, so this stays continuous.
+    const gap = Math.PI - stanceSpan;
+    const w = ((phase % Math.PI) + Math.PI) % Math.PI;
+    const f = gap > 1e-6 ? clamp((w - stanceSpan) / gap, 0, 1) : 0;
+    hipY = lowHip + (0.035 + 0.05 * run) * Math.sin(Math.PI * f);
+  }
+
+  // The pelvis has to be posed BEFORE the legs are solved. It sways, rolls and
+  // twists, and the leg roots ride with it -- a roll of 0.09 rad lifts a hip
+  // socket by most of a centimetre. Solving against a character-space target and
+  // then moving the pelvis underneath leaves the foot floating and creeping;
+  // measured at a sprint that was 8 mm of float. So set it, then aim at the
+  // target through its inverse.
+  b[B.hips].position.set(s * A * 0.035, hipY, 0);
+  b[B.hips].rotation.set(0, -s * A * 0.30, -s * A * 0.11);
+  b[B.hips].updateMatrix();
+  _inv.copy(b[B.hips].quaternion).invert();
 
   // two-bone IK, sagittal plane only: solve thigh and knee to hit the target
   const solveLeg = (thigh, knee, foot, t) => {
-    const dz = t.z, dy = hipY - t.y;
+    // where this hip socket actually ended up, and the target seen from it
+    _v.copy(b[thigh].position).applyMatrix4(b[B.hips].matrix);
+    _w.set(0, t.y - _v.y, t.z - _v.z).applyQuaternion(_inv);
+    const dz = _w.z, dy = -_w.y;
     const D = clamp(Math.hypot(dz, dy), Math.abs(L_THIGH - L_SHIN) + 1e-3, L_THIGH + L_SHIN - 1e-3);
     const aim = Math.atan2(dz, dy); // target angle off straight-down, +z forward
     // knee sits FORWARD of the hip-to-ankle line, so the thigh leads it by `off`
@@ -454,13 +514,7 @@ export function animateWalk(h, amp, dt, speed) {
   b[B.elbowL].rotation.x = -(0.20 + 0.5 * run) - Math.max(0, armA * 1.4 * s);
   b[B.elbowR].rotation.x = -(0.20 + 0.5 * run) - Math.max(0, -armA * 1.4 * s);
 
-  // Pelvis rides at whatever height the planted leg can actually reach (see
-  // hipY): drop it any lower and the foot slides under the ground, hold it any
-  // higher and the figure floats.
-  b[B.hips].position.y = hipY;
-  b[B.hips].position.x = s * A * 0.035;
-  b[B.hips].rotation.z = -s * A * 0.11;
-  b[B.hips].rotation.y = -s * A * 0.30;
+  // Pelvis was posed above, before the legs were solved against it.
   b[B.spine].rotation.y = s * A * 0.16;
   b[B.chest].rotation.y = s * A * 0.30;
   b[B.chest].rotation.x = h.lean + A * 0.10 + run * 0.10;

--- a/apps/auto/src/player.js
+++ b/apps/auto/src/player.js
@@ -16,7 +16,7 @@ export class Player {
     this.x = G.SPAWN.x;
     this.z = G.SPAWN.z;
     this.y = city.groundAt(this.x, this.z, null);
-    this.heading = 2.58; // pointed down 4th Ave, toward Pioneer Square
+    this.heading = G.SPAWN_HEADING;
     this.vy = 0;
     this.grounded = true;
     this.speed = 0;

--- a/apps/auto/src/player.js
+++ b/apps/auto/src/player.js
@@ -29,6 +29,7 @@ export class Player {
     this.enterCd = 0;
     this.lift = 0;
     this.dead = false;
+    this.crashCd = 0; // see updateDrive: one wall scrape is one crash
 
     this.camYaw = this.heading + Math.PI;
     this.camPitch = 0.1;
@@ -96,7 +97,9 @@ export class Player {
 
   updateFoot(dt, input, traffic, peds) {
     const mag = Math.hypot(input.x, input.y);
-    const run = input.sprint ? 6.4 : 3.3;
+    // On-foot pace. The city is 10 km across, so these sit above real walking
+    // and jogging speeds -- crossing a block should not be a chore.
+    const run = input.sprint ? 7.5 : 4.2;
     let target = 0;
     if (mag > 0.12) {
       // Stick is camera-relative. Note HEADING_SENSE: heading is three.js
@@ -172,8 +175,16 @@ export class Player {
     const throttle = input.gas ? 1 : 0;
     const brake = input.brake ? 1 : 0;
     v.update(dt, { throttle, brake, steer, handbrake: input.hand ? 1 : 0 });
-    const impact = collideWithBuildings(v, this.city, (imp) => this.game.onCrash(imp, false));
-    if (impact > 8) this.game.damagePlayer(impact * 0.5, 'crash');
+    // Scraping a wall is many frames of contact, not many crashes. Debounced
+    // like vehicle-vehicle damage: unthrottled, holding the accelerator into a
+    // building killed the player in about a sixth of a second.
+    this.crashCd -= dt;
+    const impact = collideWithBuildings(v, this.city, (imp) => {
+      if (this.crashCd > 0) return;
+      this.crashCd = 0.4;
+      this.game.onCrash(imp, false);
+      if (imp > 8) this.game.damagePlayer(imp * 0.5, 'crash');
+    });
     if (v.y < -1.2 && G.isWater(v.x, v.z)) this.game.onCarSank(v);
     if (v.dead) this.game.onCarDestroyed(v);
   }
@@ -193,7 +204,7 @@ export class Player {
           if (p) return;
           for (const v of traffic.cars) {
             if (dist2(v.x, v.z, hx, hz) < v.radius * v.radius) {
-              v.damage(9);
+              v.damage(9, true);
               this.game.onShotVehicle(v, hx, hz);
               return;
             }

--- a/apps/auto/src/vehicles.js
+++ b/apps/auto/src/vehicles.js
@@ -358,6 +358,9 @@ export class Vehicle {
     this.pitch = 0; this.roll = 0;
     this.health = 100;
     this.dead = false;
+    // Seconds before this vehicle can take collision damage again. One crash
+    // spans many frames -- see damage().
+    this.hitCd = 0;
     this.onGround = true;
     this.vy = 0;
     this.wheelSpin = 0;
@@ -412,6 +415,7 @@ export class Vehicle {
 
   update(dt, input) {
     const spec = this.spec;
+    if (this.hitCd > 0) this.hitCd -= dt;
     const throttle = input.throttle || 0;
     const brake = input.brake || 0;
     const hand = input.handbrake || 0;
@@ -507,13 +511,33 @@ export class Vehicle {
     this.tilt.rotation.z = this.roll;
     if (this.detailedWheels) {
       for (const m of this.wheelMeshes) {
+        // Steer OUTSIDE the spin. Euler order matters here: the default 'XYZ'
+        // builds Rx*Ry, i.e. it steers the wheel and then rolls it about the
+        // car's X axis rather than the wheel's own axle -- so a turned front
+        // wheel tumbles instead of rolling, which is the visible wobble.
+        // 'YXZ' gives Ry*Rx: roll on the axle first, then steer the whole thing.
+        m.rotation.order = 'YXZ';
         m.rotation.x = this.wheelSpin;
         m.rotation.y = m.userData.front ? this.steer : 0;
       }
     }
   }
 
-  damage(n) {
+  /**
+   * Collision damage, debounced.
+   *
+   * A crash is not one frame. The pair stays overlapping and closing for
+   * several, and the caller ran on every one of them: a 20 m/s shunt is 14
+   * damage a frame, so 100 health was gone in about an eighth of a second and
+   * any real impact detonated the car on contact. `hitCd` makes one collision
+   * count once. Gunfire and other scripted damage passes `force` and is never
+   * debounced.
+   */
+  damage(n, force) {
+    if (!force) {
+      if (this.hitCd > 0) return false;
+      this.hitCd = 0.4;
+    }
     this.health -= n;
     if (this.health <= 0 && !this.dead) {
       this.health = 0;

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -777,9 +777,12 @@ export class World {
       }
     }
 
-    // park trees
+    // Park trees. The count is candidates over the whole chunk, of which only
+    // the ones landing in a park survive -- at 46 a chunk-sized park got one
+    // tree per 60 m and read as an empty green rectangle, which is most of why
+    // the parks looked unfinished.
     const x0 = cx * CHUNK, z0 = cz * CHUNK;
-    for (let i = 0; i < 46; i++) {
+    for (let i = 0; i < 230; i++) {
       const hx = hash2(cx * 71 + i, cz * 131 + 7);
       const hz = hash2(cx * 37 + i, cz * 53 + 13);
       const x = x0 + hx * CHUNK, z = z0 + hz * CHUNK;

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -16,7 +16,7 @@
 // fetches by URL with cache:'no-cache' — WebKit rejects fetch() of a
 // navigation-mode Request, which would silently kill the refresh of './' on
 // iOS, and no-cache skips GitHub Pages' 10-minute heuristic.
-const CACHE = 'auto-v9';
+const CACHE = 'auto-v10';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -16,7 +16,7 @@
 // fetches by URL with cache:'no-cache' — WebKit rejects fetch() of a
 // navigation-mode Request, which would silently kill the refresh of './' on
 // iOS, and no-cache skips GitHub Pages' 10-minute heuristic.
-const CACHE = 'auto-v10';
+const CACHE = 'auto-v11';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -16,7 +16,7 @@
 // fetches by URL with cache:'no-cache' — WebKit rejects fetch() of a
 // navigation-mode Request, which would silently kill the refresh of './' on
 // iOS, and no-cache skips GitHub Pages' 10-minute heuristic.
-const CACHE = 'auto-v8';
+const CACHE = 'auto-v9';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -16,7 +16,7 @@
 // fetches by URL with cache:'no-cache' — WebKit rejects fetch() of a
 // navigation-mode Request, which would silently kill the refresh of './' on
 // iOS, and no-cache skips GitHub Pages' 10-minute heuristic.
-const CACHE = 'auto-v11';
+const CACHE = 'auto-v12';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];


### PR DESCRIPTION
You can now read which build you're running off the launch screen — `v9`, bottom centre, subtle enough to ignore and fading out with the loading overlay.

The reason this is worth having: a stale service worker is indistinguishable from a fix that didn't work. That's come up repeatedly while playtesting, and a number on screen settles it in a second.

## The convention

**`#build` in `index.html` and `CACHE` in `sw.js` move together, once per change** — `v9` next to `auto-v9`. Documented in `apps/auto/CLAUDE.md` next to the existing service-worker cache rule, and in the root `CLAUDE.md` beside Feed's equivalent convention so both apps' rules sit in one place.

I aligned the number with the existing service-worker cache version rather than starting at v1, since that counter has already been tracking every change to this app.

## Why two literals and not one constant

This looks like obvious duplication, so the reasoning is written into both docs to stop someone (me, later) tidying it up:

Sharing one constant means either the page fetching the number out of `sw.js` at boot, or `sw.js` pulling it in with `importScripts`. The second is the tempting one — and it quietly breaks the offline contract. If `sw.js` imports the version instead of containing it, **its own bytes stop changing between releases**, so the browser has no reason to install the new worker and the cache never turns over. The byte change to `sw.js` *is* the update trigger. So that file has to carry its own copy.

Keeping the digits equal is what makes a mismatch obvious at a glance.

## Verification

Headless Chrome, checked on the live launch screen rather than by reading the markup:

| | |
|---|---|
| text | `v9` |
| visible | yes, opacity 0.4 |
| inside the loading overlay | yes — so it fades with it |
| clearance above safe-area inset | 14 px |
| console errors | none |

[launch screen showing v9 under the AUTO title and progress bar]

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6uJPyarVs2ggkt3wXg12N)_