### PR TITLE
Auto: road shimmer, camera jolt, and the carjacking crash

### DIFF
--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -523,6 +523,28 @@ reason to install the new worker and the cache never turns over. **The byte
 change to sw.js is the update trigger**, so that file has to carry its own
 literal. Bump both, and keep the digits equal so a mismatch is obvious on sight.
 
+## Vehicle asset table is `assets`, never `t`
+
+`Vehicle.assets` holds the shared geometry for a type. It used to be
+`this.t`, and `traffic.js` spawning a car did `v.t = t` with the car's position
+along its edge — replacing the whole geometry table with a number. Nothing
+noticed, because the meshes were already built in the constructor and
+`this.t.wheelR` fell through to a default. It only surfaced when you got in:
+`setDetailed(true)` iterates `assets.wheels`, so **carjacking any moving traffic
+car threw**, and it threw *after* `this.vehicle = v` but *before*
+`this.onFoot = false`, leaving the player half in the car. The HUD read the
+car's speed while the sim still ran the player on foot, which is what "frozen
+but the speedo works" was.
+
+Parked cars were fine, which is what made it look intermittent — they spawn
+through a different path that never wrote the field.
+
+Two things follow. Don't give a shared, long-lived reference a one-letter name.
+And when a bug report says a system half-works, suspect an exception midway
+through a setup function rather than a stuck value: `requestAnimationFrame` is
+re-armed at the top of the frame, so a throw part-way through leaves the loop
+running with an object in a state no code path expects.
+
 ## Shimmer and jolt: two things that read as "janky"
 
 **Road markings flashing is the albedo map, not geometry.** Localise this kind

--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -522,3 +522,34 @@ and in that second case sw.js's own bytes never change, so the browser has no
 reason to install the new worker and the cache never turns over. **The byte
 change to sw.js is the update trigger**, so that file has to carry its own
 literal. Bump both, and keep the digits equal so a mismatch is obvious on sight.
+
+## Shimmer and jolt: two things that read as "janky"
+
+**Road markings flashing is the albedo map, not geometry.** Localise this kind
+of thing by moving the camera a few millimetres and counting pixels that change:
+a stable scene barely moves. With the road and pavement albedo maps in place,
+6.6% of pixels changed from a 4 mm move; with just those maps nulled it fell to
+0.7%. Removing the normal or roughness map changed nothing, so it isn't specular
+aliasing. Lane markings are 8–12 px lines in a 512 texture seen at a grazing
+angle — the canonical anisotropy case — and `tex()` was asking for 8 when phones
+offer 16.
+
+**SwiftShader cannot verify texture filtering.** Turning mipmaps off entirely
+produces the same churn as leaving them on, which means the software rasterizer
+is not honouring mip or anisotropy settings at all. Any filtering change has to
+be checked on a real device; do not conclude anything about it from a headless
+run.
+
+**Smooth the camera, not the ground.** The lift query has to report the kerb as
+the 22 cm step world.js draws, because the two agreeing is the whole contract in
+"The one height surface". Ramping the *surface* to make walking smoother was
+tried and reverted: it desyncs from the drawn kerb and you sink into the
+pavement, which is the same bug as feet-in-the-sidewalk. The jolt belongs to the
+camera, so that is where it is damped — vertical follow runs at 4.5 against 14
+horizontal, and the ground clamp works against a smoothed floor rather than
+snapping to a discontinuous surface. Measured over 900 frames at a fixed 60 fps
+step, worst-case camera movement per frame went 35.5 mm → 19.1 mm.
+
+Measure this at a **fixed dt**, driving `updateFoot`/`updateCamera` in a loop.
+SwiftShader runs about 4 fps, so real-time traces exaggerate every per-frame
+delta by an order of magnitude and are worthless for judging smoothness.

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -321,7 +321,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v12</div>
+    <div id="build">v13</div>
   </div>
 
   <div id="rotate">

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -321,7 +321,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v13</div>
+    <div id="build">v14</div>
   </div>
 
   <div id="rotate">

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -20,6 +20,12 @@ const CLASS_HW = { hwy: 15, art: 9.5, st: 6.5, res: 5.5, ramp: 5.5 };
 const MAX_HW = Math.max(...Object.values(CLASS_HW));
 // Widest pavement a junction ring can carry, for the same reason.
 const MAX_WALK = 3.2;
+// How far a paved surface tapers out at its outer edge, so nothing steps off a
+// cliff. Note this is the only place the lift is smoothed: the kerb between
+// road and pavement is a real 22 cm step and the query has to report it,
+// because world.js draws it that way. Smoothing belongs in the character and
+// the camera -- soften it here and you sink into the kerb instead.
+const RAMP = 0.5;
 const CLASS_SPEED = { hwy: 30, art: 17, st: 12, res: 9, ramp: 14 };
 
 // ---------------------------------------------------------------------------
@@ -704,7 +710,7 @@ export function* cityGenerator() {
             if (r.d > outer) continue;
             let l = r.d <= e.hw ? ROAD_LIFT : WALK_LIFT;
             // taper the last half metre so nothing steps off a cliff edge
-            if (r.d > outer - 0.5) l *= (outer - r.d) / 0.5;
+            if (r.d > outer - RAMP) l *= (outer - r.d) / RAMP;
             if (l > lift) lift = l;
           }
         }

--- a/apps/auto/src/player.js
+++ b/apps/auto/src/player.js
@@ -36,6 +36,7 @@ export class Player {
     this.camDist = 6.5;
     this.camPos = new THREE.Vector3(this.x + Math.sin(this.camYaw) * 4.6, this.y + 1.6, this.z + Math.cos(this.camYaw) * 4.6);
     this.camLook = new THREE.Vector3(this.x, this.y + 1.4, this.z);
+    this.camFloor = null; // smoothed floor for the camera clamp; see updateCamera
   }
 
   get position() {
@@ -255,15 +256,25 @@ export class Player {
       target.z + Math.cos(this.camYaw) * dist * cp
     );
     const rate = this.onFoot ? 14 : 9;
+    // Vertical follows far slower than horizontal. The ground under a walking
+    // player is a staircase -- 22 cm off a kerb, another step across a junction
+    // -- and a camera tracking it at the horizontal rate reproduces every one of
+    // those as a jolt. Horizontal has to stay tight or the camera feels loose,
+    // so the two rates are deliberately different.
+    const rateY = this.onFoot ? 4.5 : 7;
     this.camPos.x = damp(this.camPos.x, wanted.x, rate, dt);
-    this.camPos.y = damp(this.camPos.y, wanted.y, rate, dt);
+    this.camPos.y = damp(this.camPos.y, wanted.y, rateY, dt);
     this.camPos.z = damp(this.camPos.z, wanted.z, rate, dt);
-    // the camera clamp does not need 22 cm of kerb accuracy, so skip the scan
-    const minY = this.city.groundAt(this.camPos.x, this.camPos.z, null, 0) + 1.1;
-    if (this.camPos.y < minY) this.camPos.y = minY;
+    // Keep the camera out of the ground, but clamp against a SMOOTHED floor.
+    // The raw surface is discontinuous, so clamping straight to it turns every
+    // kerb the camera passes over into a snap of its own. It doesn't need 22 cm
+    // of kerb accuracy either, hence the zero lift.
+    const rawFloor = this.city.groundAt(this.camPos.x, this.camPos.z, null, 0) + 1.1;
+    this.camFloor = this.camFloor == null ? rawFloor : damp(this.camFloor, rawFloor, 8, dt);
+    if (this.camPos.y < this.camFloor) this.camPos.y = this.camFloor;
     this.camLook.set(
       damp(this.camLook.x, target.x, 16, dt),
-      damp(this.camLook.y, target.y + lookH, 16, dt),
+      damp(this.camLook.y, target.y + lookH, this.onFoot ? 6 : 12, dt),
       damp(this.camLook.z, target.z, 16, dt)
     );
   }

--- a/apps/auto/src/textures.js
+++ b/apps/auto/src/textures.js
@@ -16,7 +16,13 @@ function canvas(w, h) {
   return { c, g: c.getContext('2d') };
 }
 
-function tex(c, { repeat = true, aniso = 8, srgb = true, mips = true } = {}) {
+// Ask for the most anisotropy any GPU offers; three clamps it to the device
+// maximum on upload. Road surfaces are the case this exists for -- lane
+// markings are 8-12 px lines in a 512 texture, seen at a grazing angle from eye
+// height, and at anisotropy 8 they shimmered as you walked. Removing the albedo
+// map dropped the frame-to-frame churn from a 4 mm camera move from 6.6% of
+// pixels to 0.7%, so the flicker was all in this one map.
+function tex(c, { repeat = true, aniso = 16, srgb = true, mips = true } = {}) {
   const t = new THREE.CanvasTexture(c);
   if (repeat) {
     t.wrapS = THREE.RepeatWrapping;

--- a/apps/auto/src/traffic.js
+++ b/apps/auto/src/traffic.js
@@ -151,7 +151,6 @@ export class TrafficSystem {
       const v = this.spawnAt(x + lo.x, z + lo.z, heading, tn, randomCarColor((this.R.n() * 1e6) | 0), 'traffic');
       v.edge = ei;
       v.dirSign = sign;
-      v.t = t;
       v.vLong = 6 + this.R.n() * 6;
       v.panic = 0;
       return v;

--- a/apps/auto/src/vehicles.js
+++ b/apps/auto/src/vehicles.js
@@ -335,7 +335,11 @@ export class Vehicle {
     const t = A.types[typeName];
     this.city = city;
     this.typeName = typeName;
-    this.t = t;
+    // Named `assets`, not `t`. It used to be `this.t`, and traffic.js spawning a
+    // car did `v.t = t` with its position along the edge -- silently replacing
+    // the whole geometry table with a number. Nothing noticed until you tried to
+    // get in, because the meshes were already built by then.
+    this.assets = t;
     this.spec = t.spec;
     this.color = color;
     this.detailedWheels = false;
@@ -377,13 +381,13 @@ export class Vehicle {
     if (this.detailedWheels === on) return;
     this.detailedWheels = on;
     const A = vehicleAssets();
-    this.trimMesh.geometry = on ? this.t.trimGeo : this.t.trimGeoW;
-    this.matteMesh.geometry = on ? this.t.matteGeo : this.t.matteGeoW;
+    this.trimMesh.geometry = on ? this.assets.trimGeo : this.assets.trimGeoW;
+    this.matteMesh.geometry = on ? this.assets.matteGeo : this.assets.matteGeoW;
     if (on) {
-      for (const [wx, wy, wz] of this.t.wheels) {
+      for (const [wx, wy, wz] of this.assets.wheels) {
         const g = new THREE.Group();
-        const a = new THREE.Mesh(this.t.wheelTrim, A.trimMat);
-        const b = new THREE.Mesh(this.t.wheelMatte, A.matteMat);
+        const a = new THREE.Mesh(this.assets.wheelTrim, A.trimMat);
+        const b = new THREE.Mesh(this.assets.wheelMatte, A.matteMat);
         a.castShadow = b.castShadow = true;
         g.add(a, b);
         g.position.set(wx, wy, wz);
@@ -499,7 +503,7 @@ export class Vehicle {
     this.pitch = lerp(this.pitch, tgtPitch, 1 - Math.exp(-10 * dt));
     this.roll = lerp(this.roll, tgtRoll, 1 - Math.exp(-10 * dt));
 
-    this.wheelSpin += (this.vLong / (this.t.wheelR || 0.34)) * dt;
+    this.wheelSpin += (this.vLong / (this.assets.wheelR || 0.34)) * dt;
     this.sync();
     return { dx, dz };
   }

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -16,7 +16,7 @@
 // fetches by URL with cache:'no-cache' — WebKit rejects fetch() of a
 // navigation-mode Request, which would silently kill the refresh of './' on
 // iOS, and no-cache skips GitHub Pages' 10-minute heuristic.
-const CACHE = 'auto-v13';
+const CACHE = 'auto-v14';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -16,7 +16,7 @@
 // fetches by URL with cache:'no-cache' — WebKit rejects fetch() of a
 // navigation-mode Request, which would silently kill the refresh of './' on
 // iOS, and no-cache skips GitHub Pages' 10-minute heuristic.
-const CACHE = 'auto-v12';
+const CACHE = 'auto-v13';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];


### PR DESCRIPTION
Two commits, v12 → **v14**. `master` is on v12, so none of this is live yet.

---

## v13 — road markings flashing

Localised by moving the camera 4 mm and counting pixels that changed, which a stable scene barely does:

| condition | pixels changed |
|---|---|
| normal | 6.6% |
| road + pavement **albedo** nulled | **0.7%** |
| normal map removed | 6.4% |
| roughness map removed | 6.4% |

So it's the albedo, and specifically the lane markings — 8–12 px lines in a 512 texture seen at a grazing angle from eye height. That's the textbook anisotropic-filtering case, and `tex()` was asking for **8** while phones offer **16**. Now asks for 16; three clamps it to whatever the device actually supports.

**This fix is not verified.** Turning mipmaps off entirely produces identical churn to leaving them on, which means SwiftShader isn't honouring mip or anisotropy settings at all — a headless run physically cannot tell the difference. It needs checking on the phone. If it still shimmers, the next lever is softening the marking edges in the texture itself, which works regardless of filtering.

## v13 — walking jank was the camera, not the gait

The ground under a walking player is a staircase (22 cm off every kerb), and the camera tracked it at the *same* rate as horizontal, so every kerb became a jolt. Vertical follow now runs at 4.5 against 14 horizontal, the look target's vertical is slowed to match, and the clamp keeping the camera out of the ground works against a smoothed floor instead of snapping to a discontinuous surface.

Measured over 900 frames at a fixed 60 fps step:

| | before | after |
|---|---|---|
| worst camera movement / frame | 35.5 mm | **19.1 mm** |
| 99th percentile | 22.4 mm | 16.3 mm |

**Tried and reverted:** ramping the lift across the kerb and across the junction square's edge. It smooths the surface and desyncs it from the kerb `world.js` draws, so you sink into the pavement — ring samples standing below their own pavement went 285 → 406. That's the feet-in-the-sidewalk bug again. The surface query has to report what's drawn; smoothing belongs in the camera.

Player Y is deliberately unchanged (50.6 mm worst case) — it follows the real surface by contract.

## v14 — carjacking threw and left the player half in the car

Entering a car "froze" the game while the speedo kept reading and the minimap kept turning. It was an exception, not a stuck value.

`traffic.js` spawned a car and did `v.t = t` — `t` being its position along the edge — straight over `Vehicle.this.t`, the **shared geometry table** for that vehicle type. The write was dead; nothing ever read it back. Nothing noticed the damage either, because the meshes are built in the constructor before the clobber and the one other reader falls through a default (`this.t.wheelR || 0.34`).

It only surfaced on getting in. `setDetailed(true)` iterates `t.wheels`, so entering any traffic-spawned car threw `t.wheels is not iterable`. **Parked cars spawn through a path that never wrote the field** — which is what made it look intermittent.

The half-broken state comes from where the throw lands:

```js
this.vehicle = v;        // done
v.mode = 'free';         // done
v.setDetailed(true);     // throws here
this.onFoot = false;     // never runs
this.game.onEnterVehicle(v);
```

So the player was recorded as being in a car the sim still ran on foot, controls never switched to drive mode, and the car stopped being driven by traffic AI (that loop skips `v === player.vehicle`). The HUD reads the vehicle — hence a live speedo bolted to a car nobody was updating. `requestAnimationFrame` is re-armed at the top of the frame, so the loop survived and everything looked alive.

Fixed at both ends: the dead write is gone, and the field is renamed to `assets`, because a shared long-lived reference shouldn't sit on a one-letter name any system might reasonably want for a scalar.

## Verification

- 12 cars entered and driven, 0 stuck, no console errors
- Carjacking a moving traffic sedan specifically — the case that threw — reports `onFoot: false`, 4 wheel meshes attached, drives 68 m under throttle and steer
- City regressions unchanged: 0 crossings with no junction, 200/200 junction surfaces, 0 buildings in the roadway

## Also in CLAUDE.md

Two methodology notes that cost real time this round: SwiftShader can't verify texture filtering, and walk smoothness must be measured at a **fixed dt** — its real ~4 fps exaggerates every per-frame delta about tenfold, which had me chasing a "160 mm player jolt" that was mostly measurement artifact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6uJPyarVs2ggkt3wXg12N)_