### PR TITLE
Auto: stop two roads paving the same ground

### DIFF
--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -547,7 +547,32 @@ running with an object in a state no code path expects.
 
 ## Shimmer and jolt: two things that read as "janky"
 
-**Road markings flashing is the albedo map, not geometry.** Localise this kind
+**Road markings flashing was two carriageways in the same place.** The hand-drawn
+arterials and highways overlap each other and the district grids — 187
+near-parallel pairs, and beside the spawn a street and a ramp run 0.7 m apart.
+Both drew a full-width surface, each with its own centre line, and the depth
+buffer picked a winner per pixel per frame: the road flips between one yellow
+line and two. `city.roadCoveredAt()` ranks by width then edge order, and
+`meshRoad` skips any 16 m segment a higher-ranked road already paves. Only the
+surface is dropped — the edge stays in the graph and traffic still routes over
+it. Around the spawn, road area carrying two parallel carriageways went 70.9%
+→ 2.4%, and the city emits 22% fewer road quads.
+
+**A caution about the churn metric below.** Moving the camera 4 mm and counting
+changed pixels does *not* isolate this. It reads ~6.6% before and after the fix,
+and it read the same with mipmaps disabled entirely — SwiftShader's own sampling
+is unstable enough to swamp the signal. It pointed at the albedo map (removing
+it dropped churn to 0.7%) and that was a red herring: with the markings gone,
+two fighting grey surfaces look identical. **Overlapping geometry is measured on
+the geometry**, by asking how much road area is covered by more than one
+near-parallel carriageway. Keep the paragraph below for what it does show, but
+don't use it to chase flicker.
+
+**Anisotropy is set to the device maximum** (`tex()` asks for 16, three clamps
+it). That is standard for road surfaces at grazing angles and worth having, but
+it was *not* the flicker fix, despite being committed as one.
+
+**The albedo map is where high-frequency detail lives.** Localise this kind
 of thing by moving the camera a few millimetres and counting pixels that change:
 a stable scene barely moves. With the road and pavement albedo maps in place,
 6.6% of pixels changed from a 4 mm move; with just those maps nulled it fell to

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -321,7 +321,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v14</div>
+    <div id="build">v15</div>
   </div>
 
   <div id="rotate">

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -684,6 +684,45 @@ export function* cityGenerator() {
      * compute this once for the body centre and pass it in, rather than paying
      * for the edge scan on every sample.
      */
+    /**
+     * Is edge `ei`'s carriageway at (x,z) already paved by a road that outranks
+     * it?
+     *
+     * The hand-drawn arterials and highways overlap each other and the district
+     * grids -- 187 near-parallel pairs, and next to the spawn a street and a
+     * ramp run 0.7 m apart. Two full-width surfaces then land on the same
+     * ground, each painting its own centre line, and the depth buffer picks a
+     * winner per pixel per frame: the road appears to flip between one yellow
+     * line and two. That is a data problem, but the renderer should not put two
+     * carriageways in the same place regardless, so world.js asks this per
+     * segment and skips the ones that are covered.
+     *
+     * Rank is width first, then edge order, so the pairing is antisymmetric and
+     * exactly one of any overlapping pair draws. Only the surface is dropped --
+     * the edge stays in the graph and traffic still routes over it.
+     */
+    roadCoveredAt(x, z, ei) {
+      const me = g.edges[ei];
+      if (!me || me.elev) return false;
+      const c0 = Math.floor(x / CHUNK), d0 = Math.floor(z / CHUNK);
+      for (let cx = c0 - 1; cx <= c0 + 1; cx++) {
+        for (let cz = d0 - 1; cz <= d0 + 1; cz++) {
+          const c = chunks.get(ck(cx, cz));
+          if (!c) continue;
+          for (const oi of c.edges) {
+            if (oi === ei) continue;
+            const o = g.edges[oi];
+            if (o.elev) continue;
+            // outranked only by something wider, or equal-width and earlier
+            if (o.hw < me.hw || (o.hw === me.hw && oi > ei)) continue;
+            const a = g.nodes[o.a], b = g.nodes[o.b];
+            if (distToSeg(x, z, a.x, a.z, b.x, b.z).d <= o.hw) return true;
+          }
+        }
+      }
+      return false;
+    },
+
     roadLift(x, z) {
       // A junction square is drawn at NODE_LIFT and covers the ends of every
       // strip that meets there, so inside one it IS the surface -- take it

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -330,7 +330,7 @@ export class World {
       const a = city.nodes[e.a], b = city.nodes[e.b];
       const mx = (a.x + b.x) / 2, mz = (a.z + b.z) / 2;
       if (!own(mx, mz)) continue;
-      this.meshRoad(road, walk, flat, e, a, b, lod);
+      this.meshRoad(road, walk, flat, e, a, b, lod, ei);
       for (const ni of [e.a, e.b]) {
         if (nodesDone.has(ni)) continue;
         const n = city.nodes[ni];
@@ -366,7 +366,7 @@ export class World {
 
   // --- road surfaces --------------------------------------------------------
 
-  meshRoad(road, walk, flat, e, a, b, lod) {
+  meshRoad(road, walk, flat, e, a, b, lod, ei) {
     const hw = e.hw;
     const px = -e.dz, pz = e.dx;
     const steps = e.elev ? 1 : Math.max(1, Math.round(e.len / 16));
@@ -384,6 +384,11 @@ export class World {
       const r0x = x0 - px * hw, r0z = z0 - pz * hw;
       const l1x = x1 + px * hw, l1z = z1 + pz * hw;
       const r1x = x1 - px * hw, r1z = z1 - pz * hw;
+      // Don't pave over a road that outranks this one. Where two carriageways
+      // overlap, both used to draw and the depth buffer chose per pixel, which
+      // is what made the centre line flicker between one stripe and two.
+      if (!e.elev && ei != null
+        && this.city.roadCoveredAt((x0 + x1) / 2, (z0 + z1) / 2, ei)) continue;
       road.quad(
         [l0x, yAt(l0x, l0z, t0), l0z],
         [r0x, yAt(r0x, r0z, t0), r0z],

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -16,7 +16,7 @@
 // fetches by URL with cache:'no-cache' — WebKit rejects fetch() of a
 // navigation-mode Request, which would silently kill the refresh of './' on
 // iOS, and no-cache skips GitHub Pages' 10-minute heuristic.
-const CACHE = 'auto-v14';
+const CACHE = 'auto-v15';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];


### PR DESCRIPTION
v14 → **v15**. Fixes the flickering centre line properly.

## It was never aliasing

Your description settled it: the road alternates between **one yellow line and two, close together**. That's two carriageways drawn in the same place, each painting its own markings, with the depth buffer picking a winner per pixel per frame. The screenshot shows the z-fighting bands beside the dashes.

The hand-drawn arterials and highways overlap each other and the district grids — **187 near-parallel pairs** across the city. Beside the spawn, `South Lake Union [st]` and the `Aurora Denny Ramp` run **0.7 m apart** over half their length. Both drew a full road surface.

## The fix

`city.roadCoveredAt()` ranks overlapping carriageways by width, then by edge order so the comparison is antisymmetric and exactly one of any pair draws. `meshRoad` skips a 16 m segment when a higher-ranked road already paves its midpoint.

**Only the surface is dropped** — the edge stays in the graph, so traffic still routes over it and the junctions are untouched. The UV accumulator advances before the skip, so the dash pattern stays in phase across a gap.

| | before | after |
|---|---|---|
| road area on 2+ parallel carriageways, citywide | 19.8% | **2.4%** |
| same, within 150 m of the spawn | 70.9% | **2.4%** |
| road quads emitted | 42147 | 32675 |

22% fewer road quads is a free side effect — that's how much was redundant.

## I got this wrong the first time

v13 raised anisotropy 8 → device max on the strength of a "move the camera 4 mm, count changed pixels" measurement: nulling the road albedo took churn from 6.6% to 0.7%, which I read as texture aliasing.

That evidence is **equally consistent with this bug** — strip the markings and two fighting grey surfaces become indistinguishable — and the metric can't tell them apart. It still reads 6.7% after this fix, and it read the same with mipmaps switched off entirely, because SwiftShader's own sampling is unstable enough to swamp the signal. Overlapping geometry has to be measured **on the geometry**, which is what the table above does.

The anisotropy change stays. It's correct for road surfaces at grazing angles, it just wasn't this. CLAUDE.md now carries the fix, the ranking rule, and an explicit warning not to chase flicker with that churn metric.

## Verification

Regressions unchanged: 0 crossings without a junction, 200/200 junction surfaces, 0 buildings in the roadway, kerb ring unchanged at 285. Rendered at the spawn — single clean centre line, no console errors.

## Still open

The underlying cause is data: those 187 pairs exist because the arterial polylines carry the same positional drift documented in CLAUDE.md (SR 99 and Dexter Ave N are 21.8 m apart here against ~150 m in reality). This change makes the renderer robust to that, but the geography is still wrong, and the reference-map work we discussed is what actually fixes it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6uJPyarVs2ggkt3wXg12N)_