### PR TITLE
Auto: quality pass — water, kerbs, dead ends, bridge barriers, parked cars

### DIFF
--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -600,3 +600,42 @@ step, worst-case camera movement per frame went 35.5 mm → 19.1 mm.
 Measure this at a **fixed dt**, driving `updateFoot`/`updateCamera` in a loop.
 SwiftShader runs about 4 fps, so real-time traces exaggerate every per-frame
 delta by an order of magnitude and are worthless for judging smoothness.
+
+## Junctions, dead ends, bridges
+
+**Pavement must not cross a carriageway, and the ring is where that breaks.**
+Strips stop at `nodeRadius` and `meshNode` fills the corner with a square ring —
+but drawn as four whole sides, that ring lays a footpath straight over all four
+approach roads. Each side is cut into pieces and the pieces covering an approach
+are dropped, leaving pavement on the corners only.
+
+**A dead end is not a junction.** `meshNode` returns early below degree 2.
+Otherwise a single street running out to nothing gets a full crossing square and
+a kerbed ring sitting on bare ground — the "road to nowhere". `nodeSurface()`
+skips the same nodes, because the drawn surface and the lift query have to agree.
+
+**Elevated spans get subdivided like any other road.** A barrier is a box that
+can only yaw, so on a climbing ramp it stays level while the deck rises away
+from it. At `steps = 1` a 117 m span drew one 117 m barrier centred at
+mid-height, stabbing tens of metres above and below the road — the white spears
+sticking out of the freeway. Piers are placed every ~35 m along the span rather
+than one per edge.
+
+Note the "long thin triangle" probe is *not* diagnostic here: a pier is
+legitimately 30 m tall and 1.7 m wide, so it trips any aspect-ratio filter. Judge
+deck geometry from a close render alongside and down the deck.
+
+## Nothing stands on the water, and parked cars sit on the slope
+
+**`chain()` refuses to lay a ground-level edge whose midpoint is over water.**
+The hand-drawn polylines carry the usual positional drift, which had put four
+arterials — Aurora, Westlake, Dexter and Fairview — straight through Lake Union
+at 4 to 9 m below the surface, and Delridge Way through Elliott Bay: 182 edges
+in all. A span meant to cross water is marked elevated in the data and is left
+alone. Absent beats submerged, and connectivity went *up* (98.1% → 98.4%),
+because those edges only ever connected things across a lake.
+
+**`Vehicle.place()` sets pitch and roll, not just height.** A parked car never
+runs `update()`, so left at zero pitch it stays level on a hillside street and
+its downhill end is buried. That was the sunken cars on Queen Anne — a 20% grade
+needs `atan(0.2)` ≈ 0.2 rad of pitch, and it was getting none.

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -321,7 +321,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v15</div>
+    <div id="build">v16</div>
   </div>
 
   <div id="rotate">

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -333,7 +333,19 @@ export function* cityGenerator() {
         const ground = G.terrainHeight(x, z);
         const elev = hasY && y - ground > 3.5;
         const id = g.addNode(x, z, elev ? y : null, elev);
-        if (prev >= 0) g.addEdge(prev, id, cls, name);
+        if (prev >= 0) {
+          // Never lay a road on the lake bed. These polylines are hand-drawn and
+          // carry the same positional drift as everything else, which put four
+          // arterials -- Aurora, Westlake, Dexter and Fairview -- straight
+          // through Lake Union at 4 to 9 m below the surface, plus Delridge Way
+          // through Elliott Bay. A span that is meant to cross water is marked
+          // elevated in the data and is left alone; anything else that lands on
+          // water is a mistake and is better absent than submerged.
+          const p = g.nodes[prev];
+          const wet = !elev && !p.elev
+            && G.isWater((p.x + x) / 2, (p.z + z) / 2);
+          if (!wet) g.addEdge(prev, id, cls, name);
+        }
         prev = id;
       }
     }
@@ -785,6 +797,8 @@ export function* cityGenerator() {
             const n = g.nodes[ni];
             // elevated junctions ride their deck, not the terrain
             if (n.elev) continue;
+            // a dead end draws no square, so it reports no lift -- see meshNode
+            if (n.e.length < 2) continue;
             let hw = 0, rot = 0, sw = 0;
             for (const ei of n.e) {
               const e = g.edges[ei];

--- a/apps/auto/src/vehicles.js
+++ b/apps/auto/src/vehicles.js
@@ -406,6 +406,18 @@ export class Vehicle {
     this.heading = heading;
     this.lift = this.city.roadLift(x, z);
     this.y = this.city.groundAt(x, z, null, this.lift);
+    // Sit on the slope, the same way update() does. A parked car never runs
+    // update(), so left at zero pitch it stays level on a hillside street and
+    // its downhill end is buried -- the sunken cars on Queen Anne.
+    const f = this.forward;
+    const rx = f.z, rz = -f.x;
+    const at = (dx, dz) => this.city.groundAt(this.x + dx, this.z + dz, this.y + 1.5, this.lift);
+    const fh = at(f.x * this.halfLen, f.z * this.halfLen);
+    const bh = at(-f.x * this.halfLen, -f.z * this.halfLen);
+    const lh = at(rx * this.halfWid, rz * this.halfWid);
+    const rh = at(-rx * this.halfWid, -rz * this.halfWid);
+    this.pitch = Math.atan2(bh - fh, this.halfLen * 2);
+    this.roll = Math.atan2(rh - lh, this.halfWid * 2);
     this.sync();
   }
 

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -5,7 +5,7 @@ import * as THREE from './three.js';
 import * as G from './geo.js';
 import { CHUNK, ROAD_LIFT, NODE_LIFT, WALK_LIFT } from './citygen.js';
 import { Builder } from './build.js';
-import { hash2, clamp, lerp } from './util.js';
+import { hash2, clamp, lerp, distToSeg } from './util.js';
 
 const ROAD_Y = ROAD_LIFT;
 const NODE_Y = NODE_LIFT;
@@ -369,7 +369,12 @@ export class World {
   meshRoad(road, walk, flat, e, a, b, lod, ei) {
     const hw = e.hw;
     const px = -e.dz, pz = e.dx;
-    const steps = e.elev ? 1 : Math.max(1, Math.round(e.len / 16));
+    // Elevated spans get subdivided too. A barrier is a box that can only yaw,
+    // so on a climbing ramp it stays level while the deck rises away from it:
+    // one box over a 117 m span puts its ends tens of metres above and below
+    // the road, which is the white spears sticking out of the freeway. Short
+    // segments keep each box close to the deck it belongs to.
+    const steps = Math.max(1, Math.round(e.len / (e.elev ? 12 : 16)));
     const col = e.cls === 'hwy' ? [0.92, 0.92, 0.92] : [1, 1, 1];
     let v = 0;
     const yAt = (x, z, t) => (e.elev ? lerp(a.y, b.y, t) + 0.06 : G.terrainHeight(x, z) + ROAD_Y);
@@ -400,8 +405,13 @@ export class World {
     if (e.elev) {
       const bcol = [0.62, 0.62, 0.6];
       const along = Math.atan2(e.dx, e.dz);
-      for (let s = 0; s <= steps; s++) {
-        const t = s / steps;
+      // Barriers run along each SEGMENT, so they are centred on segment
+      // midpoints. Centring them on the endpoints instead (s <= steps, t =
+      // s/steps) gives every deck two barriers as long as the whole span, each
+      // overhanging its end by half a span -- which is where the white spears
+      // shooting off the freeway came from.
+      for (let s = 0; s < steps; s++) {
+        const t = (s + 0.5) / steps;
         const x = lerp(a.x, b.x, t), z = lerp(a.z, b.z, t), y = lerp(a.y, b.y, t);
         for (const sg of [-1, 1]) {
           flat.box(x + px * hw * sg, y - 0.1, z + pz * hw * sg, 0.55, 1.05, e.len / steps + 0.5, along, bcol);
@@ -409,11 +419,16 @@ export class World {
             e.len / steps + 0.5, along, [0.7, 0.71, 0.72]);
         }
       }
-      const gy = G.terrainHeight((a.x + b.x) / 2, (a.z + b.z) / 2);
-      const my = (a.y + b.y) / 2;
-      if (my - gy > 5) {
-        flat.prism((a.x + b.x) / 2, gy - 1, (a.z + b.z) / 2, 1.7, my - gy - 1.6, 6, [0.58, 0.58, 0.56]);
-        flat.box((a.x + b.x) / 2, my - 1.6, (a.z + b.z) / 2, hw * 1.5, 1.1, 2.4, along, [0.54, 0.54, 0.52]);
+      // Piers roughly every 35 m rather than one per span, whatever the span's
+      // length -- a 117 m viaduct on a single column reads as a mistake.
+      const piers = Math.max(1, Math.round(e.len / 35));
+      for (let p = 0; p < piers; p++) {
+        const t = (p + 0.5) / piers;
+        const cx = lerp(a.x, b.x, t), cz = lerp(a.z, b.z, t), cy = lerp(a.y, b.y, t);
+        const gy = G.terrainHeight(cx, cz);
+        if (cy - gy <= 5) continue;
+        flat.prism(cx, gy - 1, cz, 1.7, cy - gy - 1.6, 6, [0.58, 0.58, 0.56]);
+        flat.box(cx, cy - 1.6, cz, hw * 1.5, 1.1, 2.4, along, [0.54, 0.54, 0.52]);
       }
     } else if (lod === 1 && (e.cls === 'st' || e.cls === 'art' || e.cls === 'res')) {
       const sw = e.cls === 'art' ? 3.2 : 2.6;
@@ -474,6 +489,11 @@ export class World {
 
   meshNode(road, flat, ni, n, lod, walk) {
     const city = this.city;
+    // A dead end is not a junction. Paving a crossing square and a kerbed
+    // pavement ring at one leaves a slab of road furniture sitting on bare
+    // ground with a single street running into it -- the "road to nowhere".
+    // citygen.nodeSurface() skips these too; the two have to agree.
+    if (n.e.length < 2) return;
     let hw = 0;
     let rot = 0;
     let sw = 0;
@@ -504,21 +524,41 @@ export class World {
     const wy = (x, z) => G.terrainHeight(x, z) + WALK_Y;
     const ry = (x, z) => G.terrainHeight(x, z) + ROAD_Y;
     const cc = [0.72, 0.72, 0.7], ccLo = [0.4, 0.4, 0.39];
+    // Pavement must not cross a carriageway. Each side of the ring is cut into
+    // pieces and the pieces covering an approach road are dropped, which leaves
+    // pavement on the corners only -- drawn whole, the ring laid a footpath
+    // straight over all four approaches, the same defect the trimmed strips
+    // were meant to have fixed.
+    const onRoad = (x, z) => {
+      for (const ei of n.e) {
+        const e = city.edges[ei];
+        if (e.elev) continue;
+        const ea = city.nodes[e.a], eb = city.nodes[e.b];
+        if (distToSeg(x, z, ea.x, ea.z, eb.x, eb.z).d <= e.hw + 0.35) return true;
+      }
+      return false;
+    };
+    const SEG = 16;
     const side = (ax, az, bx, bz, nx, nz) => {
-      // inner edge a->b, pushed out by sw to make the outer edge
-      const [i0x, i0z] = P(ax, az), [i1x, i1z] = P(bx, bz);
-      const [o0x, o0z] = P(ax + nx * sw, az + nz * sw);
-      const [o1x, o1z] = P(bx + nx * sw, bz + nz * sw);
-      if (!G.isBuildable(o0x, o0z) && !G.isBuildable(o1x, o1z)) return;
-      walk.quad(
-        [i0x, wy(i0x, i0z), i0z], [o0x, wy(o0x, o0z), o0z],
-        [o1x, wy(o1x, o1z), o1z], [i1x, wy(i1x, i1z), i1z],
-        [0, 1, 0], [0, 0, 1, 0, 1, 1, 0, 1], [1, 1, 1]);
       const wn = [-(nx * c - nz * s), 0, -(nx * s + nz * c)];
-      flat.quad(
-        [i0x, ry(i0x, i0z), i0z], [i1x, ry(i1x, i1z), i1z],
-        [i1x, wy(i1x, i1z), i1z], [i0x, wy(i0x, i0z), i0z],
-        wn, [0, 0, 1, 0, 1, 1, 0, 1], [ccLo, ccLo, cc, cc]);
+      for (let k = 0; k < SEG; k++) {
+        const t0 = k / SEG, t1 = (k + 1) / SEG;
+        const sax = ax + (bx - ax) * t0, saz = az + (bz - az) * t0;
+        const sbx = ax + (bx - ax) * t1, sbz = az + (bz - az) * t1;
+        const [i0x, i0z] = P(sax, saz), [i1x, i1z] = P(sbx, sbz);
+        const [o0x, o0z] = P(sax + nx * sw, saz + nz * sw);
+        const [o1x, o1z] = P(sbx + nx * sw, sbz + nz * sw);
+        if (!G.isBuildable(o0x, o0z) && !G.isBuildable(o1x, o1z)) continue;
+        if (onRoad((i0x + o1x) / 2, (i0z + o1z) / 2)) continue;
+        walk.quad(
+          [i0x, wy(i0x, i0z), i0z], [o0x, wy(o0x, o0z), o0z],
+          [o1x, wy(o1x, o1z), o1z], [i1x, wy(i1x, i1z), i1z],
+          [0, 1, 0], [0, 0, 1, 0, 1, 1, 0, 1], [1, 1, 1]);
+        flat.quad(
+          [i0x, ry(i0x, i0z), i0z], [i1x, ry(i1x, i1z), i1z],
+          [i1x, wy(i1x, i1z), i1z], [i0x, wy(i0x, i0z), i0z],
+          wn, [0, 0, 1, 0, 1, 1, 0, 1], [ccLo, ccLo, cc, cc]);
+      }
     };
     const R = hw;
     side(-R, R, R, R, 0, 1);

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -16,7 +16,7 @@
 // fetches by URL with cache:'no-cache' — WebKit rejects fetch() of a
 // navigation-mode Request, which would silently kill the refresh of './' on
 // iOS, and no-cache skips GitHub Pages' 10-minute heuristic.
-const CACHE = 'auto-v15';
+const CACHE = 'auto-v16';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];


### PR DESCRIPTION
v15 → **v16**. Rendered the city and went looking. Six defects, each measured before and after.

## Roads sunk into Lake Union

**182 ground-level road edges ran under water.** Lake Union alone had four arterials through it — Aurora, Westlake, Dexter, Fairview — at 4 to 9 m below the surface. Delridge Way ran through Elliott Bay.

| road | edges submerged | terrain Y |
|---|---|---|
| Delridge Way SW | 36 | −9.0 |
| Westlake Ave N | 28 | −7.5 |
| Dexter Ave N | 27 | −8.8 |
| Aurora Ave N (SR 99) | 25 | −4.0 |
| …11 more | 66 | |

`chain()` now refuses to lay a ground-level edge whose midpoint is over water. A span meant to cross water is marked elevated in the data and is untouched.

| | before | after |
|---|---|---|
| edges over water | 182 | **0** |
| largest connected component | 98.1% | **98.4%** |

Connectivity went *up* — those edges only ever joined things across a lake.

## Sunken cars on Queen Anne

`Vehicle.place()` set height but never attitude, and a parked car never runs `update()` — so it stayed dead level on a hillside and its downhill end went into the road. On the steepest Queen Anne street (20% grade) a parked car now reports **pitch −0.2 rad**, which is `atan(0.2)`. It was getting zero.

## Pavement laid across the roadway at every junction

The ring `meshNode` draws to fill the corners was drawn as four whole sides, so it ran a footpath **straight over all four approach roads** — the same defect the trimmed strips were meant to have fixed, in ring form. Each side is now cut into pieces and the pieces covering an approach are dropped, leaving pavement on the corners only.

## Road to nowhere

A dead end got the full treatment — crossing square, kerbs, pavement ring — sitting on bare ground with one street running into it. `meshNode` returns early below degree 2, and `nodeSurface()` skips the same nodes so the lift query keeps agreeing with what's drawn.

## White spears sticking out of the freeway

Elevated spans were meshed at `steps = 1`. A barrier is a box that can only yaw, so one box over a 117 m climbing span sits level at mid-height while the deck rises away from it — its ends stab tens of metres above and below the road. Elevated edges are subdivided like any other road now, and piers go every ~35 m instead of one per span regardless of length.

Verified from close renders alongside and straight down a deck.

## A measurement note

The "long thin triangle" probe I reached for first is **useless** for bridge geometry: a pier is legitimately 30 m tall and 1.7 m wide, so it trips any aspect-ratio filter and reports a large count whether or not anything is wrong. Deck geometry has to be judged from a close render. That's in CLAUDE.md so I don't repeat it.

## Verification

Regressions unchanged: 0 crossings without a junction, 200/200 junction surfaces, 0 buildings in the roadway, land/water probe passes. Parked cars on the flat were checked and were already seated correctly — the Queen Anne fix is about slope only.

## Still open

Everything above except the parked-car attitude is a *symptom* of the polyline drift documented in CLAUDE.md. Roads in a lake is that drift at its most visible; the guard means it can't render underwater again, but Westlake and Fairview still don't run where they should. The reference-map work is what fixes the cause.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6uJPyarVs2ggkt3wXg12N)_