### PR TITLE
Rebuild viaducts from mitred edge lines, and put Aurora back on land

### DIFF
--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -614,15 +614,35 @@ Otherwise a single street running out to nothing gets a full crossing square and
 a kerbed ring sitting on bare ground — the "road to nowhere". `nodeSurface()`
 skips the same nodes, because the drawn surface and the lift query have to agree.
 
-**Elevated spans get subdivided like any other road.** A barrier is a box that
-can only yaw, so on a climbing ramp it stays level while the deck rises away
-from it. At `steps = 1` a 117 m span drew one 117 m barrier centred at
-mid-height, stabbing tens of metres above and below the road — the white spears
-sticking out of the freeway. Piers are placed every ~35 m along the span rather
-than one per edge.
+**An elevated span is built from two mitred edge lines, not from boxes.**
+`meshViaduct` offsets each side of the deck at the *node*, and where two spans
+meet head to head it mitres them onto one shared point (`deckEdgePoint`). Deck,
+soffit, fascia and parapet are all lofted between those same four corners, so
+they stay registered with each other and with the neighbouring span by
+construction.
+
+The version this replaced drew a barrier as a `box` per 12 m segment, and a box
+can only yaw. Two consequences, both of which were reported as bugs:
+
+- On a climbing ramp the box stays level while the deck rises away from it. At
+  `steps = 1` a 117 m span drew one 117 m barrier centred at mid-height,
+  stabbing tens of metres above and below the road — the white spears sticking
+  out of the freeway.
+- Each span offset its rails by *its own* perpendicular, so at a bend the two
+  spans' rails started at different points and different angles: "the guardrails
+  are slightly angled so they don't touch back to front". Subdividing does not
+  fix this — the splay is at the joint, not along the span.
+
+**A junction square at an elevated node fights the deck.** The square is
+horizontal at `n.y + 0.07`; a sloping deck passes through it. `meshNode` skips
+the node where two same-width elevated spans meet at under 60°, because the
+mitre has already closed that joint. A ramp merge keeps its square: there the
+spans are square-ended and the square is what fills the gap. `nodeSurface()`
+already skips `n.elev` entirely, so this costs nothing on the lift side —
+elevated ground comes from `groundAt`'s per-segment deck query.
 
 Note the "long thin triangle" probe is *not* diagnostic here: a pier is
-legitimately 30 m tall and 1.7 m wide, so it trips any aspect-ratio filter. Judge
+legitimately 30 m tall and 2.4 m wide, so it trips any aspect-ratio filter. Judge
 deck geometry from a close render alongside and down the deck.
 
 ## Nothing stands on the water, and parked cars sit on the slope
@@ -634,6 +654,35 @@ at 4 to 9 m below the surface, and Delridge Way through Elliott Bay: 182 edges
 in all. A span meant to cross water is marked elevated in the data and is left
 alone. Absent beats submerged, and connectivity went *up* (98.1% → 98.4%),
 because those edges only ever connected things across a lake.
+
+**Dropping the edge is damage control, not a fix.** The route still has a hole
+in it, and if the hole happens to sit at the end of a deck, the viaduct ramps
+down into open water — which is what Aurora did: 1.3 km of it was drawn through
+Lake Union at ground level, the ship-canal third of that was the only part
+marked elevated, and the bridge's south end touched down 200 m offshore. You
+could not drive the length of the map on the one road that is meant for it.
+Measured as the longest gap between consecutive nodes on the route, Aurora went
+**949 m → 76 m** (55 m is the normal node spacing).
+
+`city.waterDrops` records every edge dropped this way, so the condition can be
+asserted on instead of being discovered by driving into a lake. **A named
+through route is not allowed to appear in it.** Thirteen still do — Westlake,
+Dexter, Fairview, Eastlake, Delridge, Alaskan Way and others.
+
+**The lakes are where they are; move the road.** Lake Union is drawn about
+600 m west of its converted position, which is the whole reason its shore roads
+end up in it, but shifting the polygon east would put 0.8 km² of built South
+Lake Union and Eastlake under water — the Magnolia failure again, in the
+direction that actually destroys a neighbourhood. Shrinking water is safe;
+growing it is not. Aurora was re-routed instead, into the empty 580 m strip
+between the west shore (x ≈ −880) and Queen Anne Ave N (−1460), which is also
+where the real road sits relative to the water.
+
+The exception is Green Lake, where Aurora now passes **east** and the real road
+passes west. Going west means threading between the lake's west shore (−1500)
+and Phinney Ave N (−1690), and the north–south compression out here — Green
+Lake to the Aurora Bridge is 3.7 km in reality and about 700 m on this map —
+turns that into a 64° dogleg. The wrong side of a lake beats a hairpin.
 
 **`Vehicle.place()` sets pitch and roll, not just height.** A parked car never
 runs `update()`, so left at zero pitch it stays level on a hillside street and

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -321,7 +321,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v16</div>
+    <div id="build">v17</div>
   </div>
 
   <div id="rotate">

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -251,6 +251,7 @@ function planarize(g) {
 export function* cityGenerator() {
   const g = new Graph();
   const buildings = [];
+  const waterDrops = [];
   const reserved = [];
   const R = rng(20260725);
 
@@ -345,6 +346,12 @@ export function* cityGenerator() {
           const wet = !elev && !p.elev
             && G.isWater((p.x + x) / 2, (p.z + z) / 2);
           if (!wet) g.addEdge(prev, id, cls, name);
+          // Dropping it is damage control, not a fix: the route still has a
+          // hole in it, and if the gap happens to sit at the end of a deck the
+          // viaduct ramps down into open water. Aurora was 1.3 km of exactly
+          // that. Record every drop so `city.waterDrops` can be asserted on --
+          // a named through route is not allowed to lose a segment this way.
+          else waterDrops.push({ name, cls, x, z });
         }
         prev = id;
       }
@@ -685,6 +692,7 @@ export function* cityGenerator() {
     nodes: g.nodes,
     edges: g.edges,
     buildings,
+    waterDrops,
     chunks,
     chunkKey: ck,
     drivable,

--- a/apps/auto/src/geo.js
+++ b/apps/auto/src/geo.js
@@ -468,10 +468,27 @@ export const HIGHWAYS = [
     ],
   },
   {
+    // Aurora ran through Green Lake and then straight down the middle of Lake
+    // Union, and only the ship-canal third of that was marked elevated -- so
+    // chain() dropped 1.3 km of it as submerged and the viaduct's south end
+    // ramped down into open water. Absent is better than sunk, but for a
+    // through route neither is acceptable: this is the one road you are
+    // supposed to be able to drive the whole length of the map on.
+    //
+    // The lakes are where they are; the road moved. South of the canal it now
+    // runs the empty strip between the west shore (x about -880) and Queen
+    // Anne Ave N (-1460), which is also where the real road is relative to the
+    // water. At Green Lake it passes east instead of west, which is the wrong
+    // side -- the lake polygon sits about 600 m west of its converted position
+    // and passing west would put the road on top of Phinney Ave N.
     name: 'Aurora Ave N (SR 99)', cls: 'hwy', lanes: 6,
     pts: [
-      [-960, -5150], [-940, -4500], [-900, -4180], [-870, -4100, 46], [-850, -3600, 52],
-      [-830, -3200, 46], [-800, -2900], [-760, -2400], [-700, -1900], [-640, -1500],
+      [-880, -5150], [-720, -4820], [-710, -4620], [-800, -4380], [-870, -4230],
+      // the Aurora Bridge and its approach viaducts: the canal is 310 m wide
+      // here and both ends of the elevated run have to touch down on dry land
+      [-880, -4150, 44], [-905, -3830, 50], [-925, -3600, 52], [-965, -3360, 44],
+      [-1010, -3050], [-1030, -2700], [-1020, -2350], [-960, -1980], [-820, -1700],
+      [-640, -1500],
     ],
   },
   {
@@ -544,7 +561,8 @@ export const ARTERIALS = [
   { name: 'NW Market St', pts: [[-4300, -4080], [-3800, -4070], [-3450, -4060], [-3000, -4050], [-2600, -4040]] },
   { name: '15th Ave NW', pts: [[-3450, -3980], [-3460, -4400], [-3470, -4900], [-3480, -5150]] },
   { name: 'Leary Way NW', pts: [[-2600, -4040], [-2200, -4000], [-1900, -3960], [-1750, -3940]] },
-  { name: 'Aurora Ave N (north)', pts: [[-960, -5150], [-950, -4700], [-945, -4400]] },
+  // The frontage road beside Aurora, so it clears Green Lake on the same side.
+  { name: 'Aurora Ave N (north)', pts: [[-620, -5150], [-560, -4800], [-570, -4500], [-640, -4250]] },
   { name: 'Greenwood Ave N', pts: [[-1900, -5150], [-1890, -4700], [-1880, -4380]] },
   { name: 'Phinney Ave N', pts: [[-1700, -5150], [-1690, -4700], [-1680, -4200], [-1690, -3960]] },
   { name: 'Roosevelt Way NE', pts: [[1200, -5150], [1210, -4700], [1220, -4200], [1230, -3800], [1150, -3600]] },

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -366,18 +366,147 @@ export class World {
 
   // --- road surfaces --------------------------------------------------------
 
+  /**
+   * Where a deck edge passes at a node, mitred into the next span.
+   *
+   * Offsetting each span by its own perpendicular leaves two spans meeting a
+   * bend at different points and different angles, so their guardrails end up
+   * splayed and never touch. Mitreing runs both spans' edges through one shared
+   * point, which is what makes the rail continuous around a curve.
+   */
+  deckEdgePoint(ni, e, sg, w) {
+    const city = this.city;
+    const n = city.nodes[ni];
+    let ox = -e.dz * sg, oz = e.dx * sg;
+    let dist = w;
+    let other = null, count = 0;
+    for (const oi of n.e) {
+      const o = city.edges[oi];
+      if (!o.elev || o === e) continue;
+      other = o; count++;
+    }
+    // Only a simple two-span joint can be mitred; a ramp merge has no single
+    // continuation to aim at, so it keeps the square end.
+    if (count === 1 && Math.abs(other.hw - e.hw) < 0.01) {
+      let qx = -other.dz * sg, qz = other.dx * sg;
+      if (qx * ox + qz * oz < 0) { qx = -qx; qz = -qz; }
+      let mx = ox + qx, mz = oz + qz;
+      const ml = Math.hypot(mx, mz);
+      if (ml > 1e-3) {
+        mx /= ml; mz /= ml;
+        const cos = mx * ox + mz * oz;
+        // A hairpin would send the mitre off to infinity; keep the square end.
+        if (cos > 0.5) { ox = mx; oz = mz; dist = w / cos; }
+      }
+    }
+    return [n.x + ox * dist, n.z + oz * dist];
+  }
+
+  /**
+   * An elevated span: deck, edge beam, parapets and piers.
+   *
+   * Everything is built off the same two mitred edge lines, so the deck, its
+   * beam and the rail on top of it stay registered with each other and with the
+   * neighbouring span. Barriers used to be independent boxes centred on segment
+   * midpoints, which is why they didn't line up end to end.
+   */
+  meshViaduct(road, flat, e, a, b) {
+    const GIRDER = 1.35;  // structural depth below the running surface
+    const PARAPET = 0.55; // parapet wall thickness, inboard of the deck edge
+    const RAIL = 0.95;    // parapet height above the running surface
+    const conc = [0.68, 0.68, 0.66], concLo = [0.5, 0.5, 0.49];
+    const soffit = [0.42, 0.42, 0.41];
+    const ay = a.y + 0.06, by = b.y + 0.06;
+    const hw = e.hw;
+    const along = Math.atan2(e.dx, e.dz);
+
+    // Two mitred offset lines per side: the running-surface edge, where the
+    // parapet stands, and the deck edge outboard of it. Keeping the carriageway
+    // at the full `hw` means a viaduct is as wide to drive as the street it
+    // continues, instead of losing a metre to its own walls.
+    const run = {}, deck = {};
+    for (const sg of [-1, 1]) {
+      const [rsx, rsz] = this.deckEdgePoint(e.a, e, sg, hw);
+      const [rex, rez] = this.deckEdgePoint(e.b, e, sg, hw);
+      run[sg] = { sx: rsx, sz: rsz, ex: rex, ez: rez };
+      const [dsx, dsz] = this.deckEdgePoint(e.a, e, sg, hw + PARAPET);
+      const [dex, dez] = this.deckEdgePoint(e.b, e, sg, hw + PARAPET);
+      deck[sg] = { sx: dsx, sz: dsz, ex: dex, ez: dez };
+    }
+
+    // Running surface, corner to corner off the mitred edges. One quad for the
+    // whole span: it is planar, so it can't stair-step the way the old
+    // per-segment boxes did.
+    const L = run[1], R = run[-1];
+    const vLen = e.len / (hw * 2);
+    road.quad(
+      [L.sx, ay, L.sz], [R.sx, ay, R.sz], [R.ex, by, R.ez], [L.ex, by, L.ez],
+      [0, 1, 0], [0, 0, 1, 0, 1, vLen, 0, vLen],
+      e.cls === 'hwy' ? [0.92, 0.92, 0.92] : [1, 1, 1]);
+
+    // Soffit, so the deck reads as a box girder rather than a sheet of paper.
+    const DL = deck[1], DR = deck[-1];
+    flat.quad(
+      [DR.sx, ay - GIRDER, DR.sz], [DL.sx, ay - GIRDER, DL.sz],
+      [DL.ex, by - GIRDER, DL.ez], [DR.ex, by - GIRDER, DR.ez],
+      [0, -1, 0], [0, 0, 1, 0, 1, 1, 0, 1], soffit);
+
+    for (const sg of [-1, 1]) {
+      const r = run[sg], d = deck[sg];
+      const ox = -e.dz * sg, oz = e.dx * sg;       // outward across the deck
+      // Fascia: girder and parapet in one plane, running the full length of the
+      // span between the mitred corners. Because both ends are the mitre point
+      // its neighbour also uses, consecutive spans meet edge to edge instead of
+      // each being splayed off its own perpendicular.
+      flat.quad(
+        [d.sx, ay - GIRDER, d.sz], [d.ex, by - GIRDER, d.ez],
+        [d.ex, by + RAIL, d.ez], [d.sx, ay + RAIL, d.sz],
+        [ox, 0, oz], [0, 0, 1, 0, 1, 1, 0, 1], [concLo, concLo, conc, conc]);
+      // Capping over the wall.
+      flat.quad(
+        [d.sx, ay + RAIL, d.sz], [d.ex, by + RAIL, d.ez],
+        [r.ex, by + RAIL, r.ez], [r.sx, ay + RAIL, r.sz],
+        [0, 1, 0], [0, 0, 1, 0, 1, 1, 0, 1], conc);
+      // Inner face, facing the traffic.
+      flat.quad(
+        [r.sx, ay, r.sz], [r.ex, by, r.ez],
+        [r.ex, by + RAIL, r.ez], [r.sx, ay + RAIL, r.sz],
+        [-ox, 0, -oz], [0, 0, 1, 0, 1, 1, 0, 1], [concLo, concLo, conc, conc]);
+    }
+
+    // Piers on a realistic bay. One slender post per span, whatever the span's
+    // length, read as scaffolding under a 30 m deck; a bent is a plinth, a
+    // stout column and a cap spanning the full deck width.
+    const bays = Math.max(1, Math.round(e.len / 52));
+    for (let p = 0; p < bays; p++) {
+      const t = (p + 0.5) / bays;
+      const cx = lerp(a.x, b.x, t), cz = lerp(a.z, b.z, t), cy = lerp(ay, by, t);
+      const capTop = cy - GIRDER;
+      let base = G.terrainHeight(cx, cz);
+      if (capTop - base <= 4) continue;
+      if (G.isWater(cx, cz)) {
+        // A column rising straight out of the lake looks unfounded. Break the
+        // surface with a pile cap and start the shaft on top of it.
+        flat.prism(cx, base, cz, 4.2, 1.4 - base, 8, concLo);
+        flat.box(cx, 1.4, cz, 9.4, 0.55, 9.4, along, conc);
+        base = 1.95;
+      } else {
+        flat.prism(cx, base - 1.2, cz, 3.2, 1.7, 8, concLo);   // plinth
+        base += 0.3;
+      }
+      flat.prism(cx, base, cz, 2.4, capTop - 1.8 - base, 8, conc);            // shaft
+      flat.box(cx, capTop - 1.8, cz, (hw + PARAPET) * 1.9, 1.8, 3.6, along, concLo); // cap
+    }
+  }
+
   meshRoad(road, walk, flat, e, a, b, lod, ei) {
+    if (e.elev) { this.meshViaduct(road, flat, e, a, b); return; }
     const hw = e.hw;
     const px = -e.dz, pz = e.dx;
-    // Elevated spans get subdivided too. A barrier is a box that can only yaw,
-    // so on a climbing ramp it stays level while the deck rises away from it:
-    // one box over a 117 m span puts its ends tens of metres above and below
-    // the road, which is the white spears sticking out of the freeway. Short
-    // segments keep each box close to the deck it belongs to.
-    const steps = Math.max(1, Math.round(e.len / (e.elev ? 12 : 16)));
+    const steps = Math.max(1, Math.round(e.len / 16));
     const col = e.cls === 'hwy' ? [0.92, 0.92, 0.92] : [1, 1, 1];
     let v = 0;
-    const yAt = (x, z, t) => (e.elev ? lerp(a.y, b.y, t) + 0.06 : G.terrainHeight(x, z) + ROAD_Y);
+    const yAt = (x, z) => G.terrainHeight(x, z) + ROAD_Y;
     for (let s = 0; s < steps; s++) {
       const t0 = s / steps, t1 = (s + 1) / steps;
       const x0 = lerp(a.x, b.x, t0), z0 = lerp(a.z, b.z, t0);
@@ -392,45 +521,17 @@ export class World {
       // Don't pave over a road that outranks this one. Where two carriageways
       // overlap, both used to draw and the depth buffer chose per pixel, which
       // is what made the centre line flicker between one stripe and two.
-      if (!e.elev && ei != null
+      if (ei != null
         && this.city.roadCoveredAt((x0 + x1) / 2, (z0 + z1) / 2, ei)) continue;
       road.quad(
-        [l0x, yAt(l0x, l0z, t0), l0z],
-        [r0x, yAt(r0x, r0z, t0), r0z],
-        [r1x, yAt(r1x, r1z, t1), r1z],
-        [l1x, yAt(l1x, l1z, t1), l1z],
+        [l0x, yAt(l0x, l0z), l0z],
+        [r0x, yAt(r0x, r0z), r0z],
+        [r1x, yAt(r1x, r1z), r1z],
+        [l1x, yAt(l1x, l1z), l1z],
         [0, 1, 0], [0, v0, 1, v0, 1, v1, 0, v1], col
       );
     }
-    if (e.elev) {
-      const bcol = [0.62, 0.62, 0.6];
-      const along = Math.atan2(e.dx, e.dz);
-      // Barriers run along each SEGMENT, so they are centred on segment
-      // midpoints. Centring them on the endpoints instead (s <= steps, t =
-      // s/steps) gives every deck two barriers as long as the whole span, each
-      // overhanging its end by half a span -- which is where the white spears
-      // shooting off the freeway came from.
-      for (let s = 0; s < steps; s++) {
-        const t = (s + 0.5) / steps;
-        const x = lerp(a.x, b.x, t), z = lerp(a.z, b.z, t), y = lerp(a.y, b.y, t);
-        for (const sg of [-1, 1]) {
-          flat.box(x + px * hw * sg, y - 0.1, z + pz * hw * sg, 0.55, 1.05, e.len / steps + 0.5, along, bcol);
-          flat.box(x + px * (hw - 0.25) * sg, y + 0.95, z + pz * (hw - 0.25) * sg, 0.13, 0.5,
-            e.len / steps + 0.5, along, [0.7, 0.71, 0.72]);
-        }
-      }
-      // Piers roughly every 35 m rather than one per span, whatever the span's
-      // length -- a 117 m viaduct on a single column reads as a mistake.
-      const piers = Math.max(1, Math.round(e.len / 35));
-      for (let p = 0; p < piers; p++) {
-        const t = (p + 0.5) / piers;
-        const cx = lerp(a.x, b.x, t), cz = lerp(a.z, b.z, t), cy = lerp(a.y, b.y, t);
-        const gy = G.terrainHeight(cx, cz);
-        if (cy - gy <= 5) continue;
-        flat.prism(cx, gy - 1, cz, 1.7, cy - gy - 1.6, 6, [0.58, 0.58, 0.56]);
-        flat.box(cx, cy - 1.6, cz, hw * 1.5, 1.1, 2.4, along, [0.54, 0.54, 0.52]);
-      }
-    } else if (lod === 1 && (e.cls === 'st' || e.cls === 'art' || e.cls === 'res')) {
+    if (lod === 1 && (e.cls === 'st' || e.cls === 'art' || e.cls === 'res')) {
       const sw = e.cls === 'art' ? 3.2 : 2.6;
       // Stop short of each intersection: a strip run end to end would march
       // straight across the cross street. The corner is filled by meshNode.
@@ -494,6 +595,16 @@ export class World {
     // ground with a single street running into it -- the "road to nowhere".
     // citygen.nodeSurface() skips these too; the two have to agree.
     if (n.e.length < 2) return;
+    // Two elevated spans meeting head to head are already mitred into one
+    // another by meshViaduct, so a crossing square here is a horizontal patch
+    // laid across a sloping deck -- it pokes through on the uphill side and
+    // hangs in the air on the downhill one. A ramp merge keeps its square:
+    // there the spans are square-ended and the square is what closes the gap.
+    if (n.elev && n.e.length === 2) {
+      const e0 = city.edges[n.e[0]], e1 = city.edges[n.e[1]];
+      if (e0.elev && e1.elev && Math.abs(e0.hw - e1.hw) < 0.01
+        && Math.abs(e0.dx * e1.dx + e0.dz * e1.dz) > 0.5) return;
+    }
     let hw = 0;
     let rot = 0;
     let sw = 0;

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -16,7 +16,7 @@
 // fetches by URL with cache:'no-cache' — WebKit rejects fetch() of a
 // navigation-mode Request, which would silently kill the refresh of './' on
 // iOS, and no-cache skips GitHub Pages' 10-minute heuristic.
-const CACHE = 'auto-v16';
+const CACHE = 'auto-v17';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];


### PR DESCRIPTION
Build **v17**.

## The guardrails didn't line up

Each span offset its rails by *its own* perpendicular, so where two spans met at a bend they started their rails at different points and at different angles — splayed, never touching back to front. Subdividing the span doesn't help: the splay is at the joint, not along the span.

`meshViaduct` now offsets at the **node** and mitres two spans onto one shared point (`deckEdgePoint`), then lofts deck, soffit, fascia and parapet between the same four corners. Everything stays registered by construction.

This also retires the per-segment barrier boxes. A box can only yaw, so on a climbing ramp it stayed level while the deck rose away from it. Side effect: a 117 m span drops from ~240 quads of barrier to 8.

## The deck reads as a structure now

- 1.35 m girder depth with a soffit, instead of a sheet of paper
- fascia running girder and parapet in one plane
- carriageway kept at full width — the parapet sits on a deck overhang rather than eating a metre of road
- piers on a 52 m bay with a cap spanning the deck and a plinth, instead of one slender post per span whatever its length
- **a pile cap breaking the surface** where a pier stands in water, so columns aren't rising unfounded out of the lake
- no crossing square where two elevated spans meet head to head — it's horizontal and the deck isn't, so it poked through on the uphill side

## Aurora dipped into Lake Union

Aurora was drawn through the lake for **1.3 km at ground level**, with only the ship-canal third marked elevated. `chain()` dropped those edges as submerged (correctly — better absent than sunk), which left a hole in the route *and* left the viaduct's south end ramping down into open water. There was no way to drive the length of the map on the one road meant for it.

Longest gap between consecutive nodes on the route: **949 m → 76 m** (normal node spacing is 55 m).

The lake polygon is the thing actually out of place — it sits ~600 m west of its converted position — but moving it east would put **0.8 km² of built South Lake Union and Eastlake under water**, which is the Magnolia failure in the direction that destroys a neighbourhood. Shrinking water is safe; growing it is not. So the road moved: south of the canal it runs the empty 580 m strip between the west shore (x ≈ −880) and Queen Anne Ave N (−1460), which is also where the real road sits relative to the water.

One honest compromise: at Green Lake, Aurora now passes **east** and the real road passes west. Going west means threading between the lake's west shore and Phinney Ave N, and the map's north–south compression (Green Lake to the Aurora Bridge is 3.7 km in reality, ~700 m here) turns that into a 64° dogleg. Wrong side of a lake beats a hairpin. Documented in `apps/auto/CLAUDE.md`.

## A guard for the class of bug

`city.waterDrops` records every edge dropped for water, so this is assertable instead of discoverable by driving into a lake. **Thirteen named roads are still in it** — Westlake, Dexter, Fairview, Eastlake, Delridge Way, Alaskan Way, 15th Ave W, Elliott Ave W, Denny Way, Magnolia Blvd W, E Marginal Way, S Holgate, SR 99 — all the same shoreline drift. Not touched here; each needs the same treatment Aurora just got, and doing them blind risks cramming parallel carriageways into the same strip.

## Verification

Rendered the Aurora and Lake Union viaducts from side-on, from below, down the deck, three-quarter and at deck edge, plus both touchdowns. Regressions measured against `master` with the same script:

| | master | this branch |
|---|---|---|
| Aurora longest node gap | 949 m | **76 m** |
| Aurora edges in graph | 43 | 79 |
| Aurora edges dropped for water | 27 | **0** |
| crossings without a junction | 4 | 4 |
| buildings sampled in the roadway | 0 | 0 |
| land/water probe (Magnolia dry, Elliott Bay wet) | pass | pass |
| console / page errors | none | none |

The one deck end flagged over water is the Fremont Bridge touchdown, unchanged from master: it's 2 m from dry land with terrain at 12.8 m, i.e. on the bank, where the shoreline polygon overlaps it. Not a defect.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6uJPyarVs2ggkt3wXg12N)_