### PR TITLE
Make the map read as a city from above

### DIFF
--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -268,6 +268,63 @@ split leaves behind.
 To check both at once, count ground-level segment intersections whose edges
 share no node. It must be zero.
 
+## What the map looks like from above
+
+Rendering the whole graph top-down is the cheapest way to find this class of
+bug, and none of it is visible at street level. Dump `__dbg.city` to JSON and
+draw it on a canvas — water, roads by class, degree-1 nodes in red, and any
+component that isn't the largest in magenta. Four things it turned up, all now
+fixed, all worth re-checking after any change to geo.js:
+
+**Water has to be one system.** The ship canal's west end stopped 177 m short of
+Elliott Bay, so no boat could get from the sound to Lake Washington and the
+canal read as a rectangular pond dropped on a lawn. It was also a six-point
+box — straight sides, square ends, one width for 3.4 km. Assert it: union the
+water polygons by intersection and count the groups. **Two** is correct — the
+chain, and Green Lake, which really is landlocked.
+
+**Editing a water polygon is still the dangerous edit.** Every vertex east of
+the bay was moved onto or inside the old outline so the shape could only lose
+water; the one place it gains is the west end, which is the point, and it
+crosses Ballard's western 100 m to reach the sea. Diff the land/water grid both
+ways and check no district loses ground it had buildings on.
+
+**A road that stops in a field is a data artefact, not a cul-de-sac.** The
+polylines end wherever the author stopped drawing: 99 dead ends inside the map,
+74 of them arterials, plus seven pockets of grid — Pioneer Square's 27 nodes,
+all of Harbor Island, the whole University Bridge — with no route to the rest of
+the city. `stitch()` welds a loose end to a node within 75 m, bridges a stranded
+component to the main one within 190 m, and trims what's left under 55 m.
+**Run it before `planarize()` runs a second time**, or a weld reintroduces the
+crossing-without-a-junction that planarize exists to remove.
+
+**"Roads merge in crazy ways" was one street drawn twice.** 363 pairs of edges
+met at under 22°, and 361 were an arterial against the district grid it runs
+through — N 45th St weaving across Wallingford's east-west streets 21 times,
+Broadway across Capitol Hill 19. The angle is a symptom: the distribution is
+flat from 0 to 20° with no natural cut, so raising the junction threshold does
+nothing. `dedupeGrid()` drops the block street instead, keeping the hand-drawn
+road — it's the named one and it continues past the district boundary. This is
+`roadCoveredAt` applied to the graph rather than the surface.
+
+| | before | after |
+|---|---|---|
+| dead ends inside the map | 99 | 44 |
+| road-graph components | 8 | 2 |
+| nodes unreachable from the main network | 83 | 9 |
+| edge pairs meeting under 22° | 359 | 146 |
+| separate water systems | 3 | 2 |
+
+The 9 stranded nodes are Harbor Island, which is genuinely an island — reaching
+it needs a bridge in the data, not a graph pass.
+
+**Ground colour is blended, not switched.** `buildTerrain` used to pick the
+vertex tint straight from `districtAt()`, and district polygons are literally
+`rect()` calls, so the city from the air was grey rectangles on grass with a
+40 m staircase on every edge — the heightfield spacing. The lookup point is now
+pushed around by `vnoise` so the boundary wanders, and three offset taps give a
+coverage fraction to blend across. Costs about 10 ms of boot.
+
 ## Parks
 
 **The block grid does not run through a park.** Buildings already skipped them,

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -321,7 +321,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v17</div>
+    <div id="build">v18</div>
   </div>
 
   <div id="rotate">

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -162,6 +162,193 @@ function districtOwner() {
   };
 }
 
+// sin of the shallowest crossing angle that still counts as an intersection
+const SLIVER_SIN = Math.sin(15 * Math.PI / 180);
+
+/**
+ * Drop a block street that a hand-drawn road has already paved.
+ *
+ * 363 pairs of edges met at under 22 degrees, and 361 of them were an arterial
+ * against the grid of the district it runs through: N 45th St weaving across
+ * Wallingford's east-west streets 21 times, Broadway across Capitol Hill 19.
+ * That is what "roads merge in crazy ways" looks like from above -- not one bad
+ * intersection but the same street laid twice at a few degrees' offset, forking
+ * and rejoining the whole way along.
+ *
+ * The angle is a symptom, so raising the junction threshold doesn't help: the
+ * distribution is flat from 0 to 20 degrees with no natural cut. The duplicate
+ * has to go instead, and the hand-drawn road is the one to keep -- it is the
+ * named one, and it carries on past the district boundary.
+ *
+ * `roadCoveredAt` does the same job for the drawn surface; this does it for the
+ * graph, so traffic stops seeing phantom forks too.
+ */
+function dedupeGrid(g) {
+  const NEAR = 19;                                   // metres, centreline to centreline
+  const COS = Math.cos(15 * Math.PI / 180);
+  const CELL = 120, gk = (a, b) => a * 100003 + b;
+  const grid = new Map();
+  for (let ei = 0; ei < g.edges.length; ei++) {
+    const e = g.edges[ei];
+    if (e.grid || e.elev) continue;                  // index the hand-drawn roads
+    const a = g.nodes[e.a], b = g.nodes[e.b];
+    const st = Math.max(1, Math.ceil(e.len / CELL));
+    for (let s = 0; s <= st; s++) {
+      const k = gk(Math.floor((a.x + (b.x - a.x) * s / st) / CELL),
+        Math.floor((a.z + (b.z - a.z) * s / st) / CELL));
+      let l = grid.get(k);
+      if (!l) grid.set(k, (l = new Set()));
+      l.add(ei);
+    }
+  }
+  const drop = new Set();
+  for (let ei = 0; ei < g.edges.length; ei++) {
+    const e = g.edges[ei];
+    if (!e.grid) continue;
+    const a = g.nodes[e.a], b = g.nodes[e.b];
+    // Every sample has to be covered, so a street that merely touches an
+    // arterial at one end keeps its own life.
+    let covered = true;
+    for (const t of [0.15, 0.5, 0.85]) {
+      const x = a.x + (b.x - a.x) * t, z = a.z + (b.z - a.z) * t;
+      let hit = false;
+      for (const oi of grid.get(gk(Math.floor(x / CELL), Math.floor(z / CELL))) || []) {
+        const o = g.edges[oi];
+        if (Math.abs(e.dx * o.dx + e.dz * o.dz) < COS) continue;
+        const oa = g.nodes[o.a], ob = g.nodes[o.b];
+        if (distToSeg(x, z, oa.x, oa.z, ob.x, ob.z).d <= NEAR) { hit = true; break; }
+      }
+      if (!hit) { covered = false; break; }
+    }
+    if (covered) drop.add(ei);
+  }
+  if (!drop.size) return 0;
+  const keep = g.edges.filter((_, ei) => !drop.has(ei));
+  g.edges = [];
+  for (const n of g.nodes) n.e = [];
+  for (const e of keep) {
+    const ei = g.addEdge(e.a, e.b, e.cls, e.name);
+    if (ei >= 0) g.edges[ei].grid = e.grid;
+  }
+  return drop.size;
+}
+
+/**
+ * Join up loose ends, and reel in the ones that have nothing to join to.
+ *
+ * The polylines in geo.js stop wherever the author stopped drawing, so 99 of
+ * them ended in mid-air -- 74 on arterials -- and seven pockets of street grid
+ * (Pioneer Square's 27 nodes, all of Harbor Island, the whole University
+ * Bridge) had no route to the rest of the city at all. Both read from above as
+ * roads that just give up.
+ *
+ * Two passes, cheapest first: weld a dangling end to a node it is already
+ * nearly touching, then bridge whole components that are still adrift. What
+ * neither can reach gets trimmed back, because a stub going nowhere is worse
+ * than no stub.
+ */
+function stitch(g) {
+  const WELD = 75;      // a loose end this close to a node was meant to meet it
+  const BRIDGE = 190;   // how far to reach to rescue a stranded component
+  const TRIM = 55;      // a leftover stub shorter than this is deleted
+  const EDGE = G.MAP_HALF - 80;
+  const atRim = (n) => Math.abs(n.x) > EDGE || Math.abs(n.z) > EDGE;
+  const stats = { welded: 0, bridged: 0, trimmed: 0 };
+
+  const cell = 90, gk = (a, b) => a * 100003 + b;
+  const index = () => {
+    const m = new Map();
+    for (let i = 0; i < g.nodes.length; i++) {
+      const n = g.nodes[i];
+      if (!n.e.length) continue;
+      const k = gk(Math.floor(n.x / cell), Math.floor(n.z / cell));
+      let l = m.get(k);
+      if (!l) m.set(k, (l = []));
+      l.push(i);
+    }
+    return m;
+  };
+  const nearest = (grid, ni, radius, ok) => {
+    const n = g.nodes[ni];
+    const r = Math.ceil(radius / cell);
+    const c0 = Math.floor(n.x / cell), d0 = Math.floor(n.z / cell);
+    let best = -1, bd = radius;
+    for (let cx = c0 - r; cx <= c0 + r; cx++) {
+      for (let cz = d0 - r; cz <= d0 + r; cz++) {
+        for (const oi of grid.get(gk(cx, cz)) || []) {
+          if (oi === ni || !ok(oi)) continue;
+          const o = g.nodes[oi];
+          const d = Math.hypot(o.x - n.x, o.z - n.z);
+          if (d < bd) { bd = d; best = oi; }
+        }
+      }
+    }
+    return best;
+  };
+
+  // --- 1. weld dangling ends ------------------------------------------------
+  let grid = index();
+  for (let ni = 0; ni < g.nodes.length; ni++) {
+    const n = g.nodes[ni];
+    if (n.e.length !== 1 || n.elev || atRim(n)) continue;
+    const own = g.edges[n.e[0]];
+    const far = own.a === ni ? own.b : own.a;
+    const hit = nearest(grid, ni, WELD, (oi) => oi !== far && !g.nodes[oi].elev);
+    if (hit < 0) continue;
+    if (g.addEdge(ni, hit, own.cls, own.name) >= 0) stats.welded++;
+  }
+
+  // --- 2. bridge components that are still cut off --------------------------
+  const par = new Array(g.nodes.length);
+  for (let i = 0; i < par.length; i++) par[i] = i;
+  const find = (a) => { while (par[a] !== a) { par[a] = par[par[a]]; a = par[a]; } return a; };
+  const uni = (a, b) => { a = find(a); b = find(b); if (a !== b) par[a] = b; };
+  for (const e of g.edges) uni(e.a, e.b);
+  const size = new Map();
+  for (let i = 0; i < g.nodes.length; i++) {
+    if (!g.nodes[i].e.length) continue;
+    const r = find(i);
+    size.set(r, (size.get(r) || 0) + 1);
+  }
+  let main = -1;
+  for (const [r, s] of size) if (main < 0 || s > size.get(main)) main = r;
+
+  grid = index();
+  for (const [root] of size) {
+    if (root === main) continue;
+    let bestFrom = -1, bestTo = -1, bd = BRIDGE;
+    for (let ni = 0; ni < g.nodes.length; ni++) {
+      if (!g.nodes[ni].e.length || find(ni) !== root) continue;
+      const hit = nearest(grid, ni, bd, (oi) => find(oi) === main && !g.nodes[oi].elev);
+      if (hit < 0) continue;
+      const d = Math.hypot(g.nodes[hit].x - g.nodes[ni].x, g.nodes[hit].z - g.nodes[ni].z);
+      if (d < bd) { bd = d; bestFrom = ni; bestTo = hit; }
+    }
+    if (bestFrom < 0) continue;
+    const cls = g.edges[g.nodes[bestFrom].e[0]].cls;
+    if (g.addEdge(bestFrom, bestTo, cls === 'hwy' ? 'art' : cls, 'link') >= 0) {
+      stats.bridged++;
+      uni(bestFrom, bestTo);
+    }
+  }
+
+  // --- 3. trim what is still dangling and too short to be a street ----------
+  const drop = new Set();
+  for (let ni = 0; ni < g.nodes.length; ni++) {
+    const n = g.nodes[ni];
+    if (n.e.length !== 1 || n.elev || atRim(n)) continue;
+    const ei = n.e[0];
+    if (g.edges[ei].len <= TRIM) { drop.add(ei); stats.trimmed++; }
+  }
+  if (drop.size) {
+    const keep = g.edges.filter((_, ei) => !drop.has(ei));
+    g.edges = [];
+    for (const n of g.nodes) n.e = [];
+    for (const e of keep) g.addEdge(e.a, e.b, e.cls, e.name);
+  }
+  return stats;
+}
+
 /**
  * Split every pair of crossing ground-level edges and put a node at the
  * crossing.
@@ -213,6 +400,14 @@ function planarize(g) {
         const d2x = s.x - r.x, d2z = s.z - r.z;
         const den = d1x * d2z - d1z * d2x;
         if (Math.abs(den) < 1e-9) continue; // parallel
+        // A crossing at a glancing angle is not an intersection, it is two
+        // roads that were drawn on top of each other. Splitting there produced
+        // 358 forks of under 22 deg across the city -- N 45th St alone made 41
+        // where it grazes the Wallingford and University grids it runs
+        // parallel to. Below 15 deg the pair is left whole; the overlapping
+        // surface is already suppressed by roadCoveredAt().
+        const l1 = Math.hypot(d1x, d1z), l2 = Math.hypot(d2x, d2z);
+        if (Math.abs(den) / (l1 * l2) < SLIVER_SIN) continue;
         const t = ((r.x - p.x) * d2z - (r.z - p.z) * d2x) / den;
         const u = ((r.x - p.x) * d1z - (r.z - p.z) * d1x) / den;
         if (t <= 0 || t >= 1 || u <= 0 || u >= 1) continue;
@@ -298,7 +493,10 @@ export function* cityGenerator() {
       // highways in step 2 still go where they are drawn, which is right:
       // Aurora really does cut through Woodland Park.
       if (G.inPark(mx, mz)) return;
-      g.addEdge(a, c, cls, d.name);
+      const ei = g.addEdge(a, c, cls, d.name);
+      // Tagged so dedupeGrid() can tell a procedural block street from a
+      // hand-drawn road, once the hand-drawn ones exist to compare against.
+      if (ei >= 0) g.edges[ei].grid = true;
     };
     const streetCls = d.style === 'house' ? 'res' : 'st';
     for (let i = i0; i <= i1; i++)
@@ -368,8 +566,19 @@ export function* cityGenerator() {
 
   // Every ground-level crossing becomes a real junction. Do this before the
   // segment index below, which reads the final edge list.
+  // Before any junctions are cut: a block street that an arterial has already
+  // paved should never have got a junction with it in the first place.
+  const deduped = dedupeGrid(g);
+
   planarize(g);
-  yield { p: 0.48, msg: 'Cutting the intersections' };
+  yield { p: 0.47, msg: 'Cutting the intersections' };
+
+  // Loose ends and marooned pockets get joined up, then anything the new edges
+  // now cross gets a junction too -- so a weld can't reintroduce the very
+  // crossing-without-a-node that planarize exists to remove.
+  const stitched = stitch(g);
+  planarize(g);
+  yield { p: 0.48, msg: 'Tying off the loose ends' };
 
   // --- 3. Segment index for building rejection ----------------------------
   const segCell = 90;
@@ -693,6 +902,8 @@ export function* cityGenerator() {
     edges: g.edges,
     buildings,
     waterDrops,
+    stitched,
+    deduped,
     chunks,
     chunkKey: ck,
     drivable,

--- a/apps/auto/src/geo.js
+++ b/apps/auto/src/geo.js
@@ -111,16 +111,39 @@ export const WATER = [
     poly: [[-880, -3480], [240, -3480], [300, -2600], [130, -1780], [-360, -1620], [-720, -1950], [-890, -2750]],
   },
   {
+    // The point of a ship canal is that a boat can get from the sound to the
+    // lake, and this one couldn't: its west end stopped 177 m short of Elliott
+    // Bay, so the whole chain was a landlocked trench. It was also a six-point
+    // rectangle -- dead straight, square ends, one width for 3.4 km -- which
+    // from the air read as a slot cut in a lawn rather than water.
+    //
+    // Now it reaches into the bay and changes width along its length: Salmon
+    // Bay wide at the west, pinched at the Fremont cut, opening into Lake
+    // Union. Run the land/water probe after touching this.
     name: 'Lake Washington Ship Canal',
-    poly: [[-4250, -3920], [-3400, -3880], [-820, -3780], [-830, -3470], [-3400, -3420], [-4250, -3470]],
+    // Every vertex east of the bay sits ON or INSIDE the old outline, so the
+    // shape only ever loses water. The one place it gains is the west end,
+    // which is the whole point -- and that reaches the bay past x = -4350,
+    // clear of the Ballard district, so no built ground goes under.
+    poly: [
+      [-4700, -3960], [-4350, -3925], [-4250, -3920], [-3900, -3896], [-3400, -3874],
+      [-2800, -3850], [-2000, -3812], [-1400, -3796], [-820, -3780],
+      [-820, -3470], [-1400, -3462], [-2000, -3458], [-2800, -3455],
+      [-3400, -3452], [-3900, -3460], [-4250, -3470], [-4700, -3500],
+    ],
   },
   {
     name: 'Portage Bay',
-    poly: [[230, -3520], [1260, -3470], [1310, -2990], [420, -2940], [180, -3150]],
+    poly: [[230, -3520], [640, -3500], [1040, -3487], [1280, -3470], [1310, -2990],
+      [900, -2975], [420, -2940], [180, -3150]],
   },
   {
+    // A cut really is a straight channel, but 200 m of it was a canal-sized
+    // river; the real one is about 50 m across. Narrowed, and pulled out at
+    // both mouths so it meets Portage Bay and Lake Washington properly.
     name: 'Montlake Cut',
-    poly: [[1240, -3580], [1830, -3600], [1830, -3400], [1240, -3390]],
+    poly: [[1180, -3600], [1420, -3560], [1700, -3560], [1880, -3620],
+      [1880, -3390], [1700, -3450], [1420, -3450], [1180, -3420]],
   },
   {
     name: 'Lake Washington',

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -14,6 +14,30 @@ const WALK_Y = WALK_LIFT;
 const NEAR_R = 2; // chunks of full detail around the player
 const MID_R = 4; // chunks that keep roads only
 
+// Ground tints, and the taps used to soften a district's edge into them.
+const GRASS = [0.42, 0.62, 0.28];
+const SUBURB = [0.48, 0.6, 0.37];
+const URBAN = [0.56, 0.56, 0.55];
+const BLEND_TAPS = [[0, 0], [-85, 55], [70, -75]];
+
+/**
+ * Smooth value noise on a 210 m lattice, in [0,1].
+ *
+ * Only used to push the district lookup off its own straight edges, so it wants
+ * to be continuous and cheap rather than good: `hash2` alone is per-cell random
+ * and turns a boundary into static instead of a curve.
+ */
+function vnoise(x, z) {
+  const S = 210;
+  const fx = x / S, fz = z / S;
+  const i0 = Math.floor(fx), j0 = Math.floor(fz);
+  const tx = fx - i0, tz = fz - j0;
+  const sx = tx * tx * (3 - 2 * tx), sz = tz * tz * (3 - 2 * tz);
+  const a = hash2(i0, j0), b = hash2(i0 + 1, j0);
+  const c = hash2(i0, j0 + 1), d = hash2(i0 + 1, j0 + 1);
+  return lerp(lerp(a, b, sx), lerp(c, d, sx), sz);
+}
+
 /**
  * Does this GPU actually put colour into a half-float target?
  *
@@ -186,12 +210,34 @@ export class World {
             pos[k] = x; pos[k + 1] = y; pos[k + 2] = z;
             uv[(j * w + i) * 2] = x / 13;
             uv[(j * w + i) * 2 + 1] = z / 13;
+            // District polygons are literally rect() calls, so colouring the
+            // ground by a straight districtAt() test drew the city from the air
+            // as grey rectangles on grass -- hard axis-aligned edges with a
+            // 40 m staircase on them, because that is the heightfield spacing.
+            // The query point is pushed around by smooth noise so the boundary
+            // wanders, and three offset samples give a coverage fraction to
+            // blend across rather than a switch to flip.
             let c;
-            const dist = G.districtAt(x, z);
             if (y < 1.2) c = [0.94, 0.86, 0.66];
             else if (G.inPark(x, z)) c = [0.42, 0.66, 0.3];
-            else if (dist) c = dist.style === 'house' ? [0.48, 0.6, 0.37] : [0.56, 0.56, 0.55];
-            else c = [0.42, 0.62, 0.28];
+            else {
+              const jx = (vnoise(x, z) - 0.5) * 190;
+              const jz = (vnoise(x + 3137, z - 2711) - 0.5) * 190;
+              let urban = 0, house = 0;
+              for (const [ox, oz] of BLEND_TAPS) {
+                const d2 = G.districtAt(x + jx + ox, z + jz + oz);
+                if (!d2) continue;
+                if (d2.style === 'house') house++; else urban++;
+              }
+              const cover = (urban + house) / BLEND_TAPS.length;
+              const built = cover > 0 ? (urban >= house ? URBAN : SUBURB) : URBAN;
+              const t = cover * cover * (3 - 2 * cover);
+              c = [
+                GRASS[0] + (built[0] - GRASS[0]) * t,
+                GRASS[1] + (built[1] - GRASS[1]) * t,
+                GRASS[2] + (built[2] - GRASS[2]) * t,
+              ];
+            }
             const n = hash2(gi, gj) * 0.14 + 0.93;
             col[k] = c[0] * n; col[k + 1] = c[1] * n; col[k + 2] = c[2] * n;
           }

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -16,7 +16,7 @@
 // fetches by URL with cache:'no-cache' — WebKit rejects fetch() of a
 // navigation-mode Request, which would silently kill the refresh of './' on
 // iOS, and no-cache skips GitHub Pages' 10-minute heuristic.
-const CACHE = 'auto-v17';
+const CACHE = 'auto-v18';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const SHELL = ['./', './index.html', './manifest.webmanifest',
   './icon-180.png', './icon-192.png', './icon-512.png'];


### PR DESCRIPTION
Build **v18**. The four fixes from the top-down audit, in the order proposed.

Rendered the whole road graph from above — water, roads by class, degree-1 nodes in red, anything unreachable in magenta. None of this shows at street level; all of it is obvious from the air.

## 1. The ship canal was a pond

Its west end stopped **177 m short of Elliott Bay**, so there was no water route from Puget Sound to Lake Washington — the water was **three separate systems**, not one. It was also a six-point box: straight sides, square ends, one width for 3.4 km, which read as a trench cut in a lawn.

It now reaches the sound and changes width along its length. Portage Bay and the Montlake Cut got the same treatment; the cut was 200 m across against about 50 m in reality.

**On the risk:** every vertex east of the bay sits on or inside the old outline, so the shape can only *lose* water there. The one place it gains is the west end — which is the whole point — and it crosses Ballard's western 100 m to get to the sea, exactly as the real canal does.

| | |
|---|---|
| land → water | 0.132 km² (the canal reaching the sound) |
| water → land | 0.104 km² |
| road samples standing in water | 213 → **206** (15th Ave W alone 14 → 7) |
| land/water probe | Magnolia dry, Elliott Bay wet — unchanged |

## 2. 99 roads stopped in a field; 83 nodes had no route to the city

The polylines end wherever the author stopped drawing. Seven pockets of grid were islands: Pioneer Square's 27 nodes, all of Harbor Island, the whole University Bridge.

`stitch()` welds a loose end to a node within 75 m (57 welds), bridges a stranded component to the main network within 190 m (2), and trims what's left under 55 m (14). It runs **before a second `planarize()` pass**, so a weld can't reintroduce the crossing-without-a-junction that planarize exists to remove.

## 3. "Merge in crazy ways" was one street drawn twice

363 pairs of edges met at under 22°, and **361 of them were an arterial against the district grid it runs through** — N 45th St weaving across Wallingford's east-west streets 21 times, Broadway across Capitol Hill 19.

The angle is a symptom. I tried rejecting shallow crossings first; it moved 358 → 363, because the distribution is flat from 0 to 20° with no natural cut. `dedupeGrid()` drops the duplicated block street instead and keeps the hand-drawn road — it's the named one and it carries on past the district boundary. Same idea as `roadCoveredAt`, one level down: the graph rather than the surface.

## 4. The ground was grey rectangles on grass

`buildTerrain` picked its vertex tint straight from `districtAt()`, and district polygons are literally `rect()` calls — so from the air the city was axis-aligned grey blocks with a 40 m staircase on every edge (the heightfield spacing). The lookup point is now jittered by smooth value noise and blended across three offset taps.

## Measured against `master`

| | before | after |
|---|---|---|
| dead ends inside the map | 99 | **44** |
| road-graph components | 8 | **2** |
| nodes unreachable from the main network | 83 | **9** |
| edge pairs meeting under 22° | 359 | **146** |
| separate water systems | 3 | **2** |
| crossings without a junction | 4 | 5 |
| buildings in the roadway | 0 | 0 |
| boot | 5067 ms | 5077 ms |

Two things I'm not claiming as clean:

- **The extra crossing without a junction is deliberate.** `planarize` now declines to split a pair meeting under 15°, because that's two roads lying on each other rather than an intersection.
- **The 9 stranded nodes are Harbor Island**, which is genuinely an island. Reaching it needs a bridge in the data, not a graph pass.

No console or page errors. `apps/auto/CLAUDE.md` gains a "What the map looks like from above" section with the assertions to re-run after any geo.js change.

## Still open from the audit

13 named roads are still severed by water (Westlake, Dexter, Fairview, Eastlake, Delridge, Alaskan Way…), all the same shoreline drift Aurora had. Each needs re-routing the way Aurora was in #325, and doing them blind risks cramming parallel carriageways into one strip.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6uJPyarVs2ggkt3wXg12N)_