### PR TITLE
Zombies: hold L3 to sprint, R3 to melee

### DIFF
--- a/apps/zombies/CLAUDE.md
+++ b/apps/zombies/CLAUDE.md
@@ -164,6 +164,12 @@ Adding another perk is one `PERKS` entry, one map char, and one multiplier read.
   windows entirely. That is the whole reason a dog round feels different from a
   zombie round despite sharing the AI.
 
+**PAD BINDINGS FOLLOW CALL OF DUTY, NOT CONVENIENCE.** Hold L3 to sprint —
+never a toggle, which latches the state after the stick is released so you round
+a corner already sprinting and unable to shoot. R3 melees. B melees as well
+(harmless, and it is what earlier builds trained) but menus back out on B only,
+because a stick-click is a melee button and should not also mean "go back".
+
 **A CURSOR IS NOT AN ACTION.** The controller could confirm and go back for a
 whole release before it could show you WHICH item it was about to press, and the
 first attempt at a fix navigated perfectly while highlighting nothing — the ring

--- a/apps/zombies/index.html
+++ b/apps/zombies/index.html
@@ -278,8 +278,10 @@
     <b>Touch</b> — drag the left half to move (push forward to sprint), drag the right half to look.
     <b>FIRE</b> can be dragged to aim while shooting. Tap <b>BUY</b> when a prompt appears; hold it at a
     broken window to rebuild the boards.<br><br>
-    <b>Controller</b> — left stick move, right stick look, <b>RT</b> fire, <b>LT</b> aim, <b>A</b> buy / repair,
-    <b>X</b> reload, <b>B</b> knife, <b>RB</b> frag, <b>Y</b> swap weapon, <b>L3</b> sprint, <b>Start</b> pause. In menus: <b>A</b> confirm, <b>B</b> back.<br><br>
+    <b>Controller</b> — left stick move, right stick look, <b>RT</b> fire, <b>LT</b> aim,
+    <b>hold L3</b> sprint, <b>R3</b> melee, <b>A</b> buy / repair, <b>X</b> reload,
+    <b>RB</b> frag, <b>Y</b> swap weapon, <b>Start</b> pause.
+    In menus: stick or d-pad moves the highlight, <b>A</b> confirm, <b>B</b> back.<br><br>
     <b>Keyboard</b> — <span class="kbd">WASD</span> move, <span class="kbd">Shift</span> sprint,
     mouse look &amp; fire, <span class="kbd">R</span> reload, <span class="kbd">V</span> knife,
     <span class="kbd">G</span> frag, <span class="kbd">Q</span> swap, <span class="kbd">F</span> buy,
@@ -350,7 +352,7 @@ import * as THREE from 'three';
      4  map data + level build    9  FX, HUD, loop, debug harness
    ============================================================================ */
 
-const VERSION = 3;                    // bump once per PR (shown bottom-right)
+const VERSION = 4;                    // bump once per PR (shown bottom-right)
 
 // ---------------------------------------------------------------- 0. config
 const CFG = {
@@ -678,13 +680,13 @@ const Input = (() => {
     lookX: 0, lookY: 0,    // look delta accumulated this frame (radians)
     fire: false, ads: false, sprint: false,
     // edge-triggered actions, consumed by the reader
-    reload: false, knife: false, nade: false, swap: false, use: false, pause: false,
+    reload: false, knife: false, nade: false, swap: false, use: false, pause: false, back: false,
     menuNav: 0,            // -1 up / +1 down, edge-triggered, for menu cursors
     useHeld: false,        // level (for holding to repair a barricade)
     hasPad: false, mode: 'touch',
   };
   const keys = new Set();
-  let padIdx = null, prevPad = [], prevNav = 0;
+  let padIdx = null, prevPad = [], prevNav = 0, prevMelee = false;
   const LOOK_TOUCH = 0.0038, LOOK_MOUSE = 0.0022, LOOK_PAD = 2.6;
 
   // ---- touch ----------------------------------------------------------
@@ -782,6 +784,7 @@ const Input = (() => {
     if (e.code === 'Enter' || e.code === 'Space') st.use = true;   // menu confirm
     if (e.code === 'ArrowDown') st.menuNav = 1;
     if (e.code === 'ArrowUp') st.menuNav = -1;
+    if (e.code === 'Backspace') st.back = true;
     if (e.code === 'KeyM') Snd.toggleMute();
     if (['KeyW','KeyA','KeyS','KeyD','Space','KeyR','KeyF'].includes(e.code)) e.preventDefault();
   });
@@ -802,7 +805,11 @@ const Input = (() => {
 
   // ---- gamepad ---------------------------------------------------------
   // Standard mapping, which is what every MFi/Xbox/DualSense pad reports on iOS.
-  const PAD = { fire: 7, ads: 6, use: 0, knife: 1, reload: 2, swap: 3, nade: 5, sprint: 10, pause: 9, start2: 17 };
+  /* Standard mapping, laid out the way a Call of Duty player's hands already
+     work: HOLD L3 to sprint (not a toggle), click R3 to melee. B keeps meleeing
+     too — it costs nothing and it is what the earlier builds trained. */
+  const PAD = { fire: 7, ads: 6, use: 0, back: 1, knife: 1, melee: 11,
+                reload: 2, swap: 3, nade: 5, sprint: 10, pause: 9 };
   addEventListener('gamepadconnected', e => { padIdx = e.gamepad.index; st.hasPad = true; st.mode = 'pad'; touchLayer.classList.remove('on'); Snd.resume(); });
   addEventListener('gamepaddisconnected', () => { padIdx = null; st.hasPad = false; });
   function pollPad(dt) {
@@ -830,12 +837,18 @@ const Input = (() => {
     }
     st.fire = down(PAD.fire);
     st.ads = down(PAD.ads);
-    for (const k of ['use', 'knife', 'reload', 'swap', 'nade', 'pause']) {
+    for (const k of ['use', 'back', 'reload', 'swap', 'nade', 'pause']) {
       const on = down(PAD[k]);
       if (on && !prevPad[PAD[k]]) st[k] = true;
       if (k === 'use') st.useHeld = on;
     }
-    if (down(PAD.sprint) && !prevPad[PAD.sprint]) st.sprint = !st.sprint;
+    // melee from either stick-click or B, edge-detected across the pair
+    const meleeNow = down(PAD.melee) || down(PAD.knife);
+    if (meleeNow && !prevMelee) st.knife = true;
+    prevMelee = meleeNow;
+    // HOLD to sprint. A toggle leaves the state latched after you let go of the
+    // stick, so you round a corner already sprinting and cannot shoot.
+    st.sprint = down(PAD.sprint);
     // d-pad or left stick drives a menu cursor; edge-triggered so a held
     // direction moves one item, not forty
     const nav = (down(13) || my < -0.55) ? 1 : ((down(12) || my > 0.55) ? -1 : 0);
@@ -860,8 +873,8 @@ const Input = (() => {
     // consume() clears the edge flags — call once per frame, after reading
     consume() {
       const out = { reload: st.reload, knife: st.knife, nade: st.nade, swap: st.swap,
-                    use: st.use, pause: st.pause, menuNav: st.menuNav };
-      st.reload = st.knife = st.nade = st.swap = st.use = st.pause = false;
+                    use: st.use, pause: st.pause, back: st.back, menuNav: st.menuNav };
+      st.reload = st.knife = st.nade = st.swap = st.use = st.pause = st.back = false;
       st.menuNav = 0;
       return out;
     },
@@ -5041,7 +5054,7 @@ const Game = (() => {
       // the cursor. Keyboard arrows and Enter drive the same path.
       if (act.menuNav) Menu.move(act.menuNav);
       if (act.use) Menu.activate();
-      else if (act.knife) Menu.back();
+      else if (act.back) Menu.back();
       else Menu.paint();          // the ring appears the moment a pad is used
     }
     if (G.state === 'play' || G.state === 'dying') {

--- a/apps/zombies/sw.js
+++ b/apps/zombies/sw.js
@@ -14,7 +14,7 @@
  *
  * Bump CACHE when a deploy must reach installed players promptly.
  */
-const CACHE = 'zombies-v3';
+const CACHE = 'zombies-v4';
 const SHELL = ['./', './index.html', './manifest.webmanifest', './icon-192.png', './icon-512.png', './icon-180.png'];
 
 self.addEventListener('install', e => {

--- a/apps/zombies/verify.mjs
+++ b/apps/zombies/verify.mjs
@@ -541,6 +541,15 @@ const pad = await page.evaluate(() => {
   const g0 = D.Player.gun().key; __tapPad(3); D.stepN(20);
   o.ySwaps = D.Player.gun().key !== g0;
   __tapPad(1); D.stepN(2); o.bKnifes = P.knifeT > 0; D.stepN(60);
+  // R3 melee — a Call of Duty player's thumb goes here, not to B
+  __tapPad(11); D.stepN(2); o.r3Melees = P.knifeT > 0; D.stepN(60);
+  /* HOLD L3 to sprint. It was a toggle, which latches: you let go of the stick
+     and stay "sprinting", so you round a corner already unable to shoot. */
+  __btn(10, true); __ax(0, -1, 0, 0); D.stepN(10);
+  o.sprintWhileHeld = P.sprinting;
+  __btn(10, false); D.stepN(10);
+  o.sprintStopsOnRelease = !P.sprinting;
+  __ax(0, 0, 0, 0); D.stepN(4);
   const n0 = P.nades; __tapPad(5); D.stepN(40); o.rbNades = P.nades === n0 - 1;
   const wb = D.Level.wallbuys.find(w => w.char === 'a');
   D.teleport(wb.use.x, wb.use.z); D.points(9999); D.stepN(4);
@@ -560,6 +569,8 @@ check('X reloads', pad.xReloads, pad);
 check('LT aims', pad.ltAds, pad);
 check('Y swaps weapon', pad.ySwaps, pad);
 check('B knifes', pad.bKnifes, pad);
+check('R3 melees', pad.r3Melees, pad);
+check('L3 sprints only while held', pad.sprintWhileHeld && pad.sprintStopsOnRelease, pad);
 check('RB throws a frag', pad.rbNades, pad);
 check('A buys at a wall-buy', pad.aBuys, pad);
 check('Start pauses, A resumes', pad.startPauses && pad.aResumes, pad);


### PR DESCRIPTION
Polish only, both straight from playtest. **Build V4.**

## Hold L3 to sprint

It was a toggle. A toggle *latches* — you let go of the stick and stay "sprinting", so you come round a corner already in a state where you can't shoot, and you have to press again to get out of it. Holding is what a Call of Duty player's hands already do, and it self-cancels the instant you release.

## R3 melees

Where a CoD thumb actually goes for it. B still melees too — it costs nothing and it's what the earlier builds trained — but **menus now back out on B only**. A stick-click is a melee button; it shouldn't also mean "go back", which it did while both shared the same edge flag.

## Testing note

`verify.mjs` asserts sprint **stops on release**, not just that it starts — the old toggle would sail through a start-only check. Confirmed by reintroducing the toggle: `sprintWhileHeld: true, sprintStopsOnRelease: false`, check fails. Same discipline for R3.

86/86 checks passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wu8j8LhC8NLh2AKjzyP5eu)_