### PR TITLE
Auto: full controller support, map-tap spawn, and menu fixes

### DIFF
--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -89,14 +89,34 @@
   #app[data-mode="drive"] .foot-only { display: none; }
   #app:not([data-mode="drive"]) .car-only { display: none; }
 
+  /* A pad takes the thumb controls off the screen -- they cover a third of it
+     and nothing is going to press them. The look zone stays: it costs nothing
+     and a phone on a stand is still a touchscreen. */
+  #app[data-pad="1"] #pad,
+  #app[data-pad="1"] #stickZone { display: none; }
+
+  /* The controller cursor. A cursor that cannot be seen is not a cursor: being
+     able to confirm without showing WHICH row is about to be pressed is the
+     whole bug this exists to avoid. */
+  .padfocus {
+    position: relative;
+    box-shadow: 0 0 0 2px rgba(126, 200, 240, 0.95), 0 0 16px rgba(126, 200, 240, 0.45);
+    border-radius: 10px;
+  }
+
   /* ---------- hud ---------- */
   #hud { position: absolute; inset: 0; pointer-events: none; z-index: 4; }
+  /* The minimap IS the map button -- #hud is pointer-events:none, so this has
+     to opt back in for the tap to land. */
   #minimapWrap {
     position: absolute; left: calc(12px + var(--safe-l)); top: calc(12px + var(--safe-t));
     width: 138px; height: 138px; border-radius: 50%;
     border: 2px solid rgba(255,255,255,0.3); overflow: hidden;
     box-shadow: 0 6px 22px rgba(0,0,0,0.45); background: #22282a;
+    pointer-events: auto; cursor: pointer; -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation; transition: transform .06s;
   }
+  #minimapWrap:active { transform: scale(0.96); }
   #minimap { width: 100%; height: 100%; display: block; }
   #place {
     position: absolute; left: calc(12px + var(--safe-l)); top: calc(156px + var(--safe-t));
@@ -174,6 +194,24 @@
   }
   #mapOverlay.show, #pauseMenu.show { display: flex; }
   #bigMap { width: 100%; height: 100%; object-fit: contain; }
+
+  #mapBar {
+    position: absolute; left: 50%; transform: translateX(-50%);
+    bottom: calc(16px + var(--safe-b)); z-index: 31;
+    display: flex; align-items: center; gap: 12px;
+    background: rgba(16,22,28,0.82); border: 1px solid rgba(255,255,255,0.16);
+    border-radius: 999px; padding: 8px 16px 8px 8px;
+    backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px);
+  }
+  .mapchip {
+    -webkit-tap-highlight-color: transparent;
+    font: 700 12px/1 -apple-system, Helvetica, sans-serif; letter-spacing: .08em;
+    color: var(--ink); background: rgba(40,52,64,0.9);
+    border: 1px solid rgba(255,255,255,0.22); border-radius: 999px;
+    padding: 9px 15px; touch-action: manipulation;
+  }
+  .mapchip.on { background: rgba(70,180,120,0.55); border-color: rgba(150,240,190,0.7); }
+  #mapHint { font-size: 11px; opacity: .62; letter-spacing: .03em; white-space: nowrap; }
   #pauseCard {
     width: min(420px, 92%); background: rgba(20,27,34,0.94); border: 1px solid rgba(255,255,255,0.14);
     border-radius: 18px; padding: 20px; max-height: 92%; overflow-y: auto;
@@ -270,7 +308,6 @@
   <div id="hurt"></div>
 
   <div id="topBtns">
-    <button class="mini" id="mapBtn" aria-label="Map">🗺</button>
     <button class="mini" id="radioBtn" aria-label="Radio">📻</button>
     <button class="mini" id="pauseBtn" aria-label="Menu">☰</button>
   </div>
@@ -294,13 +331,23 @@
 
   <div id="wasted"><span>WASTED</span></div>
 
-  <div id="mapOverlay"><canvas id="bigMap"></canvas></div>
+  <div id="mapOverlay">
+    <canvas id="bigMap"></canvas>
+    <div id="mapBar">
+      <button id="warpBtn" class="mapchip">SET SPAWN</button>
+      <span id="mapHint">Tap the map to close</span>
+    </div>
+  </div>
 
   <div id="pauseMenu">
     <div id="pauseCard">
       <h2>AUTO</h2>
       <p class="sub">Seattle, Washington</p>
-      <div class="row"><span>Graphics</span><div class="seg">
+      <!-- Resume first: it is what the menu is opened to do, and burying it
+           under the settings meant scrolling to get back into the game. -->
+      <button class="cta" id="resumeBtn">Resume</button>
+      <button class="cta ghost" id="respawnBtn">Respawn at Harborview</button>
+      <div class="row" id="rowQuality"><span>Graphics</span><div class="seg">
         <button class="segbtn" data-quality="high">High</button>
         <button class="segbtn" data-quality="medium">Med</button>
         <button class="segbtn" data-quality="low">Low</button>
@@ -309,8 +356,6 @@
       <div class="row"><span>Radio</span><div class="toggle" id="setMusic"></div></div>
       <div class="row"><span>Sound effects</span><div class="toggle" id="setSound"></div></div>
       <div class="row"><span>Camera speed</span><input type="range" id="setSens" min="0.4" max="2.2" step="0.1" value="1"></div>
-      <button class="cta" id="resumeBtn">Resume</button>
-      <button class="cta ghost" id="respawnBtn">Respawn at Harborview</button>
       <p class="help">
         Left thumb steers and walks. Right side: drag to look, buttons to drive.
         Walk up to any car and hit ENTER to take it. Deliveries pay — the gold ring
@@ -329,7 +374,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v20</div>
+    <div id="build">v21</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -382,6 +382,42 @@ export function* cityGenerator(md) {
       return out;
     },
 
+    /**
+     * A point on a road near (x,z), for dropping the player somewhere they
+     * picked off the map.
+     *
+     * Snaps to a graph node rather than to the raw tap: nodes sit ~50 m apart
+     * along every carriageway, so one is always on tarmac, whereas the tap
+     * itself is usually in the middle of a block. Ground-level nodes are
+     * preferred over decks -- landing on an unmarked freeway bridge is a worse
+     * surprise than walking 30 m -- but a deck is still better than refusing,
+     * which is what happens out on Harbor Island or the far shore.
+     */
+    respawnPointNear(x, z, maxR = 1200) {
+      let best = -1, bd = maxR * maxR;
+      let anyBest = -1, anyBd = maxR * maxR;
+      const c0 = Math.floor((x - maxR) / nCell), c1 = Math.floor((x + maxR) / nCell);
+      const d0 = Math.floor((z - maxR) / nCell), d1 = Math.floor((z + maxR) / nCell);
+      for (let cx = c0; cx <= c1; cx++) {
+        for (let cz = d0; cz <= d1; cz++) {
+          const l = nGrid.get(skey(cx, cz));
+          if (!l) continue;
+          for (const ni of l) {
+            const n = g.nodes[ni];
+            if (!n.e.length) continue;
+            const dd = (n.x - x) * (n.x - x) + (n.z - z) * (n.z - z);
+            if (dd < anyBd) { anyBd = dd; anyBest = ni; }
+            if (n.elev) continue;
+            if (dd < bd) { bd = dd; best = ni; }
+          }
+        }
+      }
+      const ni = best >= 0 ? best : anyBest;
+      if (ni < 0) return null;
+      const n = g.nodes[ni];
+      return { x: n.x, z: n.z, elev: !!n.elev, dist: Math.hypot(n.x - x, n.z - z) };
+    },
+
     nearestNode(x, z, maxR = 260) {
       let best = -1, bd = maxR * maxR;
       const c0 = Math.floor((x - maxR) / nCell), c1 = Math.floor((x + maxR) / nCell);

--- a/apps/auto/src/controls.js
+++ b/apps/auto/src/controls.js
@@ -1,7 +1,34 @@
-// Touch controls (left stick + right buttons + camera drag) with a keyboard
-// fallback for desktop.
+// Touch controls (left stick + right buttons + camera drag), a keyboard
+// fallback for desktop, and a full gamepad layer.
 
 import { clamp } from './util.js';
+
+/* Standard-mapping button indices. Every MFi, Xbox and DualSense pad reports
+   `mapping: 'standard'` on iOS, which is what makes a fixed table safe.
+     0 A/Cross   1 B/Circle  2 X/Square  3 Y/Triangle
+     4 LB  5 RB  6 LT  7 RT  8 Back/Share  9 Start/Options
+     10 L3  11 R3   12/13/14/15 dpad U/D/L/R                                */
+const PAD = {
+  jump: 0,        // A -- also handbrake in a car, as in GTA
+  hand: 0,
+  back: 1,        // B -- menus only
+  attack: 2,      // X
+  enter: 3,       // Y -- enter/exit vehicle
+  sprintAlt: 5,   // RB
+  brake: 6,       // LT -- analogue
+  gas: 7,         // RT -- analogue
+  map: 8,         // Back/Share
+  pause: 9,       // Start/Options
+  horn: 10,       // L3 -- GTA puts the horn on the left stick click
+  sprint: 10,     // ...and on foot the same click is hold-to-sprint
+  radioPrev: 14,  // dpad left
+  radioNext: 15,  // dpad right
+  navUp: 12,
+  navDown: 13,
+};
+const DEAD = 0.16;
+const LOOK_RATE = 2.9;     // rad/s at full deflection
+const TRIGGER_ON = 0.12;   // where an analogue trigger starts counting as held
 
 export class Controls {
   constructor(root) {
@@ -15,6 +42,28 @@ export class Controls {
     this._stickId = null;
     this._lookId = null;
     this.sensitivity = 1;
+
+    // --- gamepad ---
+    this.hasPad = false;
+    this._padIndex = null;
+    this._padPrev = [];
+    this._padStick = { x: 0, y: 0 };
+    this._padGas = 0;
+    this._padBrake = 0;
+    this._padHeld = {};
+    this._ui = { pause: false, map: false, radio: 0, nav: 0, navX: 0, confirm: false, back: false, warp: false };
+    this._padLook = { x: 0, y: 0 };
+    window.addEventListener('gamepadconnected', (e) => {
+      this._padIndex = e.gamepad.index;
+      this.setPad(true);
+    });
+    window.addEventListener('gamepaddisconnected', () => {
+      this._padIndex = null;
+      this.setPad(false);
+      this._padStick = { x: 0, y: 0 };
+      this._padGas = this._padBrake = 0;
+      this._padHeld = {};
+    });
 
     this.stickBase = root.querySelector('#stickBase');
     this.stickKnob = root.querySelector('#stickKnob');
@@ -88,6 +137,101 @@ export class Controls {
     window.addEventListener('keyup', (e) => this.keys.delete(e.code));
     window.addEventListener('blur', () => this.keys.clear());
   }
+
+  /**
+   * Show or hide the touch controls for a pad.
+   *
+   * Driven by any button OR stick movement, not just `gamepadconnected`: iOS
+   * does not expose a pad until the player presses something on it, and a
+   * player who navigates with the d-pad alone would otherwise keep a full set
+   * of thumb controls sitting over the screen.
+   */
+  setPad(on) {
+    if (this.hasPad === on) return;
+    this.hasPad = on;
+    this.root.dataset.pad = on ? '1' : '';
+    if (on) this.releaseStick();
+  }
+
+  /**
+   * Poll the gamepad. Call once per frame BEFORE read()/takeLook(), and call it
+   * even while paused -- otherwise the pause menu it opened cannot be navigated
+   * with the same pad that opened it.
+   */
+  poll(dt) {
+    const pads = navigator.getGamepads ? navigator.getGamepads() : [];
+    let gp = this._padIndex !== null ? pads[this._padIndex] : null;
+    if (!gp || !gp.connected) {
+      gp = null;
+      for (const p of pads) if (p && p.connected) { gp = p; this._padIndex = p.index; break; }
+    }
+    if (!gp) {
+      if (this.hasPad) this.setPad(false);
+      return;
+    }
+
+    const dz = (v) => (Math.abs(v) < DEAD ? 0 : (v - Math.sign(v) * DEAD) / (1 - DEAD));
+    const ax = gp.axes || [];
+    const lx = dz(ax[0] || 0), ly = dz(ax[1] || 0);
+    const rx = dz(ax[2] || 0), ry = dz(ax[3] || 0);
+    const b = gp.buttons || [];
+    const raw = (i) => (b[i] ? (b[i].value != null ? b[i].value : (b[i].pressed ? 1 : 0)) : 0);
+    const down = (i) => !!(b[i] && (b[i].pressed || b[i].value > TRIGGER_ON));
+
+    let any = lx || ly || rx || ry;
+    for (let i = 0; i < b.length && !any; i++) if (down(i)) any = true;
+    if (any) this.setPad(true);
+
+    this._padStick = { x: lx, y: ly };
+    this._padLook = { x: rx, y: ry };
+    // Squared response: precise near the centre, quick at the edge. Multiplied
+    // by dt because this is a rate, unlike the touch drag which is a delta.
+    this.camDX += rx * Math.abs(rx) * LOOK_RATE * dt * this.sensitivity;
+    this.camDY += ry * Math.abs(ry) * LOOK_RATE * dt * this.sensitivity;
+
+    // Analogue triggers, passed through as 0..1 -- vehicles.js already takes a
+    // continuous throttle, so a pad gets real modulation rather than on/off.
+    this._padGas = raw(PAD.gas);
+    this._padBrake = raw(PAD.brake);
+
+    const held = {};
+    for (const k of ['jump', 'hand', 'attack', 'horn', 'sprint', 'sprintAlt']) held[k] = down(PAD[k]);
+    this._padHeld = held;
+
+    const edge = (i) => down(i) && !this._padPrev[i];
+    if (edge(PAD.enter)) this.tapped = 'enter';
+    if (edge(PAD.jump) && this.mode !== 'drive') this.tapped = 'jump';
+    if (edge(PAD.pause)) this._ui.pause = true;
+    if (edge(PAD.map)) this._ui.map = true;
+    if (edge(PAD.radioNext)) this._ui.radio = 1;
+    if (edge(PAD.radioPrev)) this._ui.radio = -1;
+    if (edge(PAD.jump)) this._ui.confirm = true;
+    if (edge(PAD.back)) this._ui.back = true;
+    if (edge(PAD.attack)) this._ui.warp = true;   // X arms the map's spawn picker
+
+    // Menu cursor: d-pad or left stick, edge-triggered so a held direction
+    // moves one item rather than forty.
+    const navNow = (down(PAD.navDown) || ly > 0.55) ? 1 : ((down(PAD.navUp) || ly < -0.55) ? -1 : 0);
+    if (navNow && navNow !== this._navPrev) this._ui.nav = navNow;
+    this._navPrev = navNow;
+    const navXNow = (down(PAD.radioNext) || lx > 0.55) ? 1 : ((down(PAD.radioPrev) || lx < -0.55) ? -1 : 0);
+    if (navXNow && navXNow !== this._navXPrev) this._ui.navX = navXNow;
+    this._navXPrev = navXNow;
+
+    this._padPrev = [];
+    for (let i = 0; i < b.length; i++) this._padPrev[i] = down(i);
+  }
+
+  /** Consume the pad's UI edges. Menus own these; gameplay never sees them. */
+  takeUi() {
+    const u = this._ui;
+    this._ui = { pause: false, map: false, radio: 0, nav: 0, navX: 0, confirm: false, back: false, warp: false };
+    return u;
+  }
+
+  /** Raw pad sticks, for UI that steers something itself (the map crosshair). */
+  padLook() { return this._padLook; }
+  padMove() { return this._padStick; }
 
   releaseStick() {
     if (this._stickId !== null) this._pointers.delete(this._stickId);
@@ -215,7 +359,7 @@ export class Controls {
     return false;
   }
 
-  /** Merged analogue state, touch + keyboard. */
+  /** Merged analogue state, touch + keyboard + pad. */
   read() {
     if (this._stickId === null && (this.stick.x || this.stick.y)) this.releaseStick();
     let sx = this.stick.x, sy = this.stick.y;
@@ -223,16 +367,36 @@ export class Controls {
     if (this.key('KeyD', 'ArrowRight')) sx += 1;
     if (this.key('KeyW', 'ArrowUp')) sy -= 1;
     if (this.key('KeyS', 'ArrowDown')) sy += 1;
+    sx += this._padStick.x;
+    sy += this._padStick.y;
+
+    const p = this._padHeld;
+    const driving = this.mode === 'drive';
+    // A is the handbrake in a car and jump on foot, and L3 is the horn in a car
+    // and hold-to-sprint on foot -- both are what GTA does with those buttons.
+    // Sprint is a HOLD, never a toggle: a toggle stays latched after the stick
+    // is released, so you arrive somewhere still sprinting.
+    const gasAmt = clamp(Math.max(
+      this._padGas,
+      (this.btn.gas || this.key('ArrowUp', 'KeyW')) ? 1 : 0,
+    ), 0, 1);
+    const brakeAmt = clamp(Math.max(
+      this._padBrake,
+      (this.btn.brake || this.key('ArrowDown', 'KeyS')) ? 1 : 0,
+    ), 0, 1);
     return {
       x: clamp(sx, -1, 1),
       y: clamp(sy, -1, 1),
-      gas: this.btn.gas || this.key('ArrowUp', 'KeyW'),
-      brake: this.btn.brake || this.key('ArrowDown', 'KeyS'),
-      hand: this.btn.hand || this.key('Space'),
-      sprint: this.btn.sprint || this.key('ShiftLeft', 'ShiftRight'),
-      attack: this.btn.attack || this.key('KeyJ') || this.key('ControlLeft'),
-      horn: this.btn.horn || this.key('KeyH'),
-      jump: this.btn.jump,
+      gas: gasAmt > TRIGGER_ON,
+      brake: brakeAmt > TRIGGER_ON,
+      gasAmt,
+      brakeAmt,
+      hand: this.btn.hand || this.key('Space') || (driving && !!p.hand),
+      sprint: this.btn.sprint || this.key('ShiftLeft', 'ShiftRight')
+        || (!driving && (!!p.sprint || !!p.sprintAlt)),
+      attack: this.btn.attack || this.key('KeyJ') || this.key('ControlLeft') || !!p.attack,
+      horn: this.btn.horn || this.key('KeyH') || (driving && !!p.horn),
+      jump: this.btn.jump || (!driving && !!p.jump),
     };
   }
 }

--- a/apps/auto/src/hud.js
+++ b/apps/auto/src/hud.js
@@ -253,6 +253,10 @@ export class Hud {
     ctx.drawImage(this.mapCanvas, 0, 0, MAP_PX, MAP_PX, ox, oy, size, size);
     const p = player.position;
     const toC = (x, z) => [ox + ((x + G.MAP_HALF) / (G.MAP_HALF * 2)) * size, oy + ((z + G.MAP_HALF) / (G.MAP_HALF * 2)) * size];
+    // Remember the projection so a tap can be turned back into world metres.
+    // The map is letterboxed inside the canvas and the canvas is scaled by dpr,
+    // so neither offset can be inferred from the element's size alone.
+    this._mapView = { ox, oy, size, dpr, w: c.width, h: c.height };
 
     ctx.font = `${Math.round(size * 0.013)}px -apple-system, Helvetica, sans-serif`;
     ctx.fillStyle = 'rgba(255,255,255,0.72)';
@@ -290,5 +294,51 @@ export class Hud {
     ctx.fill();
     ctx.stroke();
     ctx.restore();
+
+    // Warp crosshair: where the tap landed, and the road it snapped to.
+    if (this.warp) {
+      const [wx, wz] = toC(this.warp.x, this.warp.z);
+      const r = size * 0.016;
+      ctx.strokeStyle = this.warp.ok ? '#7ee0a4' : '#e5645d';
+      ctx.lineWidth = Math.max(1.5, size * 0.0022);
+      ctx.beginPath();
+      ctx.arc(wx, wz, r, 0, Math.PI * 2);
+      ctx.moveTo(wx - r * 1.7, wz); ctx.lineTo(wx - r * 0.5, wz);
+      ctx.moveTo(wx + r * 0.5, wz); ctx.lineTo(wx + r * 1.7, wz);
+      ctx.moveTo(wx, wz - r * 1.7); ctx.lineTo(wx, wz - r * 0.5);
+      ctx.moveTo(wx, wz + r * 0.5); ctx.lineTo(wx, wz + r * 1.7);
+      ctx.stroke();
+      if (this.warp.ok && this.warp.snap) {
+        // Draw the leg from the tap to the road it actually snapped to, so a
+        // long snap is visible rather than a surprise on arrival.
+        const [sx, sz] = toC(this.warp.snap.x, this.warp.snap.z);
+        ctx.setLineDash([size * 0.008, size * 0.006]);
+        ctx.beginPath();
+        ctx.moveTo(wx, wz);
+        ctx.lineTo(sx, sz);
+        ctx.stroke();
+        ctx.setLineDash([]);
+        ctx.fillStyle = '#7ee0a4';
+        ctx.beginPath();
+        ctx.arc(sx, sz, size * 0.006, 0, Math.PI * 2);
+        ctx.fill();
+      }
+    }
+  }
+
+  /**
+   * Canvas/client point -> world metres, or null outside the map square.
+   * Inverse of drawBigMap's toC(); it needs the view drawBigMap recorded.
+   */
+  mapToWorld(clientX, clientY) {
+    const v = this._mapView;
+    if (!v) return null;
+    const r = this.bigMap.getBoundingClientRect();
+    const cx = (clientX - r.left) * (v.w / r.width);
+    const cy = (clientY - r.top) * (v.h / r.height);
+    const u = (cx - v.ox) / v.size;
+    const w = (cy - v.oy) / v.size;
+    if (u < 0 || u > 1 || w < 0 || w > 1) return null;
+    return { x: u * G.MAP_HALF * 2 - G.MAP_HALF, z: w * G.MAP_HALF * 2 - G.MAP_HALF };
   }
 }

--- a/apps/auto/src/main.js
+++ b/apps/auto/src/main.js
@@ -410,6 +410,189 @@ function updatePickups(dt) {
 
 // ---------------------------------------------------------------------------
 
+/**
+ * Cursor over the pause menu for a pad.
+ *
+ * A cursor is not an action: being able to confirm and go back is useless if
+ * the player cannot see WHICH row is about to be pressed, so every move paints
+ * `.padfocus`. The ring keys off a pad being present rather than off "the last
+ * input was a stick", because a player using only the d-pad would otherwise
+ * navigate a menu that never highlights anything.
+ */
+function makePadMenu() {
+  let rows = [];
+  let i = 0;
+  let on = false;
+  const paint = () => {
+    for (const r of rows) r.el.classList.toggle('padfocus', on && r === rows[i]);
+  };
+  return {
+    open() {
+      // Same order as the menu reads on screen -- Resume first.
+      rows = [
+        { el: document.getElementById('resumeBtn'), kind: 'click' },
+        { el: document.getElementById('respawnBtn'), kind: 'click' },
+        { el: document.getElementById('rowQuality'), kind: 'seg' },
+        { el: document.getElementById('setShadows'), kind: 'click' },
+        { el: document.getElementById('setMusic'), kind: 'click' },
+        { el: document.getElementById('setSound'), kind: 'click' },
+        { el: document.getElementById('setSens'), kind: 'range' },
+      ].filter((r) => r.el);
+      i = 0;
+      on = true;
+      paint();
+    },
+    close() {
+      on = false;
+      paint();
+      rows = [];
+    },
+    get active() { return on && rows.length > 0; },
+    move(d) {
+      if (!this.active) return;
+      i = (i + d + rows.length) % rows.length;
+      paint();
+    },
+    adjust(d) {
+      if (!this.active) return;
+      const r = rows[i];
+      if (r.kind === 'range') {
+        const el = r.el;
+        const step = parseFloat(el.step) || 0.1;
+        el.value = String(clamp(parseFloat(el.value) + d * step,
+          parseFloat(el.min), parseFloat(el.max)));
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+      } else if (r.kind === 'seg') {
+        const opts = Array.from(document.querySelectorAll('[data-quality]'));
+        const cur = opts.findIndex((o) => o.classList.contains('on'));
+        const next = opts[clamp((cur < 0 ? 0 : cur) + d, 0, opts.length - 1)];
+        if (next) next.click();
+      }
+    },
+    confirm() {
+      if (!this.active) return;
+      const r = rows[i];
+      if (r.kind === 'click') r.el.click();
+      else if (r.kind === 'seg') this.adjust(1);
+    },
+  };
+}
+const padMenu = makePadMenu();
+let setPausedRef = null;
+let warpArmed = false;
+
+function setMapOpen(v) {
+  game.mapOpen = v;
+  document.getElementById('mapOverlay').classList.toggle('show', v);
+  if (v) hud.drawBigMap(player, game);
+  else setWarpArmed(false);
+}
+
+function setWarpArmed(v) {
+  warpArmed = v;
+  document.getElementById('warpBtn').classList.toggle('on', v);
+  document.getElementById('mapHint').textContent = v
+    ? (controls.hasPad ? 'Stick to aim, Ⓐ to drop in' : 'Tap anywhere to drop in')
+    : (controls.hasPad ? 'Ⓧ to set spawn, Ⓑ to close' : 'Tap the map to close');
+  if (v) {
+    // Start the crosshair on the player, so a pad has something to move.
+    hud.warp = { x: player.position.x, z: player.position.z, ok: true, snap: null };
+    refreshWarp(hud.warp.x, hud.warp.z);
+  } else {
+    hud.warp = null;
+  }
+  if (game.mapOpen) hud.drawBigMap(player, game);
+}
+
+/** Resolve a map point to the road it would drop you on, for the preview. */
+function refreshWarp(x, z) {
+  const snap = cityRef.respawnPointNear(x, z);
+  hud.warp = { x, z, ok: !!snap, snap };
+  if (game.mapOpen) hud.drawBigMap(player, game);
+  return snap;
+}
+
+/**
+ * Drop the player at a point picked off the map.
+ *
+ * Always snapped to a road node -- the tap is nearly always mid-block, and the
+ * point of the feature is to arrive somewhere you can drive away from. If there
+ * is no road within range (open water, the middle of Discovery Park) it refuses
+ * and says so rather than putting the player in the trees.
+ */
+function warpTo(x, z) {
+  const snap = refreshWarp(x, z);
+  if (!snap) {
+    hud.showToast('No road near there');
+    return;
+  }
+  setMapOpen(false);
+  player.respawn(snap.x, snap.z);
+  controls.setMode('foot');
+  game.dead = false;
+  document.getElementById('wasted').classList.remove('show');
+  world.update(snap.x, snap.z, 40);
+  hud.showToast(`Dropped in — ${G.placeNameAt(snap.x, snap.z)}`);
+  game.newTarget();
+}
+
+/**
+ * Everything the pad drives outside gameplay. Runs before the pause check in
+ * frame(), because the pad that opened the menu has to be able to work it.
+ */
+function handlePadUi(dt) {
+  const u = controls.takeUi();
+
+  if (u.pause) {
+    if (game.mapOpen) setMapOpen(false);
+    else if (setPausedRef) setPausedRef(!game.paused);
+    return;
+  }
+  if (game.mapOpen) {
+    if (u.warp) setWarpArmed(!warpArmed);
+    if (warpArmed) {
+      // The crosshair flies at a fixed metres-per-second so it crosses the
+      // 16 km map in a sane time; the map is drawn at whatever zoom fits, so
+      // moving in screen pixels would change speed with the window.
+      const s = controls.padLook();
+      const m = controls.padMove();
+      const vx = (Math.abs(m.x) > Math.abs(s.x) ? m.x : s.x);
+      const vz = (Math.abs(m.y) > Math.abs(s.y) ? m.y : s.y);
+      if (vx || vz) {
+        const sp = 2600 * dt;
+        refreshWarp(
+          G.clampToMap((hud.warp ? hud.warp.x : player.position.x) + vx * sp),
+          G.clampToMap((hud.warp ? hud.warp.z : player.position.z) + vz * sp),
+        );
+      }
+      if (u.confirm && hud.warp) { warpTo(hud.warp.x, hud.warp.z); return; }
+      if (u.back) { setWarpArmed(false); return; }
+      if (u.map) setMapOpen(false);
+      return;
+    }
+    if (u.map || u.back || u.confirm) setMapOpen(false);
+    return;
+  }
+  if (game.paused) {
+    if (u.nav) padMenu.move(u.nav);
+    if (u.navX) padMenu.adjust(u.navX);
+    if (u.confirm) padMenu.confirm();
+    if (u.back && setPausedRef) setPausedRef(false);
+    return;
+  }
+  if (u.map) setMapOpen(true);
+  if (u.radio) {
+    audio.init();
+    audio.resume();
+    if (!audio.musicOn) {
+      audio.musicOn = true;
+      hud.showToast(audio.stationName());
+    } else {
+      hud.showToast(u.radio > 0 ? audio.nextStation() : audio.nextStation());
+    }
+  }
+}
+
 function wireUi() {
   const pause = document.getElementById('pauseMenu');
   const bigMapWrap = document.getElementById('mapOverlay');
@@ -417,20 +600,30 @@ function wireUi() {
   const setPaused = (v) => {
     game.paused = v;
     pause.classList.toggle('show', v);
+    if (v) padMenu.open(); else padMenu.close();
     // iOS suspends the AudioContext when the app goes to the background and
     // does not hand it back on its own, so the world would come back silent.
     if (!v) audio.resume();
   };
+  setPausedRef = setPaused;
   document.getElementById('pauseBtn').addEventListener('click', () => setPaused(!game.paused));
   document.getElementById('resumeBtn').addEventListener('click', () => setPaused(false));
-  document.getElementById('mapBtn').addEventListener('click', () => {
-    game.mapOpen = !game.mapOpen;
-    bigMapWrap.classList.toggle('show', game.mapOpen);
-    if (game.mapOpen) hud.drawBigMap(player, game);
+  // Tap the minimap to open the full map -- it replaced a dedicated button.
+  document.getElementById('minimapWrap').addEventListener('click', () => {
+    setMapOpen(!game.mapOpen);
   });
-  bigMapWrap.addEventListener('click', () => {
-    game.mapOpen = false;
-    bigMapWrap.classList.remove('show');
+  document.getElementById('warpBtn').addEventListener('click', (e) => {
+    e.stopPropagation(); // the overlay's own click closes the map
+    setWarpArmed(!warpArmed);
+  });
+  bigMapWrap.addEventListener('click', (e) => {
+    // Armed, a tap on the map is a destination rather than "close". Disarmed,
+    // the old behaviour is untouched: tap anywhere to dismiss.
+    if (warpArmed) {
+      const w = hud.mapToWorld(e.clientX, e.clientY);
+      if (w) { warpTo(w.x, w.z); return; }
+    }
+    setMapOpen(false);
   });
   document.getElementById('radioBtn').addEventListener('click', () => {
     audio.init();
@@ -532,7 +725,15 @@ function frame(now) {
     accumFps = 0;
   }
 
+  // Poll and service the pad BEFORE the pause check: the pad that opened the
+  // menu is the one that has to be able to work it, and a paused frame returns
+  // early. takeLook() below then throws away any stick look accumulated while
+  // the menu was up, so the camera doesn't lurch on resume.
+  controls.poll(dt);
+  handlePadUi(dt);
+
   if (game.paused || game.mapOpen) {
+    controls.takeLook();
     draw(now);
     return;
   }

--- a/apps/auto/src/player.js
+++ b/apps/auto/src/player.js
@@ -173,8 +173,11 @@ export class Player {
     const v = this.vehicle;
     if (!v) { this.onFoot = true; this.h.group.visible = true; return; }
     const steer = -input.x; // HEADING_SENSE: +steer raises heading, which is a left turn
-    const throttle = input.gas ? 1 : 0;
-    const brake = input.brake ? 1 : 0;
+    // Analogue where the input is analogue. vehicles.js has always taken a
+    // continuous throttle; a trigger just stops throwing away the resolution,
+    // which is most of what makes a pad feel different from a touch button.
+    const throttle = input.gasAmt != null ? input.gasAmt : (input.gas ? 1 : 0);
+    const brake = input.brakeAmt != null ? input.brakeAmt : (input.brake ? 1 : 0);
     v.update(dt, { throttle, brake, steer, handbrake: input.hand ? 1 : 0 });
     // Scraping a wall is many frames of contact, not many crashes. Debounced
     // like vehicle-vehicle damage: unthrottled, holding the accelerator into a

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v20';
+const CACHE = 'auto-v21';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',

--- a/tools/verify-pad.mjs
+++ b/tools/verify-pad.mjs
@@ -1,0 +1,269 @@
+// Gamepad verification for apps/auto.
+//
+// A pad cannot be plugged into headless Chrome, so navigator.getGamepads is
+// replaced before boot with one driven from a global the test writes. That
+// exercises everything downstream of the poll -- the mapping table, the edge
+// detection, the menu cursor and the analogue triggers -- which is where the
+// bugs actually are. What it cannot check is that iOS reports `standard`
+// mapping for a given pad; that needs a real device.
+
+import { spawn } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const PORT = 9224;
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const URL_BASE = process.env.AUTO_URL || 'http://localhost:8000/apps/auto/';
+
+const SHIM = `
+window.__noAutoQuality = true;
+window.__pad = { axes: [0,0,0,0], buttons: new Array(17).fill(0), connected: true };
+navigator.getGamepads = () => [{
+  index: 0, id: 'test pad', mapping: 'standard', connected: window.__pad.connected,
+  axes: window.__pad.axes,
+  buttons: window.__pad.buttons.map(v => ({ pressed: v > 0.5, touched: v > 0, value: v })),
+}];
+`;
+
+function launch() {
+  return spawn(CHROME, [
+    `--remote-debugging-port=${PORT}`, '--headless=new', '--use-gl=swiftshader',
+    '--enable-unsafe-swiftshader', '--window-size=1280,720', '--no-first-run',
+    '--user-data-dir=/tmp/auto-pad-profile', 'about:blank',
+  ], { stdio: 'ignore' });
+}
+
+class S {
+  constructor(ws) {
+    this.ws = ws; this.id = 0; this.p = new Map(); this.logs = [];
+    ws.addEventListener('message', (ev) => {
+      const m = JSON.parse(ev.data);
+      if (m.id && this.p.has(m.id)) { this.p.get(m.id)(m); this.p.delete(m.id); }
+      else if (m.method === 'Runtime.exceptionThrown') {
+        this.logs.push('EXCEPTION: ' + (m.params.exceptionDetails.exception?.description
+          || m.params.exceptionDetails.text));
+      }
+    });
+  }
+  send(method, params = {}) {
+    const id = ++this.id;
+    this.ws.send(JSON.stringify({ id, method, params }));
+    return new Promise((r) => this.p.set(id, r));
+  }
+  async eval(expr, aw = false) {
+    const r = await this.send('Runtime.evaluate',
+      { expression: expr, returnByValue: true, awaitPromise: aw });
+    if (r.result?.exceptionDetails) {
+      throw new Error(r.result.exceptionDetails.exception?.description
+        || r.result.exceptionDetails.text);
+    }
+    return r.result?.result?.value;
+  }
+}
+
+const results = [];
+const check = (name, pass, detail = '') => {
+  results.push({ name, pass, detail });
+  console.log(`  ${pass ? 'PASS' : 'FAIL'}  ${name}${detail ? '   ' + detail : ''}`);
+};
+
+async function main() {
+  const chrome = launch();
+  try {
+    let page;
+    for (let i = 0; i < 80 && !page; i++) {
+      try {
+        page = (await (await fetch(`http://127.0.0.1:${PORT}/json/list`)).json())
+          .find((t) => t.type === 'page');
+      } catch { /* not up */ }
+      if (!page) await sleep(300);
+    }
+    const ws = new WebSocket(page.webSocketDebuggerUrl);
+    await new Promise((r, j) => { ws.addEventListener('open', r); ws.addEventListener('error', j); });
+    const s = new S(ws);
+    await s.send('Runtime.enable');
+    await s.send('Page.enable');
+    await s.send('Network.enable');
+    await s.send('Network.setBypassServiceWorker', { bypass: true });
+    await s.send('Page.addScriptToEvaluateOnNewDocument', { source: SHIM });
+    await s.send('Page.navigate', { url: URL_BASE });
+
+    for (let i = 0; i < 400; i++) {
+      await sleep(500);
+      if (await s.eval('!!window.__dbg')) break;
+    }
+    if (!await s.eval('!!window.__dbg')) throw new Error('never booted');
+    console.log('booted with a synthetic pad\n');
+
+    // Helpers: set pad state, then let a few frames run so poll() sees it.
+    const set = async (js) => { await s.eval(`(() => { ${js} })()`); await sleep(450); };
+    const clear = () => set('window.__pad.buttons.fill(0); window.__pad.axes=[0,0,0,0];');
+
+    // --- touch controls come off screen -----------------------------------
+    await set('window.__pad.buttons[9]=1;');
+    await clear();
+    check('pad presence hides the thumb controls',
+      await s.eval('document.getElementById("app").dataset.pad === "1"'));
+
+    // that Start press should have opened the pause menu
+    check('Start opens the pause menu', await s.eval('__dbg.game.paused === true'));
+    check('pause menu shows a controller cursor',
+      await s.eval('!!document.querySelector("#pauseCard .padfocus")'),
+      await s.eval('(document.querySelector("#pauseCard .padfocus")||{}).id || "(row)"'));
+
+    // --- menu navigation ---------------------------------------------------
+    const first = await s.eval('(document.querySelector("#pauseCard .padfocus")||{}).id || "rowQuality"');
+    await set('window.__pad.buttons[13]=1;');   // dpad down
+    await clear();
+    const second = await s.eval('(document.querySelector("#pauseCard .padfocus")||{}).id || "(row)"');
+    check('d-pad moves the cursor', first !== second, `${first} -> ${second}`);
+
+    // A on a toggle row must actually toggle it
+    const before = await s.eval('__dbg.game.settings.shadows');
+    await set('window.__pad.buttons[0]=1;');
+    await clear();
+    const after = await s.eval('__dbg.game.settings.shadows');
+    check('A activates the focused row', before !== after, `shadows ${before} -> ${after}`);
+
+    // B closes the menu
+    await set('window.__pad.buttons[1]=1;');
+    await clear();
+    check('B resumes', await s.eval('__dbg.game.paused === false'));
+
+    // --- gameplay ----------------------------------------------------------
+    await s.eval('__dbg.player.respawn(__dbg.G.SPAWN.x, __dbg.G.SPAWN.z)');
+    await sleep(600);
+
+    // left stick moves; right stick looks
+    const yaw0 = await s.eval('__dbg.player.camYaw');
+    await set('window.__pad.axes=[0,0,1,0];');
+    await clear();
+    const yaw1 = await s.eval('__dbg.player.camYaw');
+    check('right stick turns the camera', Math.abs(yaw1 - yaw0) > 0.05,
+      `yaw ${yaw0.toFixed(2)} -> ${yaw1.toFixed(2)}`);
+
+    const p0 = await s.eval('({x:__dbg.player.position.x, z:__dbg.player.position.z})');
+    await set('window.__pad.axes=[0,-1,0,0];');
+    await sleep(1800);
+    await clear();
+    const p1 = await s.eval('({x:__dbg.player.position.x, z:__dbg.player.position.z})');
+    const walked = Math.hypot(p1.x - p0.x, p1.z - p0.z);
+    check('left stick walks', walked > 1.0, `${walked.toFixed(1)} m`);
+
+    // Y enters a vehicle
+    await s.eval(`(() => { const d = window.__dbg, p = d.player.position;
+      const v = d.traffic.nearestEnterable(p.x, p.z, 500);
+      if (v) { d.player.x = v.x - 2; d.player.z = v.z; d.player.position.x = v.x - 2;
+               d.player.position.z = v.z; } })()`);
+    await sleep(400);
+    await set('window.__pad.buttons[3]=1;');
+    await clear();
+    const inCar = await s.eval('!__dbg.player.onFoot');
+    check('Y enters a vehicle', inCar);
+
+    if (inCar) {
+      // RT is analogue: half a trigger must give roughly half the throttle
+      await set('window.__pad.buttons[7]=0.5;');
+      const half = await s.eval('__dbg.controls.read().gasAmt');
+      await set('window.__pad.buttons[7]=1;');
+      const full = await s.eval('__dbg.controls.read().gasAmt');
+      check('RT throttle is analogue, not on/off',
+        half > 0.4 && half < 0.6 && full > 0.95, `half=${half} full=${full}`);
+
+      const v0 = await s.eval('({x:__dbg.player.position.x, z:__dbg.player.position.z})');
+      await sleep(2500);
+      const v1 = await s.eval('({x:__dbg.player.position.x, z:__dbg.player.position.z})');
+      const drove = Math.hypot(v1.x - v0.x, v1.z - v0.z);
+      check('RT drives the car', drove > 1.0, `${drove.toFixed(1)} m`);
+
+      // A is the handbrake in a car and must NOT be jump
+      const st = await s.eval('({hand:__dbg.controls.read().hand, jump:__dbg.controls.read().jump})');
+      await set('window.__pad.buttons[0]=1;');
+      const st2 = await s.eval('({hand:__dbg.controls.read().hand, jump:__dbg.controls.read().jump})');
+      check('A is handbrake while driving, not jump', st2.hand && !st2.jump,
+        JSON.stringify(st2));
+      // L3 is the horn in a car, sprint on foot
+      await clear();
+      await set('window.__pad.buttons[10]=1;');
+      check('L3 is the horn while driving',
+        await s.eval('__dbg.controls.read().horn === true'));
+      await clear();
+
+      await set('window.__pad.buttons[3]=1;');
+      await clear();
+      check('Y exits the vehicle', await s.eval('__dbg.player.onFoot === true'));
+    }
+
+    // on foot, L3 is sprint and A is jump
+    await set('window.__pad.buttons[10]=1;');
+    check('L3 sprints on foot', await s.eval('__dbg.controls.read().sprint === true'));
+    await clear();
+    await set('window.__pad.buttons[0]=1;');
+    check('A jumps on foot', await s.eval('__dbg.controls.read().jump === true'));
+    await clear();
+
+    // Back opens the map, and closes it again
+    await set('window.__pad.buttons[8]=1;');
+    await clear();
+    const mapOpen = await s.eval('__dbg.game.mapOpen === true');
+    await set('window.__pad.buttons[1]=1;');
+    await clear();
+    check('Back opens the map, B closes it',
+      mapOpen && await s.eval('__dbg.game.mapOpen === false'));
+
+    // --- map warp ----------------------------------------------------------
+    await set('window.__pad.buttons[8]=1;');   // Back -> open map
+    await clear();
+    await set('window.__pad.buttons[2]=1;');   // X -> arm the spawn picker
+    await clear();
+    check('X arms the spawn picker',
+      await s.eval('!!__dbg.hud.warp && document.getElementById("warpBtn").classList.contains("on")'));
+
+    const c0 = await s.eval('({x:__dbg.hud.warp.x, z:__dbg.hud.warp.z})');
+    await set('window.__pad.axes=[1,0,0,0];');
+    await sleep(1200);
+    await clear();
+    const c1 = await s.eval('({x:__dbg.hud.warp.x, z:__dbg.hud.warp.z})');
+    check('stick moves the crosshair', Math.abs(c1.x - c0.x) > 100,
+      `${c0.x.toFixed(0)} -> ${c1.x.toFixed(0)}`);
+
+    // the crosshair must resolve to a road, and A must drop the player onto it
+    const snap = await s.eval('__dbg.hud.warp.snap');
+    check('crosshair resolves to a road', !!snap,
+      snap ? `${snap.dist.toFixed(0)} m away` : 'none');
+    await set('window.__pad.buttons[0]=1;');   // A -> confirm
+    await clear();
+    const after2 = await s.eval(`(() => { const p = __dbg.player.position;
+      const n = __dbg.city.respawnPointNear(p.x, p.z, 40);
+      return { x: p.x, z: p.z, onRoad: !!n && n.dist < 6, mapOpen: __dbg.game.mapOpen,
+               onFoot: __dbg.player.onFoot }; })()`);
+    check('A drops the player, on a road, and closes the map',
+      after2.onRoad && !after2.mapOpen && after2.onFoot, JSON.stringify(after2));
+
+    // a point far out in Puget Sound has no road and must be refused
+    const refused = await s.eval(`(() => {
+      const before = { x: __dbg.player.position.x, z: __dbg.player.position.z };
+      const n = __dbg.city.respawnPointNear(-7200, -1200, 1200);
+      return { snapped: n, ok: n === null || Math.hypot(n.x + 7200, n.z + 1200) > 0 };
+    })()`);
+    check('open water finds no nearby road', refused.snapped === null,
+      refused.snapped ? `snapped ${refused.snapped.dist.toFixed(0)} m` : 'refused');
+
+    // unplugging must not leave anything held
+    await set('window.__pad.buttons[7]=1;');
+    await set('window.__pad.connected=false;');
+    await clear();
+    check('unplugging releases every held input',
+      await s.eval('__dbg.controls.read().gasAmt === 0 && !__dbg.controls.hasPad'));
+
+    const ex = s.logs.filter((l) => /EXCEPTION/.test(l));
+    if (ex.length) console.log('\n' + ex.slice(0, 6).join('\n'));
+    const bad = results.filter((r) => !r.pass).length + ex.length;
+    console.log(`\n${bad ? 'FAIL' : 'OK'}: ${results.length - results.filter(r => !r.pass).length}`
+      + `/${results.length} checks, ${ex.length} exceptions`);
+    process.exitCode = bad ? 1 : 0;
+  } finally {
+    chrome.kill('SIGKILL');
+  }
+}
+
+main().catch((e) => { console.error('verify-pad failed:', e.message); process.exitCode = 1; });


### PR DESCRIPTION
> ⚠️ **Not yet verified.** `tools/verify-pad.mjs` is written but has never been run — see the bottom of this description. Treat the controller and warp paths as untested code.

## Controller

GTA's layout, because that is the one your hands already know.

| | in a car | on foot |
|---|---|---|
| **RT / LT** | accelerate / brake — **analogue** | attack |
| **A** | handbrake | jump |
| **L3** | horn | hold to sprint |
| **Y** | exit vehicle | enter vehicle |
| **X** | attack | attack |
| **LS / RS** | steer / camera | move / camera |
| **Start / Back** | pause / map | pause / map |
| **D-pad ←→** | radio station | radio station |

Two details worth calling out:

- **The triggers are analogue.** `vehicles.js` has always taken a continuous throttle; `player.js` was flattening it to `0/1`. A trigger now just stops throwing the resolution away, which is most of what makes a pad feel different from an on-screen button.
- **Sprint is a hold, never a toggle.** A toggle stays latched after the stick is released, so you arrive somewhere still sprinting. Same rule the zombies app documents.

The pause menu gets a real controller cursor. Per that app's law — *a cursor is not an action* — being able to confirm without showing **which** row is about to be pressed is the bug this exists to avoid, so every move paints `.padfocus`. It keys off a pad being present rather than "the last input was a stick", so a d-pad-only player still sees it. A connected pad also takes the thumb controls off screen, since they cover a third of it.

## Map-tap spawn

Open the map, hit **SET SPAWN** (or **X** on a pad), then tap anywhere — or aim the crosshair with the stick and press **A**.

The destination **always snaps to a road graph node**. A tap is nearly always mid-block and the point of the feature is to arrive somewhere you can drive away from, so nodes (~50 m apart along every carriageway) are the only guaranteed-on-tarmac points. The map draws the dashed leg from your tap to the road it picked, so a long snap is visible rather than a surprise on arrival. Ground-level nodes are preferred over bridge decks — landing on an unmarked freeway is a worse surprise than walking 30 m — and anywhere with no road within 1.2 km (open water, the middle of Discovery Park) is refused with a toast rather than dropping you in the trees.

Disarmed, the map behaves exactly as before: tap anywhere to dismiss.

## The two you asked for mid-test

- **Resume is now the first thing in the pause menu**, above the settings, so getting back into the game never needs a scroll. The pad cursor order follows the new visual order.
- **The map button is gone** — the minimap itself opens the map. `#hud` is `pointer-events: none`, so the minimap has to opt back in for the tap to land.

## Verification status

`tools/verify-pad.mjs` shims `navigator.getGamepads` before boot and drives a synthetic pad through the whole surface: the mapping table, edge detection, the menu cursor, analogue trigger response, entering/exiting a car, the map warp landing on a road, open water being refused, and unplugging releasing every held input. That is where the bugs in this kind of code actually live.

**It has not been run.** What it could never check anyway is that a real iOS device reports `standard` mapping for a given pad — that needs hardware.

Build number and `CACHE` both moved to v21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B