### PR TITLE
Auto: give the landmarks their sites back

### DIFF
--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -374,7 +374,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v23</div>
+    <div id="build">v24</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -11,6 +11,7 @@
 
 import * as G from './geo.js';
 import { CLS_NAME, F_ELEV, F_TUNNEL, F_ONEWAY, F_ONEWAY_REV } from './mapdata.js';
+import { LANDMARK_CLEAR } from './landmarks.js';
 import { distToSeg, clamp, hash2 } from './util.js';
 
 export const CHUNK = 400;
@@ -51,7 +52,7 @@ function styleFor(cls, h) {
 
 // Counters the verify harness asserts on, so a regression in the clearing
 // passes shows up as a number rather than as a screenshot nobody looks at.
-export const cityStats = { buildingsShrunk: 0, buildingsDropped: 0, treesSkipped: 0 };
+export const cityStats = { buildingsShrunk: 0, buildingsDropped: 0, treesSkipped: 0, landmarkCleared: 0 };
 
 const skey = (cx, cz) => cx * 100003 + cz;
 
@@ -227,6 +228,36 @@ export function* cityGenerator(md) {
   }
   cityStats.buildingsShrunk = shrunk;
   cityStats.buildingsDropped = dropped;
+
+  // --- 2c. Landmarks get their site to themselves -------------------------
+  //
+  // We draw our own Space Needle, and OSM has a building footprint for it as
+  // well -- 38 x 38 m, tagged 184 m tall. Imported as an ordinary tower it
+  // lands on exactly the same spot and encloses the hand-built mesh, which is
+  // where the Space Needle went. Same for the stadiums, the Market and the
+  // locks. `reserved` did this job before the import rewrite and was dropped on
+  // the reasoning that "towers are just buildings" -- true of towers, false of
+  // anything we model ourselves.
+  let landmarkCleared = 0;
+  for (const l of G.LANDMARKS) {
+    const r = LANDMARK_CLEAR[l.kind] || 55;
+    const lx = l.p ? l.p[0] : l.x, lz = l.p ? l.p[1] : l.z;
+    for (let bi = buildings.length - 1; bi >= 0; bi--) {
+      const bd = buildings[bi];
+      const dx = lx - bd.x, dz = lz - bd.z;
+      if (dx * dx + dz * dz > (r + 90) * (r + 90)) continue;
+      // Nearest point of the rotated box to the landmark centre.
+      const c = Math.cos(-bd.rot), s = Math.sin(-bd.rot);
+      const px = dx * c - dz * s, pz = dx * s + dz * c;
+      const qx = clamp(px, -bd.w / 2, bd.w / 2);
+      const qz = clamp(pz, -bd.d / 2, bd.d / 2);
+      if ((px - qx) ** 2 + (pz - qz) ** 2 < r * r) {
+        buildings.splice(bi, 1);
+        landmarkCleared++;
+      }
+    }
+  }
+  cityStats.landmarkCleared = landmarkCleared;
 
   // Nothing may stand where the player gets put down. Inside a footprint,
   // blocked() refuses every direction and the player is stuck for good, walking

--- a/apps/auto/src/landmarks.js
+++ b/apps/auto/src/landmarks.js
@@ -377,6 +377,23 @@ function aquarium() {
 
 // ---------------------------------------------------------------------------
 
+/**
+ * Radius, in metres, that each landmark needs to itself.
+ *
+ * OSM has footprints for these too -- the Space Needle is a 38 x 38 m building
+ * tagged 184 m tall -- so without this the importer draws a generic grey tower
+ * in exactly the same place as the hand-built mesh and swallows it whole. That
+ * is where the Space Needle went. This file owns the meshes, so it is the file
+ * that knows how much room each one takes; keep a new entry here whenever a
+ * landmark is added or `buildLandmarks` will quietly be building it inside a box.
+ */
+export const LANDMARK_CLEAR = {
+  spaceNeedle: 48, mopop: 62, arena: 95, spheres: 44, market: 75, wheel: 42,
+  aquarium: 48, ferry: 72, library: 48, pier: 52, gasworks: 95, troll: 18,
+  locks: 75, kerry: 30, ferriswheelPier: 42, convention: 62,
+  stadiumF: 135, stadiumB: 128, stadiumH: 122,
+};
+
 export function buildLandmarks(scene) {
   const root = new THREE.Group();
   for (const l of G.LANDMARKS) {
@@ -419,6 +436,7 @@ export function buildLandmarks(scene) {
     root.add(g);
   }
   const merged = mergeByMaterial(root);
+  merged.name = 'landmarks';
   merged.traverse((o) => { if (o.isMesh) o.frustumCulled = false; });
   scene.add(merged);
   return merged;

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v23';
+const CACHE = 'auto-v24';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',

--- a/tools/verify.mjs
+++ b/tools/verify.mjs
@@ -218,6 +218,7 @@ async function main() {
       mkdirSync(OUT, { recursive: true });
       const views = [
         ['spawn', null],
+        ['needle', [-857, -1130]],
         ['downtown', [200, 400, 60]],
         // I-5 and Aurora-through-Woodland-Park are the two spots the road
         // complaints came from: a box across the freeway, and trees on the
@@ -242,6 +243,10 @@ async function main() {
       // Aerial. The frame loop still draws while paused but stops driving the
       // camera from the player, so it can just be posed.
       for (const [name, x, z, h] of [
+        // Posed at the Space Needle. A respawn faces wherever the camera
+        // happened to be, which is how a landmark can look missing when it is
+        // simply behind you.
+        ['needle-posed', -857, -1019, 55],
         ['aerial-downtown', 300, 700, 700],
         ['aerial-lakeunion', 200, -2600, 1100],
       ]) {
@@ -249,8 +254,8 @@ async function main() {
           const d = window.__dbg;
           d.game.paused = true;
           d.world.update(${x}, ${z}, 40);
-          d.camera.position.set(${x}, ${h}, ${z + h * 0.9});
-          d.camera.lookAt(${x}, 0, ${z});
+          d.camera.position.set(${x}, ${h}, ${z + (h > 200 ? h * 0.9 : 260)});
+          d.camera.lookAt(${x}, ${h > 200 ? 0 : 120}, ${z});
           d.camera.updateMatrixWorld(true);
         })()`);
         await sleep(6000);


### PR DESCRIPTION
**The Space Needle was inside a box.**

OpenStreetMap has a building footprint for it — 38 × 38 m, tagged 184 m tall — so the importer drew a generic grey tower in exactly the same place as our hand-built mesh and swallowed it whole. Same for Lumen Field, T-Mobile Park, Husky Stadium, Pike Place, the locks and the Arena.

`reserved` used to do this job and I dropped it in the import rewrite, reasoning that *"towers are just buildings, from the same source as the roads"*. That's true of towers and false of anything we model ourselves: where there's a hand-built mesh, the imported box is a **duplicate of it**, not a neighbour.

## The fix

`LANDMARK_CLEAR` lives in `landmarks.js` because that file owns the meshes and is therefore the only one that knows how much room each takes — a stadium needs 130 m, the Fremont Troll needs 18. **86 boxes removed**, and all landmark sites now measure clear.

Add an entry whenever a landmark is added, or `buildLandmarks` will quietly build it inside a box again.

## What this cost me, and the harness change that follows from it

The geometry was right the whole time. Before touching anything, the Needle's beacon measured **224.5 m against terrain at 40.5 m** — exactly the model's 185 m spire. It was simply wrapped in a grey box.

What sent me looking for a rendering bug was the screenshot: `player.respawn()` faces wherever the camera happened to be, so the first "where is it" shot pointed at MoPOP instead, which also *looked* like it was floating (it wasn't — that's a rise in the ground between camera and building). A respawn is not a way to look at a specific thing.

So `verify.mjs` now **poses a camera at the Needle** instead of respawning next to it, and the merged landmark mesh is named `landmarks` so it can be found from `__dbg` at all — `mergeByMaterial` flattens the meshes and discards the per-landmark `userData`, which is why my first probe reported `meshFound: false` for something that was plainly in the scene.

![the Needle, framed properly]

Build number and `CACHE` both moved to v24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B