### PR TITLE
Auto: clean up the road surface

### DIFF
--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -256,6 +256,50 @@ which made every I-5 carriageway 21.6 m wide whether it carried three lanes or
 six. `CLASS_MIN_HW` is per-class and low enough that the lane count actually
 drives the width.
 
+### The road surface itself
+
+**Coplanar asphalt is what "messy" looked like.** `roadCoveredAt` only drops a
+surface whose whole width is inside another's -- it has to, or every ramp beside
+a motorway loses its tarmac -- so partial overlaps are drawn, and they used to be
+drawn at exactly the same height. A raycast over one freeway found a second road
+surface within half a metre behind **129 of 148 sampled pixels**. Coplanar quads
+z-fight, and because the two face slightly differently it reads as soft dark
+blotches smeared over the road rather than as obvious flicker, which is why it
+looks like a texture problem and is not one. Each edge now takes a deterministic
+`hash2(ei, 7) * 0.03` lift, so overlaps resolve instead of fighting: median
+separation went 0 -> 29 mm and 93 % of coplanar samples cleared. 3 cm is far
+under the 22 cm kerb, so `roadLift` doesn't need to know.
+
+**Don't diagnose this from a render.** Nulling the albedo, the normal map, the
+roughness map and the vertex colours in turn all failed to explain it, and a
+luminance dump of the road texture came back flat (84-93 across a 16x16 grid).
+Raycasting the offending pixels and asking what was behind them found it in one
+step. Same lesson as the wheel-well slab in "Vehicles".
+
+**Lane markings are geometry, not texture.** They used to be painted into the
+asphalt texture, which forced one repeat to stretch across the full road width so
+the lines landed at the edges and the centre -- and that tied the ASPHALT's grain
+to the road's width too: 1.8 cm per texel on a residential street, 5.3 cm on a
+27 m highway, so the aggregate became gravel on anything wide. The texture now
+tiles at a fixed `ROAD_TILE` metres and `meshRoadMarks()` lays lines down in real
+metres: 12 cm wide, 3 m dashes with 6 m gaps, on every class. Under 4 m of
+half-width gets nothing, which is what an alley has.
+
+**Nothing scattered may stand on a carriageway, including above one.**
+`city.onRoad()` deliberately counts **elevated** edges: anything placed on the
+ground under a viaduct grows straight through the deck, and there was a pine tree
+in the middle of the I-90 bridge because it didn't. Street furniture needs the
+same check for a different reason -- it offsets sideways from its own road, which
+beside a ramp lands it on the freeway.
+
+**Survey the freeways specifically, and pose the camera.** `tools/survey.mjs`
+poses a camera on the carriageway looking along it, at a spread of sites. Two
+things it got wrong at first and now doesn't: it skipped elevated edges, so every
+viaduct in the city went unlooked-at; and it posed the camera without moving the
+sun, whose shadow camera is only ~105 m wide and follows the player -- the stale
+shadow map painted dark blotches on the asphalt that looked exactly like the bug
+being hunted.
+
 ## What the map looks like from above
 
 Still the cheapest way to find a layout bug, and none of it is visible at street

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -374,7 +374,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v24</div>
+    <div id="build">v25</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -52,7 +52,7 @@ function styleFor(cls, h) {
 
 // Counters the verify harness asserts on, so a regression in the clearing
 // passes shows up as a number rather than as a screenshot nobody looks at.
-export const cityStats = { buildingsShrunk: 0, buildingsDropped: 0, treesSkipped: 0, landmarkCleared: 0 };
+export const cityStats = { buildingsShrunk: 0, buildingsDropped: 0, treesSkipped: 0, landmarkCleared: 0, propsSkipped: 0 };
 
 const skey = (cx, cz) => cx * 100003 + cz;
 
@@ -568,7 +568,10 @@ export function* cityGenerator(md) {
           if (!c) continue;
           for (const ei of c.edges) {
             const e = g.edges[ei];
-            if (e.elev) continue;
+            // Elevated edges count. Anything scattered on the ground under a
+            // viaduct grows straight up through the deck -- there was a pine
+            // tree in the middle of the I-90 bridge because this said
+            // `if (e.elev) continue`, and a tree does not know it is indoors.
             const a = g.nodes[e.a], b = g.nodes[e.b];
             if (distToSeg(x, z, a.x, a.z, b.x, b.z).d <= e.hw + pad) return true;
           }

--- a/apps/auto/src/textures.js
+++ b/apps/auto/src/textures.js
@@ -363,19 +363,16 @@ function roadSurface() {
     rgh.g.fillStyle = g1;
     rgh.g.fillRect(cx - 26, 0, 52, S);
   }
-  // U runs across the road width, V along its length
-  const paint = (g, style, x, y, w, h) => { g.fillStyle = style; g.fillRect(x, y, w, h); };
-  paint(a.g, '#e9e7de', 12, 0, 8, S);
-  paint(a.g, '#e9e7de', S - 20, 0, 8, S);
-  paint(hgt.g, grey(0.8), 12, 0, 8, S);
-  paint(hgt.g, grey(0.8), S - 20, 0, 8, S);
-  paint(rgh.g, grey(0.9), 12, 0, 8, S);
-  paint(rgh.g, grey(0.9), S - 20, 0, 8, S);
-  for (let y = 0; y < S; y += 80) {
-    paint(a.g, '#e4c23e', S / 2 - 6, y, 12, 48);
-    paint(hgt.g, grey(0.8), S / 2 - 6, y, 12, 48);
-    paint(rgh.g, grey(0.9), S / 2 - 6, y, 12, 48);
-  }
+  // No lane markings in here.
+  //
+  // They used to be painted into this texture, which forced world.js to stretch
+  // one repeat across the full road width so the lines landed at the edges and
+  // the centre. That made the ASPHALT scale with the road too: a residential
+  // street got 1.8 cm per texel and a 27 m highway got 5.3 cm, so on anything
+  // wide the aggregate became gravel and the repair patches became 8 m smudges.
+  // That is what the wide roads' "messy" surface was. The texture now tiles at a
+  // fixed size in metres and world.js lays the markings down as geometry, which
+  // also gets them the right real-world width and dash spacing on every class.
   return { map: tex(a.c), normalMap: normalFrom(hgt.c, 1.1), roughnessMap: tex(rgh.c, { srgb: false }) };
 }
 

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -8,6 +8,13 @@ import { Builder } from './build.js';
 import { hash2, clamp, lerp, distToSeg } from './util.js';
 
 const ROAD_Y = ROAD_LIFT;
+// Metres per road-texture repeat. Fixed, so the asphalt's grain is the same
+// size on an alley and on a freeway.
+const ROAD_TILE = 9;
+// Paint sits just proud of the asphalt; any less and it z-fights at distance.
+const MARK_Y = ROAD_LIFT + 0.012;
+// `flat` has no map, but Builder.quad indexes the uv array unconditionally.
+const ZERO_UV = [0, 0, 0, 0, 0, 0, 0, 0];
 const NODE_Y = NODE_LIFT;
 const WALK_Y = WALK_LIFT;
 
@@ -578,20 +585,90 @@ export class World {
     }
   }
 
+  /**
+   * Lane markings, as geometry rather than baked into the asphalt texture.
+   *
+   * Drawn in real metres, so a line is 12 cm wide and a dash is 3 m long with a
+   * 6 m gap on every class instead of scaling with the carriageway -- baked into
+   * the texture, a 27 m highway got 4.3 m dashes and a residential street got
+   * 1.4 m ones. Alleys and the narrowest streets get nothing, which is also
+   * what they have in life.
+   */
+  meshRoadMarks(flat, e, a, b, ei) {
+    const hw = e.hw;
+    const bias = hash2(ei | 0, 7) * 0.03;
+    if (hw < 4.0) return;                       // alleys and lanes are unmarked
+    const px = -e.dz, pz = e.dx;
+    const yAt = (x, z) => G.terrainHeight(x, z) + MARK_Y + bias;
+    const W = 0.06;                             // half-width of a painted line
+    const WHITE = [0.94, 0.93, 0.88];
+    const YELLOW = [0.88, 0.72, 0.2];
+
+    const stripe = (off, from, to, col) => {
+      if (to <= from) return;
+      const t0 = from / e.len, t1 = to / e.len;
+      const cx0 = lerp(a.x, b.x, t0) + px * off, cz0 = lerp(a.z, b.z, t0) + pz * off;
+      const cx1 = lerp(a.x, b.x, t1) + px * off, cz1 = lerp(a.z, b.z, t1) + pz * off;
+      if (ei != null && this.city.roadCoveredAt((cx0 + cx1) / 2, (cz0 + cz1) / 2, ei)) return;
+      const l0x = cx0 + px * W, l0z = cz0 + pz * W, r0x = cx0 - px * W, r0z = cz0 - pz * W;
+      const l1x = cx1 + px * W, l1z = cz1 + pz * W, r1x = cx1 - px * W, r1z = cz1 - pz * W;
+      flat.quad(
+        [l0x, yAt(l0x, l0z), l0z],
+        [r0x, yAt(r0x, r0z), r0z],
+        [r1x, yAt(r1x, r1z), r1z],
+        [l1x, yAt(l1x, l1z), l1z],
+        [0, 1, 0], ZERO_UV, col
+      );
+    };
+
+    // Edge lines, set in from the kerb by about a shoulder's width.
+    const edge = hw - Math.min(0.7, hw * 0.06);
+    const step = 8; // subdivide so a line follows the terrain rather than spanning it
+    for (let s = 0; s < e.len; s += step) {
+      const to = Math.min(e.len, s + step);
+      stripe(edge, s, to, WHITE);
+      stripe(-edge, s, to, WHITE);
+    }
+
+    // Centre line. A motorway carriageway is one-way and has no centre line;
+    // everything else is two-way here, so it gets a broken yellow one.
+    if (e.cls === 'hwy' || e.oneway) return;
+    const DASH = 3, GAP = 6;
+    for (let s = 0; s < e.len; s += DASH + GAP) {
+      stripe(0, s, Math.min(e.len, s + DASH), YELLOW);
+    }
+  }
+
   meshRoad(road, walk, flat, e, a, b, lod, ei) {
     if (e.elev) { this.meshViaduct(road, flat, e, a, b); return; }
     const hw = e.hw;
+    const U1 = (hw * 2) / ROAD_TILE;
     const px = -e.dz, pz = e.dx;
     const steps = Math.max(1, Math.round(e.len / 16));
     const col = e.cls === 'hwy' ? [0.92, 0.92, 0.92] : [1, 1, 1];
     let v = 0;
-    const yAt = (x, z) => G.terrainHeight(x, z) + ROAD_Y;
+    // Deterministic sub-centimetre lift per edge, so two carriageways that
+    // genuinely overlap resolve instead of fighting.
+    //
+    // roadCoveredAt only drops a surface whose WHOLE width is inside another's
+    // -- it has to, or every ramp beside a motorway loses its tarmac. What that
+    // leaves is partial overlaps, and those used to be drawn coplanar: a
+    // raycast over one freeway found a second road surface within half a metre
+    // behind 129 of 148 sampled pixels. Coplanar asphalt z-fights, and because
+    // the two quads face slightly differently it reads as soft dark blotches
+    // smeared over the road rather than as obvious flicker. That is the "messy
+    // surface". 3 cm is far below the 22 cm kerb, so roadLift need not know.
+    const bias = hash2(ei | 0, 7) * 0.03;
+    const yAt = (x, z) => G.terrainHeight(x, z) + ROAD_Y + bias;
     for (let s = 0; s < steps; s++) {
       const t0 = s / steps, t1 = (s + 1) / steps;
       const x0 = lerp(a.x, b.x, t0), z0 = lerp(a.z, b.z, t0);
       const x1 = lerp(a.x, b.x, t1), z1 = lerp(a.z, b.z, t1);
       const seg = e.len / steps;
-      const v0 = v, v1 = v + seg / (hw * 2);
+      // Fixed metres per texture repeat, in BOTH directions. This used to be
+      // `seg / (hw * 2)` with u spanning 0..1 across the road, which tied the
+      // asphalt's grain to how wide the road happened to be.
+      const v0 = v, v1 = v + seg / ROAD_TILE;
       v = v1;
       const l0x = x0 + px * hw, l0z = z0 + pz * hw;
       const r0x = x0 - px * hw, r0z = z0 - pz * hw;
@@ -607,9 +684,10 @@ export class World {
         [r0x, yAt(r0x, r0z), r0z],
         [r1x, yAt(r1x, r1z), r1z],
         [l1x, yAt(l1x, l1z), l1z],
-        [0, 1, 0], [0, v0, 1, v0, 1, v1, 0, v1], col
+        [0, 1, 0], [0, v0, U1, v0, U1, v1, 0, v1], col
       );
     }
+    this.meshRoadMarks(flat, e, a, b, ei);
     if (lod === 1 && (e.cls === 'st' || e.cls === 'art' || e.cls === 'res')) {
       const sw = e.cls === 'art' ? 3.2 : 2.6;
       // Stop short of each intersection: a strip run end to end would march
@@ -946,6 +1024,10 @@ export class World {
         const ox = x + px * sg * (e.hw + 1.4);
         const oz = z + pz * sg * (e.hw + 1.4);
         if (!G.isBuildable(ox, oz)) continue;
+        // Offsetting sideways off THIS road can land on a different one -- a
+        // ramp beside a freeway puts its lamp posts and trees on the freeway,
+        // and beneath a viaduct they grow through the deck.
+        if (city.onRoad(ox, oz, 0.8)) { cityStats.propsSkipped++; continue; }
         const gy = G.terrainHeight(ox, oz) + WALK_Y;
         const armRot = Math.atan2(-px * sg, -pz * sg);
         if (h < 0.42) {

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v24';
+const CACHE = 'auto-v25';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',

--- a/tools/survey.mjs
+++ b/tools/survey.mjs
@@ -1,0 +1,156 @@
+// Street-level survey. Poses the camera on the carriageway at a spread of
+// locations and looks ALONG the road, which is the only way to actually see
+// what the road surface looks like.
+//
+//   node tools/survey.mjs [count]
+//
+// A respawn is no good for this: it faces wherever the camera happened to be.
+// Every shot here is deliberately aimed down a chosen edge.
+
+import { spawn } from 'node:child_process';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const PORT = 9225;
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const OUT = 'tools/data/survey';
+const N = parseInt(process.argv[2] || '14', 10);
+
+// Places worth looking at, chosen to hit every road class and the awkward
+// geometry: interchanges, bridge touchdowns, junctions, park crossings.
+// `elev:true` looks at a DECK. The survey skipped elevated edges entirely at
+// first, which meant every viaduct in the city went unlooked-at -- and the
+// freeways are exactly where the geometry is hardest.
+const SITES = [
+  ['fwy-i5-downtown', 900, 700, 'hwy'],
+  ['fwy-i5-ship-canal', 1050, -3300, 'hwy'],
+  ['fwy-i90-bridge', 3400, 2100, 'elev'],
+  ['fwy-520-bridge', 3900, -3100, 'elev'],
+  ['fwy-viaduct-99', -500, 1200, 'elev'],
+  ['fwy-ws-bridge', -1900, 3050, 'elev'],
+  ['fwy-i5-express', 1200, -1500, 'hwy'],
+  ['fwy-ramp-mercer', 500, -1300, 'ramp'],
+  ['downtown-grid', 300, 500],
+  ['downtown-3rd', 120, 700],
+  ['i5-express', 1270, 2641],
+  ['i5-ship-canal', 1000, -3400],
+  ['i5-interchange', 1294, 3982],
+  ['aurora-bridge', -880, -4550],
+  ['ballard-15th', -3466, -6100],
+  ['fremont', -700, -4400],
+  ['capitol-hill', 1947, -1296],
+  ['west-seattle-bridge', -2100, 3100],
+  ['sodo-marginal', 22, 6582],
+  ['woodland-park', -676, -4842],
+  ['alaskan-way', -400, 500],
+  ['queen-anne-hill', -1436, -2853],
+  ['ud-45th', 1900, -4400],
+  ['rainier-ave', 3200, 4200],
+];
+
+function launch() {
+  return spawn(CHROME, [
+    `--remote-debugging-port=${PORT}`, '--headless=new', '--use-gl=swiftshader',
+    '--enable-unsafe-swiftshader', '--autoplay-policy=no-user-gesture-required',
+    '--window-size=1280,720', '--no-first-run',
+    '--user-data-dir=/tmp/auto-survey-profile', 'about:blank',
+  ], { stdio: 'ignore' });
+}
+
+async function main() {
+  const chrome = launch();
+  try {
+    let page;
+    for (let i = 0; i < 80 && !page; i++) {
+      try {
+        page = (await (await fetch(`http://127.0.0.1:${PORT}/json/list`)).json())
+          .find((t) => t.type === 'page');
+      } catch { /* not up */ }
+      if (!page) await sleep(300);
+    }
+    const ws = new WebSocket(page.webSocketDebuggerUrl);
+    await new Promise((r, j) => { ws.addEventListener('open', r); ws.addEventListener('error', j); });
+    let id = 0; const pend = new Map();
+    ws.addEventListener('message', (ev) => {
+      const m = JSON.parse(ev.data);
+      if (m.id && pend.has(m.id)) { pend.get(m.id)(m); pend.delete(m.id); }
+    });
+    const send = (method, params = {}) => new Promise((res) => {
+      ws.send(JSON.stringify({ id: ++id, method, params })); pend.set(id, res);
+    });
+    const evaluate = async (e, aw = false) => {
+      const r = await send('Runtime.evaluate', { expression: e, returnByValue: true, awaitPromise: aw });
+      if (r.result?.exceptionDetails) throw new Error(r.result.exceptionDetails.exception?.description);
+      return r.result?.result?.value;
+    };
+    await send('Runtime.enable');
+    await send('Page.enable');
+    await send('Network.enable');
+    await send('Network.setBypassServiceWorker', { bypass: true });
+    await send('Network.setCacheDisabled', { cacheDisabled: true });
+    await send('Page.addScriptToEvaluateOnNewDocument', { source: 'window.__noAutoQuality = true;' });
+    await send('Page.navigate', { url: 'http://localhost:8000/apps/auto/' });
+    for (let i = 0; i < 400; i++) {
+      await sleep(500);
+      if (await evaluate('!!window.__dbg')) break;
+    }
+    console.log('booted\n');
+    mkdirSync(OUT, { recursive: true });
+
+    // Hide the HUD -- it covers a third of the frame and none of it is road.
+    await evaluate(`(() => { for (const id of ['hud','pad','stickZone','objective'])
+      { const e = document.getElementById(id); if (e) e.style.display = 'none'; }
+      window.__dbg.game.paused = true; })()`);
+
+    if (process.env.SURVEY_MUTATE) await evaluate(process.env.SURVEY_MUTATE);
+    const sites = process.env.SURVEY_SITE
+      ? SITES.filter((s) => s[0] === process.env.SURVEY_SITE)
+      : SITES.slice(0, N);
+    for (const [name, x, z, want] of sites) {
+      const info = await evaluate(`(() => {
+        const d = window.__dbg, c = d.city;
+        // Nearest ground-level edge, and a camera posed just above its surface
+        // looking along it -- eye height, like a driver.
+        const want = ${JSON.stringify(want || 'ground')};
+        let best = -1, bd = 1e9;
+        for (const ei of c.edgesNear(${x}, ${z}, 700)) {
+          const e = c.edges[ei];
+          if (want === 'elev' ? !e.elev : e.elev) continue;
+          if ((want === 'hwy' || want === 'ramp') && e.cls !== want) continue;
+          const a = c.nodes[e.a], b = c.nodes[e.b];
+          const mx = (a.x + b.x) / 2, mz = (a.z + b.z) / 2;
+          const dd = (mx - ${x}) ** 2 + (mz - ${z}) ** 2;
+          if (dd < bd) { bd = dd; best = ei; }
+        }
+        if (best < 0) return null;
+        const e = c.edges[best], a = c.nodes[e.a], b = c.nodes[e.b];
+        const px = (a.x + b.x) / 2, pz = (a.z + b.z) / 2;
+        d.world.update(px, pz, 60);
+        const y = (e.elev ? (a.y + b.y) / 2 : c.groundAt(px, pz, null)) + 1.9;
+        d.camera.position.set(px - e.dx * 22, y, pz - e.dz * 22);
+        d.camera.lookAt(px + e.dx * 60, y - 1.1, pz + e.dz * 60);
+        // Move the sun with the camera. The shadow camera is only ~105 m wide
+        // and follows the player; posing a camera elsewhere without it leaves a
+        // stale shadow map, which paints dark blotches over the asphalt and
+        // looks exactly like a road-surface bug.
+        d.sun.position.set(px - 150, y + 230, pz - 110);
+        d.sun.target.position.set(px, y, pz);
+        d.sun.target.updateMatrixWorld();
+        d.camera.updateMatrixWorld(true);
+        return { cls: e.cls, name: e.name, hw: +e.hw.toFixed(1),
+                 x: +px.toFixed(0), z: +pz.toFixed(0), y: +y.toFixed(1) };
+      })()`);
+      if (!info) { console.log(`  ${name}: no ground edge nearby`); continue; }
+      await sleep(6500);
+      const { result } = await send('Page.captureScreenshot', { format: 'png' });
+      writeFileSync(`${OUT}/${name}.png`, Buffer.from(result.data, 'base64'));
+      console.log(`  ${name.padEnd(20)} ${info.cls.padEnd(5)} hw=${String(info.hw).padStart(5)} `
+        + `${info.name || ''}`);
+    }
+    console.log(`\n${N} shots in ${OUT}/`);
+  } finally {
+    chrome.kill('SIGKILL');
+  }
+}
+
+main().catch((e) => { console.error('survey failed:', e.message); process.exitCode = 1; });


### PR DESCRIPTION
**The messy asphalt was coplanar road quads, not a texture problem.**

`roadCoveredAt` only drops a surface whose whole width is inside another's — it has to, or every ramp beside a motorway loses its tarmac. What that leaves is *partial* overlaps, and those were drawn at exactly the same height. A raycast over one freeway found a second road surface within half a metre behind **129 of 148 sampled pixels**. Coplanar quads z-fight, and because the two face slightly differently it reads as soft dark blotches smeared over the road rather than as obvious flicker — which is precisely why it looks like a texture bug.

Each edge now takes a deterministic sub-centimetre lift, so overlaps resolve instead of fighting:

| stacked road surfaces | before | after |
|---|---|---|
| median vertical separation | ~0 mm | **29 mm** |
| samples coplanar within 4 mm | ~all | **20 of 279** |

3 cm is far under the 22 cm kerb, so `roadLift` doesn't need to know.

### How long that took to find

Nulling the albedo, the normal map, the roughness map and the vertex colours **in turn all failed to explain it**, and a luminance dump of the road texture came back flat — 84–93 across a 16×16 grid, i.e. no large-scale structure at all. Raycasting the offending pixels and asking what was *behind* them found it in one step. Same lesson the wheel-well slab taught in the "Vehicles" section of the app's docs, relearned the hard way.

## Lane markings are geometry now

They used to be painted into the asphalt texture, which forced one repeat to stretch across the full road width so the lines landed at the edges and the centre. That tied the **asphalt's grain** to the road's width: 1.8 cm per texel on a residential street against 5.3 cm on a 27 m highway, so the aggregate became gravel on anything wide and the subtle repair patches became 8 m smudges.

The texture now tiles at a fixed size in metres, and `meshRoadMarks()` lays lines down in real metres — 12 cm wide, 3 m dashes with 6 m gaps, the same on every class instead of 4.3 m dashes on a freeway and 1.4 m on a side street. Under 4 m of half-width gets nothing, which is what an alley has.

## There was a pine tree growing out of the I-90 bridge

`onRoad()` skipped elevated edges, so nothing stopped a tree being planted on the ground *under* a viaduct and coming up through the deck. It counts elevated edges now. Street furniture gets the same check for a different reason: it offsets sideways from its own road, which beside a ramp lands a lamp post on the freeway.

## `tools/survey.mjs`

New. Poses a camera on the carriageway looking along it, at a spread of sites — the only way to actually see the road surface, since a respawn faces wherever the camera happened to be.

**Two things it got wrong at first, both of which matter:**

- It **skipped elevated edges**, so every viaduct in the city went unlooked-at. That's why the freeways were the worst part and I hadn't seen it — thanks for pushing me to check them specifically.
- It posed the camera **without moving the sun**, whose shadow camera is only ~105 m wide and follows the player. The stale shadow map painted dark blotches on the asphalt that looked exactly like the bug being hunted.

## Verification

`node tools/verify.mjs` — boots clean, 0 exceptions, landmark accuracy unchanged (mean 21 m), radio live+offline both pass. 306 draws / 444k triangles (markings add geometry; still inside the streaming budget).

Build number and `CACHE` both moved to v25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B