### PR TITLE
Auto: keep terrain out of the road, and cars on the ground

### DIFF
--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -300,6 +300,50 @@ sun, whose shadow camera is only ~105 m wide and follows the player -- the stale
 shadow map painted dark blotches on the asphalt that looked exactly like the bug
 being hunted.
 
+### Terrain through the tarmac, and cars that won't sit down
+
+**A road quad is a chord, and its error grows with the square of its length.**
+`meshRoad` used fixed 16 m pieces spanning the FULL carriageway width, sampling
+terrain only at the four corners. McGraw Street on Queen Anne drops 5.4 m across
+one such piece and the chord cut **1.39 m** under the crest -- terrain standing
+proud of the asphalt, which is grass growing over the road. Pieces are now sized
+from the terrain, and subdivided across the width as well as along the length
+(~8 m cells; the heightfield is 40 m, so finer than that buys nothing).
+
+Sizing needs **both** tests, taking whichever is finer. Gradient alone misses a
+road that is level end to end but crests in the middle -- the downtown case. Bow
+(the sag at the midpoint) alone misses one whose crest is off-centre or is
+S-shaped, where the midpoint happens to land on the chord; measured on its own it
+was *worse* than the gradient test on Queen Anne, 36.7 cm against 11.8 cm.
+
+| worst terrain above the asphalt | before | after |
+|---|---|---|
+| Queen Anne | 139 cm | **12 cm** |
+| downtown | 106 cm | **24 cm** |
+| West Seattle | -- | **3 cm** |
+
+Under the 22 cm `ROAD_LIFT` nothing shows through, so that is the number to beat.
+Costs about 6 % more triangles and no extra draw calls.
+
+**Paint stops short of a junction, like the pavement does.** Markings that run
+end to end lay each road's edge lines straight across every cross street it
+meets: white lines cutting the carriageway diagonally, centre dashes doubling
+back. `meshRoadMarks` trims to `nodeRadius` at both ends. A crossing is mostly
+bare tarmac in life too.
+
+**`rotation.z` raises local +X, so the far side is the one you subtract.** The
+body attitude used `atan2(rh - lh, ...)` with `lh` sampled along local +X, which
+leans the car INTO the slope instead of along it. On a 2.4 deg cross-slope the
++X wheels sat 7.2 cm under the road and the other pair floated 7.1 cm above it --
+the two-wheels-in-the-air. `place()` had the same inverted formula, so parked
+cars leaned wrong too.
+
+**A car rides the plane through its four contact patches, not the ground under
+its centre.** On a crest the centre reads high and the wheels hang; in a dip it
+reads low and they sink. Both `update()` and `place()` now average the four wheel
+samples. Measured after both fixes, all four wheels sit within 0.2 cm of the
+ground on a Queen Anne cross-slope, against +/-7 cm before.
+
 ## What the map looks like from above
 
 Still the cheapest way to find a layout bug, and none of it is visible at street

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -374,7 +374,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v25</div>
+    <div id="build">v26</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/src/vehicles.js
+++ b/apps/auto/src/vehicles.js
@@ -451,7 +451,11 @@ export class Vehicle {
     const lh = at(rx * this.halfWid, rz * this.halfWid);
     const rh = at(-rx * this.halfWid, -rz * this.halfWid);
     this.pitch = Math.atan2(bh - fh, this.halfLen * 2);
-    this.roll = Math.atan2(rh - lh, this.halfWid * 2);
+    this.roll = Math.atan2(lh - rh, this.halfWid * 2); // see update(): +X is raised by +rotation.z
+    // Rest on the plane through the four contact patches, not on the ground
+    // under the centre -- otherwise a car parked across a camber sits with one
+    // pair of wheels buried and the other pair in the air.
+    this.y = (fh + bh + lh + rh) / 4;
     this.sync();
   }
 
@@ -534,8 +538,20 @@ export class Vehicle {
     this.x = G.clampToMap(this.x);
     this.z = G.clampToMap(this.z);
 
+    // Ground under each contact patch. Sampled BEFORE the vertical follow,
+    // because the height the body should sit at is the plane through its four
+    // wheels, not the ground under its centre. On a crest the centre reads high
+    // and the wheels hang; in a dip it reads low and they sink.
+    const f2 = this.forward;
+    const rx2 = f2.z, rz2 = -f2.x;
+    const gAt = (ox, oz) => this.city.groundAt(this.x + ox, this.z + oz, this.y + 1.5, this.lift);
+    const fh = gAt(f2.x * this.halfLen, f2.z * this.halfLen);
+    const bh = gAt(-f2.x * this.halfLen, -f2.z * this.halfLen);
+    const lh = gAt(rx2 * this.halfWid, rz2 * this.halfWid);
+    const rh = gAt(-rx2 * this.halfWid, -rz2 * this.halfWid);
+
     // vertical: follow ground, with a little air time over crests
-    const target = this.city.groundAt(this.x, this.z, this.y + 1.2, this.lift);
+    const target = (fh + bh + lh + rh) / 4;
     if (this.y > target + 0.25) {
       this.vy -= 22 * dt;
       this.y += this.vy * dt;
@@ -548,13 +564,14 @@ export class Vehicle {
       this.onGround = true;
     }
 
-    // body attitude
-    const fh = this.city.groundAt(this.x + f.x * this.halfLen, this.z + f.z * this.halfLen, this.y + 1.5, this.lift);
-    const bh = this.city.groundAt(this.x - f.x * this.halfLen, this.z - f.z * this.halfLen, this.y + 1.5, this.lift);
-    const lh = this.city.groundAt(this.x + rx * this.halfWid, this.z + rz * this.halfWid, this.y + 1.5, this.lift);
-    const rh = this.city.groundAt(this.x - rx * this.halfWid, this.z - rz * this.halfWid, this.y + 1.5, this.lift);
+    // body attitude, from the samples taken above
     const tgtPitch = Math.atan2(bh - fh, this.halfLen * 2) - clamp(acc, -12, 12) * 0.0045;
-    const tgtRoll = Math.atan2(rh - lh, this.halfWid * 2) + clamp(this.vLat, -9, 9) * 0.016;
+    // `lh` is sampled along the body's local +X, and a positive rotation.z
+    // raises local +X -- so the far side has to be SUBTRACTED, not the near one.
+    // Reversed, the car leaned into the slope instead of along it: measured on
+    // a 2.4 deg cross-slope, the +X wheels sat 7.2 cm under the road while the
+    // other pair floated 7.1 cm above it, which is the two-wheels-in-the-air.
+    const tgtRoll = Math.atan2(lh - rh, this.halfWid * 2) + clamp(this.vLat, -9, 9) * 0.016;
     this.pitch = lerp(this.pitch, tgtPitch, 1 - Math.exp(-10 * dt));
     this.roll = lerp(this.roll, tgtRoll, 1 - Math.exp(-10 * dt));
 

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -621,11 +621,20 @@ export class World {
       );
     };
 
+    // Paint stops short of a junction, the same way the pavement strips do.
+    // Run end to end and each road lays its edge lines straight across every
+    // cross street it meets -- white lines cutting the carriageway diagonally
+    // and centre dashes doubling back on themselves. The crossing itself is
+    // bare tarmac, which is what a real junction mostly is.
+    const from = this.nodeRadius(e.a);
+    const till = e.len - this.nodeRadius(e.b);
+    if (till <= from) return;
+
     // Edge lines, set in from the kerb by about a shoulder's width.
     const edge = hw - Math.min(0.7, hw * 0.06);
     const step = 8; // subdivide so a line follows the terrain rather than spanning it
-    for (let s = 0; s < e.len; s += step) {
-      const to = Math.min(e.len, s + step);
+    for (let s = from; s < till; s += step) {
+      const to = Math.min(till, s + step);
       stripe(edge, s, to, WHITE);
       stripe(-edge, s, to, WHITE);
     }
@@ -634,8 +643,10 @@ export class World {
     // everything else is two-way here, so it gets a broken yellow one.
     if (e.cls === 'hwy' || e.oneway) return;
     const DASH = 3, GAP = 6;
-    for (let s = 0; s < e.len; s += DASH + GAP) {
-      stripe(0, s, Math.min(e.len, s + DASH), YELLOW);
+    // Phase the dashes off the edge's own start so they stay evenly spaced
+    // rather than restarting at each junction.
+    for (let s = from; s < till; s += DASH + GAP) {
+      stripe(0, s, Math.min(till, s + DASH), YELLOW);
     }
   }
 
@@ -644,7 +655,32 @@ export class World {
     const hw = e.hw;
     const U1 = (hw * 2) / ROAD_TILE;
     const px = -e.dz, pz = e.dx;
-    const steps = Math.max(1, Math.round(e.len / 16));
+    // Segment length follows the gradient. A flat street is fine in 16 m
+    // pieces, but a road quad is a CHORD and its error grows with the square of
+    // its length: McGraw Street on Queen Anne drops 5.4 m across one 18 m
+    // segment and the chord cut 1.39 m under the crest, which is terrain
+    // standing proud of the asphalt -- the grass growing over the road. At 4 m
+    // the same crest costs about 7 cm, comfortably under the 22 cm road lift.
+    // Only steep roads pay for the extra pieces.
+    // Measure the BOW, not the gradient. A street that climbs steadily is a
+    // chord's best case; what defeats a chord is curvature, and a road can be
+    // level end to end while cresting a rise in the middle -- that is the
+    // downtown case a gradient test missed entirely. One extra terrain sample
+    // gives the sag at the midpoint, and chord error falls with the square of
+    // the piece length, so the length that keeps it under ~6 cm is direct.
+    // The two tests fail on different shapes, so take whichever is finer.
+    // Gradient alone misses a road that is level end to end but crests in the
+    // middle; bow alone misses one whose crest is off-centre or S-shaped, where
+    // the midpoint happens to land on the chord -- measured on its own it was
+    // worse than the gradient test on Queen Anne (36.7 cm against 11.8 cm).
+    const bow = Math.abs(
+      G.terrainHeight((a.x + b.x) / 2, (a.z + b.z) / 2) - (a.y + b.y) / 2
+    );
+    const grade = Math.abs(a.y - b.y) / Math.max(1, e.len);
+    const byGrade = grade > 0.08 ? 4 : grade > 0.03 ? 6 : 8;
+    const byBow = bow < 0.02 ? 8 : clamp(e.len * Math.sqrt(0.06 / bow), 3, 8);
+    const segLen = Math.min(byGrade, byBow);
+    const steps = Math.max(1, Math.round(e.len / segLen));
     const col = e.cls === 'hwy' ? [0.92, 0.92, 0.92] : [1, 1, 1];
     let v = 0;
     // Deterministic sub-centimetre lift per edge, so two carriageways that
@@ -660,32 +696,43 @@ export class World {
     // surface". 3 cm is far below the 22 cm kerb, so roadLift need not know.
     const bias = hash2(ei | 0, 7) * 0.03;
     const yAt = (x, z) => G.terrainHeight(x, z) + ROAD_Y + bias;
+    // Subdivide ACROSS the width as well as along the length.
+    //
+    // The quad used to span the full carriageway with terrain sampled only at
+    // its four corners, so the drawn surface was the bilinear of those -- and on
+    // a cross-slope the real ground in between bulges straight through it. On
+    // Queen Anne that put terrain up to 1.39 m above the asphalt, which is the
+    // grass growing over the road. The heightfield is 40 m, so cells of roughly
+    // 8 m follow it closely without paying for detail that isn't there.
+    const across = Math.max(1, Math.round((hw * 2) / 8));
     for (let s = 0; s < steps; s++) {
       const t0 = s / steps, t1 = (s + 1) / steps;
-      const x0 = lerp(a.x, b.x, t0), z0 = lerp(a.z, b.z, t0);
-      const x1 = lerp(a.x, b.x, t1), z1 = lerp(a.z, b.z, t1);
       const seg = e.len / steps;
       // Fixed metres per texture repeat, in BOTH directions. This used to be
       // `seg / (hw * 2)` with u spanning 0..1 across the road, which tied the
       // asphalt's grain to how wide the road happened to be.
       const v0 = v, v1 = v + seg / ROAD_TILE;
       v = v1;
-      const l0x = x0 + px * hw, l0z = z0 + pz * hw;
-      const r0x = x0 - px * hw, r0z = z0 - pz * hw;
-      const l1x = x1 + px * hw, l1z = z1 + pz * hw;
-      const r1x = x1 - px * hw, r1z = z1 - pz * hw;
-      // Don't pave over a road that outranks this one. Where two carriageways
-      // overlap, both used to draw and the depth buffer chose per pixel, which
-      // is what made the centre line flicker between one stripe and two.
-      if (ei != null
-        && this.city.roadCoveredAt((x0 + x1) / 2, (z0 + z1) / 2, ei)) continue;
-      road.quad(
-        [l0x, yAt(l0x, l0z), l0z],
-        [r0x, yAt(r0x, r0z), r0z],
-        [r1x, yAt(r1x, r1z), r1z],
-        [l1x, yAt(l1x, l1z), l1z],
-        [0, 1, 0], [0, v0, U1, v0, U1, v1, 0, v1], col
-      );
+      // Don't pave over a road that outranks this one. Asked once per segment
+      // rather than per cell -- it is a 3x3-chunk scan and the answer cannot
+      // meaningfully differ across one carriageway's width.
+      const mx = lerp(a.x, b.x, (t0 + t1) / 2), mz = lerp(a.z, b.z, (t0 + t1) / 2);
+      if (ei != null && this.city.roadCoveredAt(mx, mz, ei)) continue;
+      for (let k = 0; k < across; k++) {
+        const o0 = hw - (hw * 2 * k) / across;
+        const o1 = hw - (hw * 2 * (k + 1)) / across;
+        const u0 = (hw - o0) / ROAD_TILE, u1 = (hw - o1) / ROAD_TILE;
+        const P = (t, o) => [lerp(a.x, b.x, t) + px * o, lerp(a.z, b.z, t) + pz * o];
+        const [ax, az] = P(t0, o0), [bx, bz] = P(t0, o1);
+        const [cx, cz] = P(t1, o1), [dx, dz] = P(t1, o0);
+        road.quad(
+          [ax, yAt(ax, az), az],
+          [bx, yAt(bx, bz), bz],
+          [cx, yAt(cx, cz), cz],
+          [dx, yAt(dx, dz), dz],
+          [0, 1, 0], [u0, v0, u1, v0, u1, v1, u0, v1], col
+        );
+      }
     }
     this.meshRoadMarks(flat, e, a, b, ei);
     if (lod === 1 && (e.cls === 'st' || e.cls === 'art' || e.cls === 'res')) {

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v25';
+const CACHE = 'auto-v26';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',

--- a/tools/survey.mjs
+++ b/tools/survey.mjs
@@ -44,6 +44,7 @@ const SITES = [
   ['woodland-park', -676, -4842],
   ['alaskan-way', -400, 500],
   ['queen-anne-hill', -1436, -2853],
+  ['queen-anne-mcgraw', -1118, -3181],
   ['ud-45th', 1900, -4400],
   ['rainier-ave', 3200, 4200],
 ];


### PR DESCRIPTION
Two bugs, both about sloped ground.

## Grass over the road in Queen Anne

**A road quad is a chord, and its error grows with the square of its length.** `meshRoad` used fixed 16 m pieces spanning the *full* carriageway width, sampling terrain only at the four corners. McGraw Street drops 5.4 m across one such piece and the chord cut **1.39 m** under the crest — so the terrain stood proud of the asphalt, which is exactly the grass you were seeing.

Pieces are now sized from the terrain, and subdivided across the width as well as along the length.

| worst terrain above the asphalt | before | after |
|---|---|---|
| Queen Anne | 139 cm | **12 cm** |
| downtown | 106 cm | **24 cm** |
| West Seattle | — | **3 cm** |
| Ballard | — | **0 cm** |

Under the 22 cm `ROAD_LIFT` nothing shows through, so that's the number to beat. Costs ~6% more triangles and no extra draw calls.

**Sizing needs two tests, taking whichever is finer.** Gradient alone misses a road that's level end to end but crests in the middle — the downtown case. Bow (sag at the midpoint) alone misses one whose crest is off-centre or S-shaped, where the midpoint happens to land on the chord; on its own it measured *worse* than the gradient test on Queen Anne, 36.7 cm against 11.8 cm. I tried each separately before combining them.

## Cars with two wheels in the air

Two independent causes, both measurable:

**The roll sign was inverted.** A positive `rotation.z` raises the body's local +X, so the far side is the one to subtract — the code used `atan2(rh - lh, ...)` with `lh` sampled along +X, which leans the car **into** the slope instead of along it. On a 2.4° cross-slope the +X wheels sat 7.2 cm *under* the road while the other pair floated 7.1 cm *above* it. `place()` carried the same inverted formula, so parked cars leaned wrong too.

**The body rode the ground under its centre**, not the plane through its four contact patches — so it hung on crests and sank in dips. Both `update()` and `place()` now average the four wheel samples.

After both fixes, all four wheels sit within **0.2 cm** of the ground on a Queen Anne cross-slope, against ±7 cm before.

## Also

Paint now stops short of a junction the way the pavement strips do. Running end to end, each road laid its edge lines straight across every cross street it met — white lines cutting the carriageway diagonally and centre dashes doubling back on themselves. A crossing is mostly bare tarmac in life too.

## Verification

`node tools/verify.mjs` — boots clean, 0 exceptions, landmark accuracy unchanged, radio live+offline both pass. 306 draws / 453k triangles. New `queen-anne-mcgraw` survey site pinned on the worst measured spot.

Build number and `CACHE` both moved to v26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B