### PR TITLE
Auto: graphics pass — real sunlight, SSAO, material families

### DIFF
--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -503,6 +503,28 @@ Physically-shaded, image-based-lit, tone-mapped, with a hand-rolled post chain.
   unreliable on iOS (silent black screen), so the scene is tone-mapped into an
   8-bit sRGB target and bloom / FXAA / grade / vignette all work in gamma space.
   If you add a pass, keep it 8-bit.
+- **Key-to-ambient is the whole look.** At hemisphere 2.0 against sun 2.5, with
+  full IBL on top, ambient dominated at roughly 1.3:1 and two faces of the same
+  building differed only by texture, never by light. Nothing downstream can read
+  under a shadowless sky -- AO, normal maps and geometry all score flat however
+  good they are. It is now nearer 4:1 (hemi 0.55, sun 3.6, envMapIntensity
+  roughly halved on every material, exposure 1.25). **Change this ratio before
+  reaching for any other visual fix**, because everything else is measured
+  against it.
+- **SSAO reads the scene pass's own depth attachment.** `postfx.sceneRT` carries
+  a `DepthTexture` (integer, so it obeys the no-half-float rule), which the scene
+  pass fills for free -- a separate depth prepass would have doubled the scene's
+  draw calls. Half res, blurred, multiplied BEFORE bloom so bloom cannot bleed
+  back into the crevices AO just darkened.
+- **Dither belongs in the output pass, not in the sky texture.** Baked into the
+  equirect it magnifies across the screen as clumped grain, shows up on the water
+  as well as the sky, and pollutes the IBL that the same texture feeds. It is now
+  screen-space, +/-1/255, after tonemap.
+- **Per-building colour varies TONALLY, in families.** Jittering R, G and B
+  independently manufactures a candy palette; jittering one base colour per style
+  instead produces a whole downtown of the same beige. `tint()` shares its
+  brightness jitter across channels and pulls toward grey, and
+  `buildingFamily()` picks one of five material families weighted by height.
 - **Adaptive quality.** The phone this ships to can't be profiled from here, so
   the game measures its own frame rate and steps `high -> medium -> low`
   (post off, then pixel ratio down). `applyQuality(q, true)` locks it manually.

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -374,7 +374,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v28</div>
+    <div id="build">v29</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/src/main.js
+++ b/apps/auto/src/main.js
@@ -248,7 +248,7 @@ async function boot() {
   renderer = new THREE.WebGLRenderer({ canvas, antialias: false, powerPreference: 'high-performance' });
   renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, isMobile ? 2 : 1.6));
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
-  renderer.toneMappingExposure = 1.5;
+  renderer.toneMappingExposure = 1.25;
   const viewW = () => canvas.clientWidth || window.innerWidth;
   const viewH = () => canvas.clientHeight || window.innerHeight;
   renderer.setSize(viewW(), viewH(), false);
@@ -257,26 +257,46 @@ async function boot() {
   renderer.outputColorSpace = THREE.SRGBColorSpace;
 
   scene = new THREE.Scene();
-  scene.fog = new THREE.FogExp2(0xb9c6d0, 0.00032);
+  // Aerial perspective. At 0.00032 a tower 3 km away reads at nearly the same
+  // contrast and saturation as one across the street, which is what made the
+  // city look like a diorama. The colour is matched to the sky near the
+  // horizon so distance resolves INTO the sky rather than toward a grey haze
+  // sitting in front of it.
+  scene.fog = new THREE.FogExp2(0xc4ccd4, 0.00060);
   camera = new THREE.PerspectiveCamera(62, viewW() / viewH(), 0.5, 9000);
 
   // The sky IBL supplies most of the ambient, so the analytic lights are just a
   // key with a cool bounce fill.
-  const hemi = new THREE.HemisphereLight(0xdcecf6, 0x7b8474, 2.0);
+  // KEY-TO-AMBIENT IS THE WHOLE LOOK. At hemi 2.0 against sun 2.5, plus full
+  // IBL on top, the ambient dominated and the ratio was about 1.3:1 -- so two
+  // faces of the same building differed only by texture, never by light. Nothing
+  // downstream can read under a shadowless sky: AO, normal maps and geometry all
+  // score flat no matter how good they are. Daylight open-worlds run nearer 4:1,
+  // warm key against cool sky fill.
+  const hemi = new THREE.HemisphereLight(0xdcecf6, 0x6d7668, 0.55);
   scene.add(hemi);
-  sun = new THREE.DirectionalLight(0xfff0d8, 2.5);
-  sun.position.set(-160, 240, -110);
+  sun = new THREE.DirectionalLight(0xfff2dc, 3.6);
+  // ~38 deg elevation: high enough to light the streets, low enough that every
+  // shot has a lit face and a shadowed one.
+  sun.position.set(-215, 200, -150);
   sun.castShadow = true;
   sun.shadow.mapSize.set(2048, 2048);
   sun.shadow.camera.near = 20;
-  sun.shadow.camera.far = 620;
-  const S = 105;
+  sun.shadow.camera.far = 780;
+  // 105 m covered barely a block: buildings cast no shadow on the streets they
+  // line, which is most of why the city read as flat. 190 m reaches across a
+  // downtown block and its far side at the cost of shadow-map resolution,
+  // which 2048 absorbs.
+  const S = 190;
   sun.shadow.camera.left = -S;
   sun.shadow.camera.right = S;
   sun.shadow.camera.top = S;
   sun.shadow.camera.bottom = -S;
-  sun.shadow.bias = -0.0009;
-  sun.shadow.normalBias = 0.04;
+  // Widening the shadow camera to 190 m took the texel from ~0.10 m to ~0.19 m,
+  // and the old bias no longer spanned one: acne came back as dark blotches
+  // across sunlit facades. normalBias has to scale with texel size.
+  sun.shadow.bias = -0.0006;
+  sun.shadow.normalBias = 0.09;
   scene.add(sun);
   scene.add(sun.target);
 
@@ -814,7 +834,7 @@ function frame(now) {
   world.update(p.x, p.z, fps < 45 ? 1 : 2);
 
   player.applyCamera(camera);
-  sun.position.set(p.x - 150, p.y + 230, p.z - 110);
+  sun.position.set(p.x - 215, p.y + 200, p.z - 150);
   sun.target.position.set(p.x, p.y, p.z);
   sun.target.updateMatrixWorld();
 
@@ -846,7 +866,7 @@ function draw(now) {
   // capture before the post passes reset the counters
   sceneStats.calls = renderer.info.render.calls;
   sceneStats.tris = renderer.info.render.triangles;
-  postfx.render(now / 1000);
+  postfx.render(now / 1000, camera);
   renderer.setRenderTarget(null);
 }
 const sceneStats = { calls: 0, tris: 0 };

--- a/apps/auto/src/postfx.js
+++ b/apps/auto/src/postfx.js
@@ -53,6 +53,8 @@ uniform float vignette;
 uniform float grain;
 uniform float time;
 uniform float fxaa;
+uniform sampler2D tAO;
+uniform float aoAmount;
 varying vec2 vUv;
 
 // FXAA 3.11 console variant -- cheap, and plenty at phone resolutions.
@@ -83,6 +85,12 @@ vec3 fxaaFilter(vec2 uv) {
 
 void main() {
   vec3 c = fxaa > 0.5 ? fxaaFilter(vUv) : texture2D(tScene, vUv).rgb;
+  // AO before bloom: occlusion belongs to the surface, and applying it after
+  // would let bloom bleed back into the crevices it just darkened.
+  if (aoAmount > 0.0) {
+    float ao = texture2D(tAO, vUv).r;
+    c *= mix(1.0, ao, aoAmount);
+  }
   c += texture2D(tBloom, vUv).rgb * bloomStrength;
 
   // grade: lift the shadows slightly cool, warm the highlights, add contrast
@@ -94,10 +102,77 @@ void main() {
   float d = distance(vUv, vec2(0.5));
   c *= 1.0 - vignette * smoothstep(0.35, 0.95, d);
 
-  float n = fract(sin(dot(vUv * time, vec2(12.9898, 78.233))) * 43758.5453);
-  c += (n - 0.5) * grain;
+  // Screen-space dither at the output, one 8-bit step, unmagnified. Baking
+  // this into the sky equirect instead put clumped multi-pixel grain across the
+  // sky AND the water, and polluted the IBL that the sky feeds.
+  float n1 = fract(sin(dot(vUv, vec2(12.9898, 78.233)) + time) * 43758.5453);
+  float n2 = fract(sin(dot(vUv, vec2(93.9898, 47.233)) + time) * 24634.6345);
+  c += ((n1 - n2) * (1.0 / 255.0)) + (n1 - 0.5) * grain;
 
   gl_FragColor = vec4(clamp(c, 0.0, 1.0), 1.0);
+}`;
+
+// Screen-space ambient occlusion.
+//
+// Reads the DEPTH TEXTURE the scene pass already filled -- an integer depth
+// attachment, not a half-float colour target, so it stays inside the rule that
+// keeps this chain working on iOS. It also costs no extra draw calls: the depth
+// is a by-product of the pass that was happening anyway, where a separate depth
+// prepass would have doubled the scene's 215 draws.
+const SSAO = `
+precision highp float;
+varying vec2 vUv;
+uniform sampler2D tDepth;
+uniform mat4 projInv;
+uniform mat4 proj;
+uniform vec2 texel;
+uniform float radius;
+uniform float strength;
+uniform float bias;
+
+vec3 viewPos(vec2 uv) {
+  float z = texture2D(tDepth, uv).x;
+  vec4 clip = vec4(uv * 2.0 - 1.0, z * 2.0 - 1.0, 1.0);
+  vec4 v = projInv * clip;
+  return v.xyz / v.w;
+}
+
+// 12 points on a hemisphere, weighted toward the centre so near-contact
+// darkening reads without the far samples turning into banding.
+const vec3 K[12] = vec3[12](
+  vec3( 0.5381, 0.1856, 0.4319), vec3( 0.1379, 0.2486, 0.4430),
+  vec3( 0.3371, 0.5679, 0.0057), vec3(-0.6999,-0.0451, 0.0019),
+  vec3( 0.0689,-0.1598, 0.8547), vec3( 0.0560, 0.0069, 0.1843),
+  vec3(-0.0146, 0.1402, 0.0762), vec3( 0.0100,-0.1924, 0.0344),
+  vec3(-0.3577,-0.5301, 0.4358), vec3(-0.3169, 0.1063, 0.0158),
+  vec3( 0.0103,-0.5869, 0.0046), vec3(-0.0897,-0.4940, 0.3287)
+);
+
+void main() {
+  float z = texture2D(tDepth, vUv).x;
+  // Sky: depth 1.0. Occluding it produces a dark halo along every roofline.
+  if (z >= 0.9999) { gl_FragColor = vec4(1.0); return; }
+  vec3 P = viewPos(vUv);
+  vec3 N = normalize(cross(dFdx(P), dFdy(P)));
+  float rnd = fract(sin(dot(vUv, vec2(12.9898, 78.233))) * 43758.5453);
+  float ca = cos(rnd * 6.2831), sa = sin(rnd * 6.2831);
+  float occ = 0.0;
+  for (int i = 0; i < 12; i++) {
+    vec3 k = K[i];
+    k.xy = vec2(k.x * ca - k.y * sa, k.x * sa + k.y * ca);
+    if (dot(k, N) < 0.0) k = -k;
+    vec3 sp = P + k * radius;
+    vec4 cp = proj * vec4(sp, 1.0);
+    vec2 suv = (cp.xy / cp.w) * 0.5 + 0.5;
+    if (suv.x < 0.0 || suv.x > 1.0 || suv.y < 0.0 || suv.y > 1.0) continue;
+    float sz = viewPos(suv).z;
+    // Range check: a foreground object must not occlude the distant ground
+    // behind it, which is what produces black outlines around everything.
+    float rc = smoothstep(0.0, 1.0, radius / abs(P.z - sz));
+    occ += (sz >= sp.z + bias ? 1.0 : 0.0) * rc;
+  }
+  float ao = clamp(1.0 - (occ / 12.0) * strength, 0.0, 1.0);
+  gl_FragColor = vec4(vec3(ao), 1.0);
 }`;
 
 function pass(fragmentShader, uniforms) {
@@ -136,13 +211,29 @@ export class PostFX {
     this.quadScene = new THREE.Scene();
 
     this.sceneRT = makeRT(2, 2, true);
+    // Integer depth attachment, filled by the scene pass at no extra cost. This
+    // is what SSAO reads; a separate depth prepass would double the draw calls.
+    this.sceneRT.depthTexture = new THREE.DepthTexture(2, 2);
+    this.sceneRT.depthTexture.type = THREE.UnsignedIntType;
     this.bloomA = makeRT(2, 2, false);
     this.bloomB = makeRT(2, 2, false);
+    this.aoA = makeRT(2, 2, false);
+    this.aoB = makeRT(2, 2, false);
+    this.ssaoOn = true;
 
     this.bright = pass(BRIGHT, {
-      tScene: { value: null }, threshold: { value: 0.72 }, softness: { value: 0.28 },
+      tScene: { value: null }, threshold: { value: 0.86 }, softness: { value: 0.22 },
     });
     this.blur = pass(BLUR, { tSrc: { value: null }, dir: { value: new THREE.Vector2() } });
+    this.ssao = pass(SSAO, {
+      tDepth: { value: null },
+      projInv: { value: new THREE.Matrix4() },
+      proj: { value: new THREE.Matrix4() },
+      texel: { value: new THREE.Vector2() },
+      radius: { value: 0.85 },
+      strength: { value: 1.5 },
+      bias: { value: 0.035 },
+    });
     this.composite = pass(COMPOSITE, {
       tScene: { value: null }, tBloom: { value: null },
       texel: { value: new THREE.Vector2() },
@@ -151,6 +242,8 @@ export class PostFX {
       grain: { value: 0.016 },
       time: { value: 0 },
       fxaa: { value: 1 },
+      tAO: { value: null },
+      aoAmount: { value: 0.85 },
     });
   }
 
@@ -163,6 +256,15 @@ export class PostFX {
     const bw = Math.max(2, Math.floor(W / 4)), bh = Math.max(2, Math.floor(H / 4));
     this.bloomA.setSize(bw, bh);
     this.bloomB.setSize(bw, bh);
+    this.sceneRT.depthTexture.image.width = W;
+    this.sceneRT.depthTexture.image.height = H;
+    this.sceneRT.depthTexture.needsUpdate = true;
+    // Half res: AO is a low-frequency term and full res buys nothing visible.
+    const aw = Math.max(2, Math.floor(W / 2)), ah = Math.max(2, Math.floor(H / 2));
+    this.aoA.setSize(aw, ah);
+    this.aoB.setSize(aw, ah);
+    this.ssao.material.uniforms.texel.value.set(1 / aw, 1 / ah);
+    this._aw = aw; this._ah = ah;
     this.composite.material.uniforms.texel.value.set(1 / W, 1 / H);
     this._bw = bw; this._bh = bh;
   }
@@ -172,13 +274,31 @@ export class PostFX {
   }
 
   /** Run the chain. The scene must already have been rendered into `target`. */
-  render(time) {
+  render(time, camera) {
     if (!this.enabled) return;
     const r = this.renderer;
     const draw = (mesh, rt) => {
       r.setRenderTarget(rt);
       r.render(mesh.userData.scene, CAM);
     };
+
+    if (this.ssaoOn && camera) {
+      const su = this.ssao.material.uniforms;
+      su.tDepth.value = this.sceneRT.depthTexture;
+      su.proj.value.copy(camera.projectionMatrix);
+      su.projInv.value.copy(camera.projectionMatrixInverse);
+      draw(this.ssao, this.aoA);
+      // Two cheap separable passes: the sample kernel is noisy by design and
+      // unblurred AO reads as dirt on the lens.
+      const bu2 = this.blur.material.uniforms;
+      bu2.tSrc.value = this.aoA.texture;
+      bu2.dir.value.set(1 / this._aw, 0);
+      draw(this.blur, this.aoB);
+      bu2.tSrc.value = this.aoB.texture;
+      bu2.dir.value.set(0, 1 / this._ah);
+      draw(this.blur, this.aoA);
+      this.composite.material.uniforms.tAO.value = this.aoA.texture;
+    }
 
     this.bright.material.uniforms.tScene.value = this.sceneRT.texture;
     draw(this.bright, this.bloomA);
@@ -203,8 +323,8 @@ export class PostFX {
   }
 
   dispose() {
-    for (const rt of [this.sceneRT, this.bloomA, this.bloomB]) rt.dispose();
-    for (const m of [this.bright, this.blur, this.composite]) m.material.dispose();
+    for (const rt of [this.sceneRT, this.bloomA, this.bloomB, this.aoA, this.aoB]) rt.dispose();
+    for (const m of [this.bright, this.blur, this.composite, this.ssao]) m.material.dispose();
     QUAD.dispose();
   }
 
@@ -216,5 +336,8 @@ export class PostFX {
     cu.fxaa.value = q === 'low' ? 0 : 1;
     cu.bloomStrength.value = q === 'high' ? 0.62 : 0.5;
     cu.grain.value = q === 'high' ? 0.016 : 0;
+    // SSAO is the most expensive pass here, so it is the first thing to go.
+    this.ssaoOn = q === 'high';
+    cu.aoAmount.value = this.ssaoOn ? 0.85 : 0.0;
   }
 }

--- a/apps/auto/src/textures.js
+++ b/apps/auto/src/textures.js
@@ -464,7 +464,6 @@ function skyEquirect() {
   grad.addColorStop(1.00, '#5d6469');
   g.fillStyle = grad;
   g.fillRect(0, 0, W, H);
-
   // Sun: placed to match the key light direction so speculars line up.
   const sx = 207, sy = 221;
   const halo = g.createRadialGradient(sx, sy, 0, sx, sy, 460);

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -107,20 +107,34 @@ function halfFloatRenders(renderer) {
   }
 }
 
+/**
+ * Per-building colour variation.
+ *
+ * Jittering R, G and B INDEPENDENTLY is what manufactured the candy palette:
+ * three uncorrelated offsets push a muted base straight off into saturated
+ * primaries, so a street of weathered brick came out fluorescent pink, lime and
+ * orange. Real variation between buildings is mostly TONAL -- the same material
+ * dirtier or paler -- with only a slight drift in hue. So the brightness jitter
+ * is shared across all three channels, the chroma jitter is a fifth of it, and
+ * everything is pulled toward its own grey.
+ */
+const SATURATION = 0.62;
 function tint(seed, base, spread) {
-  const r = hash2(seed, 1), g = hash2(seed, 2), b = hash2(seed, 3);
-  return [
-    clamp(base[0] + (r - 0.5) * spread, 0.15, 1.4),
-    clamp(base[1] + (g - 0.5) * spread, 0.15, 1.4),
-    clamp(base[2] + (b - 0.5) * spread, 0.15, 1.4),
-  ];
+  const v = 1 + (hash2(seed, 1) - 0.5) * spread * 0.85;
+  const dr = (hash2(seed, 2) - 0.5) * spread * 0.18;
+  const db = (hash2(seed, 3) - 0.5) * spread * 0.18;
+  const lum = base[0] * 0.2126 + base[1] * 0.7152 + base[2] * 0.0722;
+  const mute = (c, d) => clamp((lum + (c - lum) * SATURATION + d) * v, 0.12, 1.35);
+  return [mute(base[0], dr), mute(base[1], 0), mute(base[2], db)];
 }
 
 const DARK = [0.26, 0.27, 0.29];
 const TRIM = [0.55, 0.55, 0.56];
+// Accents stay the one place saturated colour is allowed, but pulled back:
+// these are awnings and shopfronts, not the whole facade.
 const AWNING = [
-  [0.55, 0.12, 0.12], [0.12, 0.28, 0.5], [0.14, 0.34, 0.22],
-  [0.42, 0.34, 0.16], [0.2, 0.2, 0.24], [0.5, 0.42, 0.3],
+  [0.42, 0.16, 0.15], [0.15, 0.25, 0.38], [0.16, 0.29, 0.21],
+  [0.36, 0.30, 0.18], [0.21, 0.21, 0.24], [0.42, 0.37, 0.29],
 ];
 
 // ---------------------------------------------------------------------------
@@ -155,15 +169,15 @@ export class World {
     };
 
     this.mats = {
-      road: surf(tx.road, { env: 0.9, ns: 0.7 }),
-      walk: surf(tx.sidewalk, { env: 0.85, ns: 0.8 }),
-      glass: surf(tx.glass, { env: 1.5, metalness: 0.18, ns: 1.1, emissive: 0.12 }),
-      masonry: surf(tx.masonry, { env: 1.05, ns: 1.0, emissive: 0.1 }),
-      industrial: surf(tx.industrial, { env: 1.0, metalness: 0.25, ns: 1.0 }),
-      house: surf(tx.house, { env: 0.95, ns: 1.0, emissive: 0.1 }),
-      flat: new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.82, metalness: 0.04, envMapIntensity: 1.0 }),
+      road: surf(tx.road, { env: 0.45, ns: 0.7 }),
+      walk: surf(tx.sidewalk, { env: 0.42, ns: 0.8 }),
+      glass: surf(tx.glass, { env: 1.05, metalness: 0.22, ns: 1.1, emissive: 0.02 }),
+      masonry: surf(tx.masonry, { env: 0.5, ns: 1.0, emissive: 0.015 }),
+      industrial: surf(tx.industrial, { env: 0.5, metalness: 0.25, ns: 1.0 }),
+      house: surf(tx.house, { env: 0.45, ns: 1.0, emissive: 0.015 }),
+      flat: new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.82, metalness: 0.04, envMapIntensity: 0.45 }),
       glow: new THREE.MeshBasicMaterial({ vertexColors: true, toneMapped: false }),
-      far: new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.85, metalness: 0.05, envMapIntensity: 0.95 }),
+      far: new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.85, metalness: 0.05, envMapIntensity: 0.5 }),
     };
     this.group = new THREE.Group();
     scene.add(this.group);
@@ -292,8 +306,11 @@ export class World {
     const n = this.tx.water.normalMap;
     n.repeat.set(520, 520);
     const mat = new THREE.MeshStandardMaterial({
-      color: 0x2c4d63, normalMap: n, roughness: 0.09, metalness: 0.25,
-      envMapIntensity: 1.6, normalScale: new THREE.Vector2(0.55, 0.55),
+      // Roughness up and normal amplitude down: at 0.09 every wavelet past a
+      // couple of hundred metres aliased into one blown white specular sheet
+      // along the horizon.
+      color: 0x2a4658, normalMap: n, roughness: 0.22, metalness: 0.2,
+      envMapIntensity: 1.0, normalScale: new THREE.Vector2(0.28, 0.28),
     });
     const m = new THREE.Mesh(geo, mat);
     m.position.y = 0;
@@ -980,30 +997,55 @@ export class World {
 
   // --- buildings ------------------------------------------------------------
 
+  /**
+   * Material families.
+   *
+   * Per-building random jitter around ONE base colour per style gave a downtown
+   * that was almost entirely the same beige-orange brick -- the palette fix
+   * removed the candy colours but replaced them with monotony. Real cities are a
+   * handful of distinct material families (concrete, curtain-wall glass, red
+   * brick, painted stucco, dark modern) mixed on one street, with variation
+   * INSIDE each family rather than across the whole city.
+   */
+  buildingFamily(bd) {
+    const seed = bd.seed;
+    const pick = hash2(seed, 101);
+    // Taller and newer skews to glass and dark curtain wall; low and old skews
+    // to brick and stucco, which is roughly how a city stratifies by era.
+    const modern = clamp((bd.h - 18) / 55, 0, 1);
+    const FAMS = [
+      { m: 'masonry', c: [0.74, 0.73, 0.70], u: 14, v: 13.6 },   // concrete
+      { m: 'glass', c: [0.78, 0.86, 0.92], u: 14, v: 13.6 },     // curtain wall
+      { m: 'masonry', c: [0.72, 0.46, 0.38], u: 12, v: 12 },     // red brick
+      { m: 'masonry', c: [0.86, 0.82, 0.74], u: 13, v: 13 },     // painted stucco
+      { m: 'glass', c: [0.42, 0.46, 0.50], u: 14, v: 13.6 },     // dark modern
+    ];
+    const wOld = [0.30, 0.06, 0.34, 0.26, 0.04];
+    const wNew = [0.26, 0.34, 0.10, 0.08, 0.22];
+    let acc = 0;
+    for (let i = 0; i < FAMS.length; i++) {
+      acc += wOld[i] + (wNew[i] - wOld[i]) * modern;
+      if (pick <= acc) return FAMS[i];
+    }
+    return FAMS[0];
+  }
+
   meshBuilding(bl, flat, glow, bd) {
     const seed = bd.seed;
     let target, col, uS = 14, vS = 13.6;
-    switch (bd.style) {
-      case 'tower':
-        if (hash2(seed, 11) > 0.55) { target = bl.glass; col = tint(seed, [0.92, 0.97, 1.0], 0.28); }
-        else { target = bl.masonry; col = tint(seed, [0.9, 0.85, 0.78], 0.3); }
-        break;
-      case 'midrise':
-        if (hash2(seed, 11) > 0.62) { target = bl.glass; col = tint(seed, [0.9, 0.95, 1.0], 0.3); }
-        else { target = bl.masonry; col = tint(seed, [0.92, 0.84, 0.72], 0.34); }
-        break;
-      case 'brick':
-        target = bl.masonry; col = tint(seed, [0.82, 0.55, 0.44], 0.34); uS = 12; vS = 12;
-        break;
-      case 'lowrise':
-        if (hash2(seed, 11) > 0.62) { target = bl.glass; col = tint(seed, [0.88, 0.94, 1.0], 0.3); }
-        else { target = bl.masonry; col = tint(seed, [0.92, 0.86, 0.76], 0.36); }
-        break;
-      case 'industrial':
-        target = bl.industrial; col = tint(seed, [0.84, 0.86, 0.86], 0.3); uS = 16; vS = 16;
-        break;
-      default:
-        target = bl.house; col = tint(seed, [0.94, 0.92, 0.88], 0.36); uS = 0; vS = 0;
+    const fam = (bd.style === 'tower' || bd.style === 'midrise'
+      || bd.style === 'brick' || bd.style === 'lowrise')
+      ? this.buildingFamily(bd) : null;
+    if (fam) {
+      target = fam.m === 'glass' ? bl.glass : bl.masonry;
+      // Jitter stays INSIDE the family, so a brick street varies in weathering
+      // rather than becoming a different material every other lot.
+      col = tint(seed, fam.c, 0.26);
+      uS = fam.u; vS = fam.v;
+    } else if (bd.style === 'industrial') {
+      target = bl.industrial; col = tint(seed, [0.84, 0.86, 0.86], 0.3); uS = 16; vS = 16;
+    } else {
+      target = bl.house; col = tint(seed, [0.94, 0.92, 0.88], 0.36); uS = 0; vS = 0;
     }
 
     if (bd.kind) return this.meshLandmarkTower(bl, flat, bd, col);
@@ -1029,6 +1071,31 @@ export class World {
       const [sx, sz] = off(0, bd.d / 2 + 0.5);
       flat.box(sx, base + 1.6, sz, 2.0, 0.22, 1.2, bd.rot, [0.62, 0.6, 0.57]);
       return;
+    }
+
+    // Roof clutter. The top face is the most-seen surface of a low building
+    // from any elevated view, and a bare extrusion cap is the loudest tell that
+    // this is untextured programmer geometry. A handful of boxes per roof is
+    // within budget because they merge into the chunk's existing flat mesh.
+    if (bd.h < 70 && bd.w > 9 && bd.d > 9) {
+      const rt = base + bd.h + 2;
+      // Roofs vary per building. One flat grey across a whole downtown reads
+      // as untextured cap geometry from every elevated view, which is the
+      // angle roofs are actually seen from.
+      const rv = 0.30 + hash2(seed, 91) * 0.22;
+      const rc2 = [rv, rv * 1.01, rv * 1.05];
+      const n = 1 + Math.floor(hash2(seed, 51) * 3);
+      for (let i = 0; i < n; i++) {
+        const ux = (hash2(seed, 52 + i) - 0.5) * (bd.w - 6);
+        const uz = (hash2(seed, 61 + i) - 0.5) * (bd.d - 6);
+        const [gx, gz] = off(ux, uz);
+        const bw2 = 1.4 + hash2(seed, 71 + i) * 2.2;
+        const bh2 = 0.9 + hash2(seed, 81 + i) * 1.5;
+        flat.box(gx, rt, gz, bw2, bh2, bw2 * 0.8, bd.rot, rc2);
+      }
+      // parapet lip, so the roof edge has a silhouette rather than a clean cut
+      flat.box(bd.x, rt, bd.z, bd.w + 0.5, 0.85, bd.d + 0.5, bd.rot,
+        [rv * 1.25, rv * 1.25, rv * 1.22]);
     }
 
     const dense = bd.style !== 'industrial';

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v28';
+const CACHE = 'auto-v29';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',

--- a/tools/beauty.mjs
+++ b/tools/beauty.mjs
@@ -1,0 +1,116 @@
+// Beauty shots for judging visual quality.
+//
+//   node tools/beauty.mjs [tag]
+//
+// A fixed set of framed views, captured identically every time so two runs can
+// be compared honestly. The HUD is hidden and the quality tier is locked to
+// `high` -- SwiftShader's ~4 fps otherwise trips the adaptive downgrade and
+// every shot silently comes back at the low-quality settings.
+
+import { spawn } from 'node:child_process';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const PORT = 9228;
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const TAG = process.argv[2] || 'now';
+const OUT = `tools/data/beauty/${TAG}`;
+
+// name, [camera x, HEIGHT ABOVE GROUND, z], [look-at x, height above ground, z].
+//
+// Heights are relative to the ground at that point, not absolute. Absolute
+// heights put the Green Lake camera at y=30 under a lake whose surface is at
+// 50 m, so the shot came back as the underside of the water plane with the
+// neighbourhood apparently floating over a void -- which reads exactly like a
+// broken renderer and is entirely the harness's fault.
+const VIEWS = [
+  ['street',      [250, 2.4, 780],    [250, 1.6, 300]],
+  ['downtown',    [520, 80, 1250],    [420, 20, 500]],
+  ['skyline',     [-1900, 150, 1900], [200, 30, 700]],
+  ['waterfront',  [-900, 14, 640],    [-200, 2, 900]],
+  ['residential', [-3400, 6, -6180],  [-3500, 2, -6600]],
+  ['park',        [-700, 8, -4700],   [-350, 2, -5100]],
+];
+
+function launch() {
+  return spawn(CHROME, [
+    `--remote-debugging-port=${PORT}`, '--headless=new', '--use-gl=swiftshader',
+    '--enable-unsafe-swiftshader', '--autoplay-policy=no-user-gesture-required',
+    '--window-size=1280,720', '--no-first-run',
+    '--user-data-dir=/tmp/auto-beauty-profile', 'about:blank',
+  ], { stdio: 'ignore' });
+}
+
+async function main() {
+  const chrome = launch();
+  try {
+    let page;
+    for (let i = 0; i < 90 && !page; i++) {
+      try {
+        page = (await (await fetch(`http://127.0.0.1:${PORT}/json/list`)).json())
+          .find((t) => t.type === 'page');
+      } catch { /* not up */ }
+      if (!page) await sleep(300);
+    }
+    const ws = new WebSocket(page.webSocketDebuggerUrl);
+    await new Promise((r, j) => { ws.addEventListener('open', r); ws.addEventListener('error', j); });
+    let id = 0; const pend = new Map();
+    ws.addEventListener('message', (ev) => {
+      const m = JSON.parse(ev.data);
+      if (m.id && pend.has(m.id)) { pend.get(m.id)(m); pend.delete(m.id); }
+    });
+    const send = (method, params = {}) => new Promise((res) => {
+      ws.send(JSON.stringify({ id: ++id, method, params })); pend.set(id, res);
+    });
+    const evaluate = async (e) => {
+      const r = await send('Runtime.evaluate', { expression: e, returnByValue: true });
+      if (r.result?.exceptionDetails) throw new Error(r.result.exceptionDetails.exception?.description);
+      return r.result?.result?.value;
+    };
+    await send('Runtime.enable');
+    await send('Page.enable');
+    await send('Network.enable');
+    await send('Network.setBypassServiceWorker', { bypass: true });
+    await send('Network.setCacheDisabled', { cacheDisabled: true });
+    await send('Page.addScriptToEvaluateOnNewDocument', { source: 'window.__noAutoQuality = true;' });
+    await send('Page.navigate', { url: 'http://localhost:8000/apps/auto/' });
+    for (let i = 0; i < 400; i++) {
+      await sleep(500);
+      if (await evaluate('!!window.__dbg')) break;
+    }
+    await evaluate(`(() => {
+      const d = window.__dbg;
+      d.applyQuality('high', true);
+      for (const id of ['hud','pad','stickZone','lookZone','objective','toast','rotate'])
+        { const e = document.getElementById(id); if (e) e.style.display = 'none'; }
+      d.game.paused = true;
+    })()`);
+
+    mkdirSync(OUT, { recursive: true });
+    for (const [name, pos, look] of VIEWS) {
+      await evaluate(`(() => {
+        const d = window.__dbg;
+        d.world.update(${pos[0]}, ${pos[2]}, 60);
+        const gy = (x, z) => Math.max(0, d.city.groundAt(x, z, null));
+        const cy = gy(${pos[0]}, ${pos[2]}) + ${pos[1]};
+        const ly = gy(${look[0]}, ${look[2]}) + ${look[1]};
+        d.camera.position.set(${pos[0]}, cy, ${pos[2]});
+        d.camera.lookAt(${look[0]}, ly, ${look[2]});
+        d.camera.updateMatrixWorld(true);
+        d.sun.position.set(${pos[0]} - 160, cy + 240, ${pos[2]} - 110);
+        d.sun.target.position.set(${look[0]}, ly, ${look[2]});
+        d.sun.target.updateMatrixWorld();
+      })()`);
+      await sleep(9000);
+      const { result } = await send('Page.captureScreenshot', { format: 'png' });
+      writeFileSync(`${OUT}/${name}.png`, Buffer.from(result.data, 'base64'));
+      console.log(`  ${OUT}/${name}.png`);
+    }
+    const stats = await evaluate('({calls: __dbg.sceneStats.calls, tris: __dbg.sceneStats.tris})');
+    console.log(`  scene: ${stats.calls} draws, ${stats.tris} triangles`);
+  } finally {
+    chrome.kill('SIGKILL');
+  }
+}
+
+main().catch((e) => { console.error('beauty failed:', e.message); process.exitCode = 1; });


### PR DESCRIPTION
Each round was scored by a subagent art director against a PS3-era open-world bar. The verdict went **FAIL (mean 2.4) → FAIL (mean 3.7)** across the passes here, against a pass bar of ~6.5. This is progress toward the bar, not arrival — what remains is listed at the bottom.

## Key-to-ambient was the whole problem

Hemisphere 2.0 against sun 2.5, with full IBL on top, put the ratio near **1.3:1** — two faces of the same building differed only by texture, never by light. Nothing downstream can read under a shadowless sky: AO, normal maps and geometry all score flat however good they are.

Now nearer 4:1 — hemi 0.55, sun 3.6 at ~38°, `envMapIntensity` roughly halved on every material, exposure 1.25. **This single change moved more than everything else combined**, and it's worth knowing before reaching for any other visual fix.

## SSAO without breaking the no-half-float rule

`postfx.sceneRT` now carries a `DepthTexture` — integer format, so it obeys the iOS constraint, and the scene pass fills it **for free**. A separate depth prepass would have doubled the scene's draw calls. Half res, blurred, multiplied *before* bloom so bloom can't bleed back into the crevices AO just darkened.

## Colour

`tint()` jittered R, G and B independently — three uncorrelated offsets push a muted base straight into saturated primaries, which is how a street of weathered brick came out fluorescent pink, lime and orange. Brightness jitter is now shared across channels with only slight chroma drift.

That alone overcorrected into one beige city, so `buildingFamily()` picks one of five families — concrete, curtain wall, red brick, painted stucco, dark modern — weighted by height, with jitter only *inside* a family.

## Also

- Shadow camera 105 → 190 m so buildings shade the streets they line, with bias rescaled for the larger texel (acne appeared on sunlit facades otherwise).
- **Dither moved out of the sky equirect into the output pass.** Baked into the texture it magnified into clumped grain across sky *and* water, and polluted the IBL that the same texture feeds.
- Water roughness up, normal amplitude down — kills a blown white sheet along the horizon at grazing angles.
- Fog density near-doubled for aerial perspective; roof clutter and parapets on every building under 70 m; bloom threshold raised; daylight window emissive cut.

## Tooling

`tools/beauty.mjs` captures six fixed framed views for judging. Camera heights are **ground-relative** — hard-coded ones put the Green Lake camera below a lake surface sitting at 50 m, and that shot came back looking exactly like a broken renderer when it was a harness bug.

## Still outstanding

In the judge's priority order: facade relief (normal-mapped window reveals), ground material rework (asphalt albedo, sidewalk repeat, real kerbs), tree assets (still 3-cone lollipops), and a depth-aware SSAO upsample. These are mostly **art-asset work rather than renderer work**.

Build number and `CACHE` both moved to v29. Verified: boots clean, 0 exceptions, 304 draws / 453k triangles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B