### PR TITLE
Auto: graphics pass — tone mapping, signage, brick, solid trees

### DIFF
--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -503,6 +503,28 @@ Physically-shaded, image-based-lit, tone-mapped, with a hand-rolled post chain.
   unreliable on iOS (silent black screen), so the scene is tone-mapped into an
   8-bit sRGB target and bloom / FXAA / grade / vignette all work in gamma space.
   If you add a pass, keep it 8-bit.
+- **Key-to-ambient is the whole look.** At hemisphere 2.0 against sun 2.5, with
+  full IBL on top, ambient dominated at roughly 1.3:1 and two faces of the same
+  building differed only by texture, never by light. Nothing downstream can read
+  under a shadowless sky -- AO, normal maps and geometry all score flat however
+  good they are. It is now nearer 4:1 (hemi 0.55, sun 3.6, envMapIntensity
+  roughly halved on every material, exposure 1.25). **Change this ratio before
+  reaching for any other visual fix**, because everything else is measured
+  against it.
+- **SSAO reads the scene pass's own depth attachment.** `postfx.sceneRT` carries
+  a `DepthTexture` (integer, so it obeys the no-half-float rule), which the scene
+  pass fills for free -- a separate depth prepass would have doubled the scene's
+  draw calls. Half res, blurred, multiplied BEFORE bloom so bloom cannot bleed
+  back into the crevices AO just darkened.
+- **Dither belongs in the output pass, not in the sky texture.** Baked into the
+  equirect it magnifies across the screen as clumped grain, shows up on the water
+  as well as the sky, and pollutes the IBL that the same texture feeds. It is now
+  screen-space, +/-1/255, after tonemap.
+- **Per-building colour varies TONALLY, in families.** Jittering R, G and B
+  independently manufactures a candy palette; jittering one base colour per style
+  instead produces a whole downtown of the same beige. `tint()` shares its
+  brightness jitter across channels and pulls toward grey, and
+  `buildingFamily()` picks one of five material families weighted by height.
 - **Adaptive quality.** The phone this ships to can't be profiled from here, so
   the game measures its own frame rate and steps `high -> medium -> low`
   (post off, then pixel ratio down). `applyQuality(q, true)` locks it manually.

--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -531,6 +531,87 @@ Physically-shaded, image-based-lit, tone-mapped, with a hand-rolled post chain.
   When testing headlessly, set `window.__noAutoQuality = true` **before boot** or
   SwiftShader's ~5 fps immediately drops the tier and every screenshot lies.
 
+## Judging how it looks
+
+Four separate visual bugs were each diagnosed two or three times as something
+else, because the thing doing the judging was wrong. The rule that came out of
+it: **measure the composited frame, and check the harness before the renderer.**
+
+`tools/beauty.mjs` captures a fixed set of framed views; `tools/values.py`
+reports the linear value structure of the resulting PNGs -- percentiles, the
+median of the lit and shadowed quartiles, and the ratio between them. A daylight
+open world of the target era runs a lit-to-shadow ratio of roughly **2.2-3.3:1**.
+At 13.8:1 the shadows are night values under a daylight sky, and no amount of
+albedo tuning fixes it, because every base colour is being multiplied by an
+ambient term near zero.
+
+**Measure the PNG, not the scene pass.** `renderer.render(scene, camera)` in a
+probe skips the whole post chain, and AO, grade and vignette are a large part of
+where the values land. A probe that renders directly reported a shadowed
+quartile of 0.19 for a frame whose actual pixels were at 0.004 -- a factor of
+fifty, in the direction that hides the bug.
+
+**The harness lights the shot, so the harness can be the bug.** `beauty.mjs`
+used to place the sun relative to the camera and aim it at the LOOK-AT point.
+That is fine for a shot 20 m deep and badly wrong for one 2400 m deep: the
+skyline view ended up with the light 240 m above a target 2400 m away, a sun
+**5.7 degrees above the horizon**. Every up-facing surface in the aerial got a
+tenth of the key and the mid-ground rendered as a black band. It reproduces
+main.js's own `(-215, 200, -150)` offset now. Same class of error as the stale
+shadow map in `survey.mjs`.
+
+**Spawning is not placing.** Traffic and pedestrians set their logical position
+on spawn; only each system's `update()` moves the meshes. The beauty shots pause
+the game so the camera can be flown, so for several passes they counted a dozen
+vehicles in the frustum and drew none of them. Seed, then step the systems.
+
+**Frame the views from the map, not from coordinates.** Hardcoded camera
+positions went stale the moment the city became real data -- the shot named
+`park` contained no park and `residential` framed an office block, so vegetation
+and housing were never actually being looked at. The views resolve at capture
+time from the loaded city: densest cluster of `style === 'house'`, densest
+cluster of buildings over 60 m, the fully-green patch nearest downtown.
+
+### Four bugs that all looked like a material problem
+
+- **A shadow with no bottom is the shadow map running out.** A tower's shadow
+  was sliced off mid-facade in a straight vertical line. The ortho box was 190 m
+  and shadowing simply stops at its edge. The proof is one render: widen the box
+  and previously *lit* pixels go dark. No real shadow gains area when you
+  enlarge the camera that draws it.
+- **Vertex tint multiplies the windows too.** Glazing drawn at `rgb(36,48,58)`
+  and then multiplied by a red-brick family colour lands at `(29,18,16)` --
+  black holes, on brick buildings only. Panes start bright now, which is also
+  what a daylight window actually is: mostly a reflection of the sky.
+- **Banding in the sky was the cloud generator.** 390 ellipses squashed to about
+  a fifteenth of their width at 3-11% alpha are individually invisible and stack
+  into continuous horizontal streaks across the equirect. It was twice blamed on
+  dither and precision in the post chain.
+- **A canopy built from `prism` has no top or bottom.** `Builder.prism` is an
+  open drum, so a squashed one seen from eye level is a single band of vertical
+  wall -- the "green slab on a stick" that trees rendered as. `spheroid` is
+  closed and costs about the same.
+
+## Solid street objects
+
+Until recently the **only** solid thing in the entire map was a building: trees
+and lamp posts were scenery you drove and walked straight through.
+`world.buildChunk` registers trunks and poles into `city.obstacles`, keyed by
+chunk so they are cleared with the geometry that drew them, and
+`city.obstacleHit(x, z, r)` returns the deepest overlap.
+
+Both collision paths consult it: `collideWithBuildings` tests obstacles *first*
+(a tree is nearer than the building line and is what you actually hit coming off
+a kerb) with a softer response than a wall, and `Player.blocked` uses a circle so
+you slide around a trunk instead of sticking to it. The radius is the **trunk**,
+not the canopy -- blocking the full spread makes a park impassable.
+
+**Greenspace and footprints are separate OSM layers and they overlap.** Park
+polygons are mapped straight over the museum, pavilion or house standing in
+them, so `inPark()` happily says yes in the middle of a building: 9.3 % of
+surviving park-tree candidates stood inside a footprint. Anything scattered on
+open ground needs `inBuilding()` as well as `inPark()` and `onRoad()`.
+
 ## Models
 
 Cars and characters are the two things a player looks at closely, and both are

--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -524,7 +524,12 @@ Physically-shaded, image-based-lit, tone-mapped, with a hand-rolled post chain.
   independently manufactures a candy palette; jittering one base colour per style
   instead produces a whole downtown of the same beige. `tint()` shares its
   brightness jitter across channels and pulls toward grey, and
-  `buildingFamily()` picks one of five material families weighted by height.
+  `buildingFamily()` picks one of eight named families weighted by height.
+  **A family needs its own MATERIAL, not just its own tint.** With one wall
+  texture, concrete, stucco and red brick were three values of the same thing
+  and a street of five families still read as one stone -- no tint can turn
+  ashlar into a running bond. `masonrySurface()` is parameterised and called
+  twice, for stone and for brick.
 - **Adaptive quality.** The phone this ships to can't be profiled from here, so
   the game measures its own frame rate and steps `high -> medium -> low`
   (post off, then pixel ratio down). `applyQuality(q, true)` locks it manually.

--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -494,7 +494,22 @@ Physically-shaded, image-based-lit, tone-mapped, with a hand-rolled post chain.
   surfaces reflect too sharply, but the city stays lit instead of going dark.
   Anything that makes the probe inconclusive counts as a pass, so hardware that
   renders correctly today keeps the PMREM path.
-- **Tone mapping is ACES**, applied during the scene pass. Exposure lives in main.js.
+- **Tone mapping is ACES, and getting it to run at all took a flag.**
+  `WebGLRenderer` applies `toneMapping` only when the current render target is
+  null -- when it draws straight to the canvas -- or when the target is marked
+  `isXRRenderTarget`. The whole scene goes into postfx's 8-bit target, so for a
+  long time **ACES and `toneMappingExposure` never ran**, and this file claimed
+  they did. Highlights had no shoulder and hard-clipped to flat 255 plateaus
+  that read as missing textures; the scene floor sat where the toe should have
+  been, so light added at the source was eaten before it reached the
+  framebuffer (hemisphere and ambient pushed 2.6x bought 1.6x on screen) and
+  three separate value bugs were attacked through albedo instead. The tell was
+  that moving exposure 1.02 -> 1.55 changed the measured output by less than a
+  thousandth of a stop. `postfx.sceneRT.isXRRenderTarget = true` is the only
+  way to get the curve applied before an 8-bit target quantises the highlights;
+  it is pinned to the vendored r160, so **re-check it on a three bump**.
+  Exposure lives in main.js and is meaningful now -- tune it against
+  `tools/values.py`, not by eye.
 - **Every surface is a set**: albedo + normal + roughness (+ emissive where there
   are lit windows). Normals are sobel'd from a purpose-drawn *height* pass, not
   from the albedo, so window reveals read as recesses.

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -374,7 +374,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v28</div>
+    <div id="build">v29</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -374,7 +374,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v29</div>
+    <div id="build">v30</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/src/build.js
+++ b/apps/auto/src/build.js
@@ -2,6 +2,7 @@
 // BufferGeometries through this.
 
 import * as THREE from './three.js';
+import { hash2 } from './util.js';
 
 /**
  * Flattens a group of static meshes into one mesh per material. Landmarks are
@@ -254,6 +255,50 @@ export class Builder {
       const x1 = cx + Math.cos(a1) * r, z1 = cz + Math.sin(a1) * r;
       const mx = Math.cos((a0 + a1) / 2), mz = Math.sin((a0 + a1) / 2);
       this.tri([x0, by, z0], [x1, by, z1], [cx, by + h, cz], [mx, 0.45, mz], col);
+    }
+  }
+
+  /**
+   * Low-poly spheroid, for anything that has to read as ROUND rather than as a
+   * drum. `prism` is open at both ends, so a squashed one seen from eye level
+   * shows a single band of vertical wall and nothing else -- which is why a
+   * broadleaf canopy built from squashed prisms rendered as a flat green slab
+   * on a stick. A closed, tapered lathe costs about the same triangles and has
+   * an actual silhouette.
+   *
+   * `squash` scales Y against the horizontal radius: below 1 is a flattened
+   * canopy, above 1 an upright one.
+   */
+  spheroid(cx, cy, cz, r, sides, stacks, col, squash = 1, jitter = 0) {
+    const ry = r * squash;
+    const ptAt = (si, i) => {
+      // Latitude from the south pole to the north; radius follows the sine so
+      // the profile closes at both ends instead of ending in a flat disc.
+      const t = si / stacks;
+      const lat = (t - 0.5) * Math.PI;
+      // A little per-vertex wobble breaks the lathe's obvious symmetry without
+      // needing more segments.
+      const wob = jitter ? 1 + (hash2(si * 31 + i * 7, 3) - 0.5) * jitter : 1;
+      const rr = Math.cos(lat) * r * wob;
+      const ang = (i / sides) * Math.PI * 2;
+      return [cx + Math.cos(ang) * rr, cy + Math.sin(lat) * ry * wob, cz + Math.sin(ang) * rr];
+    };
+    for (let si = 0; si < stacks; si++) {
+      for (let i = 0; i < sides; i++) {
+        const a = ptAt(si, i), b = ptAt(si, i + 1);
+        const c = ptAt(si + 1, i + 1), d = ptAt(si + 1, i);
+        // Normals point out from the centre, which is what makes a faceted
+        // lathe still shade like a ball.
+        const nrm = (p) => {
+          const vx = p[0] - cx, vy = p[1] - cy, vz = p[2] - cz;
+          const l = Math.hypot(vx, vy, vz) || 1;
+          return [vx / l, vy / l, vz / l];
+        };
+        const n = nrm([(a[0] + c[0]) / 2, (a[1] + c[1]) / 2, (a[2] + c[2]) / 2]);
+        if (si === 0) this.tri(b, a, d, n, col);
+        else if (si === stacks - 1) this.tri(a, b, c, n, col);
+        else this.quad(a, b, c, d, n, [0, 0, 1, 0, 1, 1, 0, 1], col);
+      }
     }
   }
 

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -46,7 +46,14 @@ const CLASS_SPEED = { hwy: 30, art: 17, st: 12, res: 9, ramp: 14 };
 const walkWidth = (cls) => (cls === 'st' || cls === 'res' ? 2.6 : cls === 'art' ? 3.2 : 0);
 
 // Building class (tools/build_buildings.py) + height -> facade style.
-function styleFor(cls, h) {
+function styleFor(cls, h, w, d) {
+  // An untagged, unnamed OSM building falls to cls 0, which used to mean
+  // "house" outright -- so a 30 m commercial block with no tags came out clad
+  // in clapboard siding at domestic plank scale. Size overrides the tag: a
+  // house is small AND low.
+  if (cls === 0 && (h > 11 || (w != null && w * d > 260))) {
+    return h > 22 ? 'midrise' : 'brick';
+  }
   if (cls === 0) return 'house';
   if (cls === 1) return h > 25 ? 'midrise' : 'lowrise';
   if (cls === 3) return 'industrial';
@@ -124,7 +131,7 @@ export function* cityGenerator(md) {
         buildings.push({
           x, z, w, d, rot, h,
           y: G.terrainHeight(x, z),
-          style: styleFor(cls, h),
+          style: styleFor(cls, h, w, d),
           seed: (hash2(Math.round(x), Math.round(z)) * 65536) | 0,
           kind: null,
         });
@@ -531,6 +538,58 @@ export function* cityGenerator(md) {
           const y = s.ay + (s.by - s.ay) * r.t + ROAD_LIFT * 0.3;
           if (curY == null || y <= curY + 2.6) {
             if (y > best) best = y;
+          }
+        }
+      }
+      return best;
+    },
+
+    /**
+     * Solid street objects -- tree trunks and poles -- recorded by world.js as
+     * it meshes each chunk.
+     *
+     * They live here rather than in world.js because collision already takes
+     * `city` and nothing else does: a tree you can drive through is a tree the
+     * player does not believe in, and until now the ONLY solid thing in the
+     * whole map was a building. Only near chunks are meshed, which is exactly
+     * the range collision needs, so the store is filled and cleared with them.
+     *
+     * Keyed by chunk so it can be pruned when a chunk unloads without walking
+     * the whole city.
+     */
+    obstacles: new Map(),
+
+    addObstacle(ck, x, z, r) {
+      let l = this.obstacles.get(ck);
+      if (!l) this.obstacles.set(ck, (l = []));
+      l.push(x, z, r);
+    },
+
+    clearObstacles(ck) {
+      this.obstacles.delete(ck);
+    },
+
+    /**
+     * Nearest solid street object overlapping a circle, or null. Returns the
+     * deepest overlap rather than the first, so a car wedged between a tree and
+     * a pole is pushed out of the one it is furthest into.
+     */
+    obstacleHit(x, z, rad) {
+      let best = null;
+      const c0 = Math.floor((x - rad) / CHUNK), c1 = Math.floor((x + rad) / CHUNK);
+      const d0 = Math.floor((z - rad) / CHUNK), d1 = Math.floor((z + rad) / CHUNK);
+      for (let cx = c0; cx <= c1; cx++) {
+        for (let cz = d0; cz <= d1; cz++) {
+          const l = this.obstacles.get(skey(cx, cz));
+          if (!l) continue;
+          for (let i = 0; i < l.length; i += 3) {
+            const dx = x - l[i], dz = z - l[i + 1];
+            const rr = rad + l[i + 2];
+            const d2 = dx * dx + dz * dz;
+            if (d2 >= rr * rr) continue;
+            const d = Math.sqrt(d2) || 1e-4;
+            const pen = rr - d;
+            if (!best || pen > best.pen) best = { pen, nx: dx / d, nz: dz / d };
           }
         }
       }

--- a/apps/auto/src/main.js
+++ b/apps/auto/src/main.js
@@ -7,7 +7,7 @@ import { loadMapData } from './mapdata.js';
 import { buildTextures } from './textures.js';
 import { World } from './world.js';
 import { buildLandmarks } from './landmarks.js';
-import { TrafficSystem } from './traffic.js';
+import { TrafficSystem, collideWithBuildings } from './traffic.js';
 import { PedSystem, animateWalk } from './peds.js';
 import { Player } from './player.js';
 import { Controls } from './controls.js';
@@ -203,6 +203,8 @@ class Game {
 
 let renderer, scene, camera, sun, world, cityRef, traffic, peds, player, controls, hud, fx, audio, game, marker, postfx;
 let pickups = [];
+// Scratch vector for the shadow-camera aim, so the frame loop allocates none.
+const LOOK_AHEAD = new THREE.Vector3();
 let last = 0;
 let accumFps = 0, frames = 0, fps = 60;
 let startedAt = 0;
@@ -256,13 +258,61 @@ async function boot() {
   renderer.shadowMap.type = THREE.PCFSoftShadowMap;
   renderer.outputColorSpace = THREE.SRGBColorSpace;
 
+/**
+ * Height falloff on the exponential fog.
+ *
+ * FogExp2 is uniform in every direction, so haze that reads correctly along a
+ * street also fills the sky at the top of a tower: a 180 m building three
+ * kilometres out dissolves at its crown exactly as much as at its base, and
+ * the downtown silhouette flattens into one grey wash. Real aerial haze sits
+ * in the lower atmosphere, which is why distant towers punch out of it.
+ *
+ * Patched into three's fog shader chunks rather than done with a custom
+ * material, because it has to apply to every lit surface in the scene --
+ * terrain, roads, buildings, water, vehicles, characters -- and those are a
+ * dozen different materials. `transformed` is the final local position by the
+ * time <fog_vertex> is included (skinning and morphs have already run), so
+ * skinned pedestrians fog from where they actually stand.
+ *
+ * This is per-fragment height rather than a true integral along the view ray.
+ * The integral is the physically right answer and costs an exp and a divide
+ * per pixel; at the scale of the error over a 16 km map it is not visible.
+ */
+function installHeightFog() {
+  const C = THREE.ShaderChunk;
+  if (C.__heightFog) return;
+  C.__heightFog = true;
+  C.fog_pars_vertex = `${C.fog_pars_vertex}\n#ifdef USE_FOG\n  varying float vFogWorldY;\n#endif`;
+  C.fog_vertex = `${C.fog_vertex}\n#ifdef USE_FOG\n  vFogWorldY = (modelMatrix * vec4(transformed, 1.0)).y;\n#endif`;
+  C.fog_pars_fragment = `${C.fog_pars_fragment}\n#ifdef USE_FOG\n  varying float vFogWorldY;\n#endif`;
+  // Scale the density by the fragment's height above sea level. At a scale
+  // height of 130 m a street is fully hazed and a 200 m crown keeps about a
+  // fifth of the density, which is the separation the skyline needs.
+  //
+  // The scale height is a shader constant, not a uniform. ShaderLib.physical
+  // COPIES UniformsLib.fog when three's module is evaluated, so a key added to
+  // UniformsLib afterwards never reaches the program and the shader compiles
+  // against an undeclared name.
+  C.fog_fragment = C.fog_fragment.replace(
+    'float fogFactor = 1.0 - exp( - fogDensity * fogDensity * vFogDepth * vFogDepth );',
+    'float heightScale = exp( - max( vFogWorldY, 0.0 ) / 130.0 );\n'
+    + '\tfloat hDensity = fogDensity * heightScale;\n'
+    + '\tfloat fogFactor = 1.0 - exp( - hDensity * hDensity * vFogDepth * vFogDepth );'
+  );
+}
+
   scene = new THREE.Scene();
   // Aerial perspective. At 0.00032 a tower 3 km away reads at nearly the same
   // contrast and saturation as one across the street, which is what made the
   // city look like a diorama. The colour is matched to the sky near the
   // horizon so distance resolves INTO the sky rather than toward a grey haze
   // sitting in front of it.
-  scene.fog = new THREE.FogExp2(0xc4ccd4, 0.00060);
+  // 0.00060 overshot: it dissolved the downtown silhouette into the sky rather
+  // than giving it depth. Aerial perspective should separate planes, not erase
+  // them, and the fog is tinted slightly cooler than the horizon so towers
+  // still read against it.
+  scene.fog = new THREE.FogExp2(0xb9c3cf, 0.00040);
+  installHeightFog();
   camera = new THREE.PerspectiveCamera(62, viewW() / viewH(), 0.5, 9000);
 
   // The sky IBL supplies most of the ambient, so the analytic lights are just a
@@ -273,8 +323,24 @@ async function boot() {
   // downstream can read under a shadowless sky: AO, normal maps and geometry all
   // score flat no matter how good they are. Daylight open-worlds run nearer 4:1,
   // warm key against cool sky fill.
-  const hemi = new THREE.HemisphereLight(0xdcecf6, 0x6d7668, 0.55);
+  const hemi = new THREE.HemisphereLight(0xdcecf6, 0x8d968a, 1.15);
   scene.add(hemi);
+  // A floor under the shadows.
+  //
+  // Measured on the composited frame -- which is the only honest place to
+  // measure it, since the post chain is part of the value structure -- the
+  // aerial city ran a lit-to-shadow ratio of 13.8:1, with the shadowed quarter
+  // sitting at 0.004 linear under a 0.43 sky. That is a night value and a
+  // daylight sky in the same picture. Console open worlds of this era ran
+  // roughly 2.2-3.3:1, because a shadowed surface outdoors still sees most of
+  // the sky dome plus bounce off everything around it.
+  //
+  // Four passes were spent lifting albedos against this, which is the wrong
+  // lever: no base colour survives being multiplied by an ambient term near
+  // zero. Raising the floor fixes the aerial value inversion, the near-black
+  // street asphalt and the black tower bodies at once, and it lets the roof
+  // albedo go back where it belongs.
+  scene.add(new THREE.AmbientLight(0xb4c2cc, 0.62));
   sun = new THREE.DirectionalLight(0xfff2dc, 3.6);
   // ~38 deg elevation: high enough to light the streets, low enough that every
   // shot has a lit face and a shadowed one.
@@ -282,21 +348,33 @@ async function boot() {
   sun.castShadow = true;
   sun.shadow.mapSize.set(2048, 2048);
   sun.shadow.camera.near = 20;
-  sun.shadow.camera.far = 780;
+  sun.shadow.camera.far = 1150;
   // 105 m covered barely a block: buildings cast no shadow on the streets they
   // line, which is most of why the city read as flat. 190 m reaches across a
   // downtown block and its far side at the cost of shadow-map resolution,
   // which 2048 absorbs.
-  const S = 190;
+  //
+  // 190 was still not enough, and the way it failed was mistaken three times
+  // for a material bug. Where the ortho box ends, shadowing simply stops, so a
+  // tower's shadow on the block behind it was cut off mid-facade in a straight
+  // vertical line with no bottom to it -- a black band with a hard edge and no
+  // caster you could point at, which is not a shape any real shadow has. The
+  // giveaway is that widening the box turns previously LIT pixels dark: a real
+  // shadow does not gain area when you enlarge the camera that renders it.
+  //
+  // 260 m at 2048 is 0.25 m per texel, which is inside the range this era of
+  // console shadow ran at. `far` goes up with it, or tall casters fall out of
+  // the frustum at the same edge for the same reason.
+  const S = 260;
   sun.shadow.camera.left = -S;
   sun.shadow.camera.right = S;
   sun.shadow.camera.top = S;
   sun.shadow.camera.bottom = -S;
-  // Widening the shadow camera to 190 m took the texel from ~0.10 m to ~0.19 m,
-  // and the old bias no longer spanned one: acne came back as dark blotches
-  // across sunlit facades. normalBias has to scale with texel size.
+  // The texel is now ~0.25 m and the old bias no longer spans one: acne comes
+  // back as dark blotches across sunlit facades. normalBias scales with texel
+  // size, so it goes up whenever S does.
   sun.shadow.bias = -0.0006;
-  sun.shadow.normalBias = 0.09;
+  sun.shadow.normalBias = 0.12;
   scene.add(sun);
   scene.add(sun.target);
 
@@ -354,7 +432,7 @@ async function boot() {
   }
 
   await step(1, 'Welcome to Seattle');
-  window.__dbg = { game, city, player, world, traffic, peds, scene, camera, renderer, G, fx, hud, controls, audio, pickups, THREE, postfx, applyQuality, sun, sceneStats, cityStats, animateWalk };
+  window.__dbg = { game, city, player, world, traffic, peds, scene, camera, renderer, G, fx, hud, controls, audio, pickups, THREE, postfx, applyQuality, sun, sceneStats, cityStats, animateWalk, collideWithBuildings };
   wireUi();
   game.newTarget();
   applyQuality('high', false);
@@ -834,8 +912,14 @@ function frame(now) {
   world.update(p.x, p.z, fps < 45 ? 1 : 2);
 
   player.applyCamera(camera);
-  sun.position.set(p.x - 215, p.y + 200, p.z - 150);
-  sun.target.position.set(p.x, p.y, p.z);
+  // Aim the shadow box down the view, not at the player's feet. Centred on the
+  // player, half of its area covers ground that is behind the camera and can
+  // never be seen, so the useful reach forward is only half what is paid for.
+  // Pushing the centre ahead roughly doubles the forward coverage for nothing.
+  const fwd = LOOK_AHEAD.set(0, 0, -1).applyQuaternion(camera.quaternion);
+  const sx = p.x + fwd.x * 90, sz = p.z + fwd.z * 90;
+  sun.position.set(sx - 215, p.y + 200, sz - 150);
+  sun.target.position.set(sx, p.y, sz);
   sun.target.updateMatrixWorld();
 
   // audio state

--- a/apps/auto/src/main.js
+++ b/apps/auto/src/main.js
@@ -250,7 +250,14 @@ async function boot() {
   renderer = new THREE.WebGLRenderer({ canvas, antialias: false, powerPreference: 'high-performance' });
   renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, isMobile ? 2 : 1.6));
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
-  renderer.toneMappingExposure = 1.25;
+  // EXPOSURE, not ambient, is the lever on a scene sitting in the ACES toe.
+  //
+  // The city floor was at 0.02-0.04 scene-referred, which is exactly where the
+  // ACES curve compresses hardest, so light added at the source was eaten
+  // before it reached the framebuffer: hemisphere and ambient were pushed 2.6x
+  // and bought 1.6x on screen. Exposure slides the whole scene up the curve
+  // instead of pushing harder into the compressed region.
+  renderer.toneMappingExposure = 0.46;
   const viewW = () => canvas.clientWidth || window.innerWidth;
   const viewH = () => canvas.clientHeight || window.innerHeight;
   renderer.setSize(viewW(), viewH(), false);
@@ -323,7 +330,7 @@ function installHeightFog() {
   // downstream can read under a shadowless sky: AO, normal maps and geometry all
   // score flat no matter how good they are. Daylight open-worlds run nearer 4:1,
   // warm key against cool sky fill.
-  const hemi = new THREE.HemisphereLight(0xdcecf6, 0x8d968a, 1.15);
+  const hemi = new THREE.HemisphereLight(0xdcecf6, 0x8d968a, 0.72);
   scene.add(hemi);
   // A floor under the shadows.
   //
@@ -340,8 +347,8 @@ function installHeightFog() {
   // zero. Raising the floor fixes the aerial value inversion, the near-black
   // street asphalt and the black tower bodies at once, and it lets the roof
   // albedo go back where it belongs.
-  scene.add(new THREE.AmbientLight(0xb4c2cc, 0.62));
-  sun = new THREE.DirectionalLight(0xfff2dc, 3.6);
+  scene.add(new THREE.AmbientLight(0xb4c2cc, 0.36));
+  sun = new THREE.DirectionalLight(0xfff2dc, 4.3);
   // ~38 deg elevation: high enough to light the streets, low enough that every
   // shot has a lit face and a shadowed one.
   sun.position.set(-215, 200, -150);

--- a/apps/auto/src/main.js
+++ b/apps/auto/src/main.js
@@ -248,7 +248,7 @@ async function boot() {
   renderer = new THREE.WebGLRenderer({ canvas, antialias: false, powerPreference: 'high-performance' });
   renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, isMobile ? 2 : 1.6));
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
-  renderer.toneMappingExposure = 1.5;
+  renderer.toneMappingExposure = 1.25;
   const viewW = () => canvas.clientWidth || window.innerWidth;
   const viewH = () => canvas.clientHeight || window.innerHeight;
   renderer.setSize(viewW(), viewH(), false);
@@ -257,26 +257,46 @@ async function boot() {
   renderer.outputColorSpace = THREE.SRGBColorSpace;
 
   scene = new THREE.Scene();
-  scene.fog = new THREE.FogExp2(0xb9c6d0, 0.00032);
+  // Aerial perspective. At 0.00032 a tower 3 km away reads at nearly the same
+  // contrast and saturation as one across the street, which is what made the
+  // city look like a diorama. The colour is matched to the sky near the
+  // horizon so distance resolves INTO the sky rather than toward a grey haze
+  // sitting in front of it.
+  scene.fog = new THREE.FogExp2(0xc4ccd4, 0.00060);
   camera = new THREE.PerspectiveCamera(62, viewW() / viewH(), 0.5, 9000);
 
   // The sky IBL supplies most of the ambient, so the analytic lights are just a
   // key with a cool bounce fill.
-  const hemi = new THREE.HemisphereLight(0xdcecf6, 0x7b8474, 2.0);
+  // KEY-TO-AMBIENT IS THE WHOLE LOOK. At hemi 2.0 against sun 2.5, plus full
+  // IBL on top, the ambient dominated and the ratio was about 1.3:1 -- so two
+  // faces of the same building differed only by texture, never by light. Nothing
+  // downstream can read under a shadowless sky: AO, normal maps and geometry all
+  // score flat no matter how good they are. Daylight open-worlds run nearer 4:1,
+  // warm key against cool sky fill.
+  const hemi = new THREE.HemisphereLight(0xdcecf6, 0x6d7668, 0.55);
   scene.add(hemi);
-  sun = new THREE.DirectionalLight(0xfff0d8, 2.5);
-  sun.position.set(-160, 240, -110);
+  sun = new THREE.DirectionalLight(0xfff2dc, 3.6);
+  // ~38 deg elevation: high enough to light the streets, low enough that every
+  // shot has a lit face and a shadowed one.
+  sun.position.set(-215, 200, -150);
   sun.castShadow = true;
   sun.shadow.mapSize.set(2048, 2048);
   sun.shadow.camera.near = 20;
-  sun.shadow.camera.far = 620;
-  const S = 105;
+  sun.shadow.camera.far = 780;
+  // 105 m covered barely a block: buildings cast no shadow on the streets they
+  // line, which is most of why the city read as flat. 190 m reaches across a
+  // downtown block and its far side at the cost of shadow-map resolution,
+  // which 2048 absorbs.
+  const S = 190;
   sun.shadow.camera.left = -S;
   sun.shadow.camera.right = S;
   sun.shadow.camera.top = S;
   sun.shadow.camera.bottom = -S;
-  sun.shadow.bias = -0.0009;
-  sun.shadow.normalBias = 0.04;
+  // Widening the shadow camera to 190 m took the texel from ~0.10 m to ~0.19 m,
+  // and the old bias no longer spanned one: acne came back as dark blotches
+  // across sunlit facades. normalBias has to scale with texel size.
+  sun.shadow.bias = -0.0006;
+  sun.shadow.normalBias = 0.09;
   scene.add(sun);
   scene.add(sun.target);
 
@@ -814,7 +834,7 @@ function frame(now) {
   world.update(p.x, p.z, fps < 45 ? 1 : 2);
 
   player.applyCamera(camera);
-  sun.position.set(p.x - 150, p.y + 230, p.z - 110);
+  sun.position.set(p.x - 215, p.y + 200, p.z - 150);
   sun.target.position.set(p.x, p.y, p.z);
   sun.target.updateMatrixWorld();
 
@@ -846,7 +866,7 @@ function draw(now) {
   // capture before the post passes reset the counters
   sceneStats.calls = renderer.info.render.calls;
   sceneStats.tris = renderer.info.render.triangles;
-  postfx.render(now / 1000);
+  postfx.render(now / 1000, camera);
   renderer.setRenderTarget(null);
 }
 const sceneStats = { calls: 0, tris: 0 };

--- a/apps/auto/src/peds.js
+++ b/apps/auto/src/peds.js
@@ -636,7 +636,11 @@ export function animateWalk(h, amp, dt, speed) {
 
 // ---------------------------------------------------------------------------
 
-const MAX_PEDS = 26;
+// A pavement with 26 people spread over a 150 m radius is a pavement with
+// nobody on it at any given moment. Characters are one draw call each -- the
+// cheapest population in the game -- so this is the least expensive density
+// there is to buy.
+const MAX_PEDS = 34;
 const PED_RADIUS = 150;
 
 export class PedSystem {
@@ -664,7 +668,10 @@ export class PedSystem {
       const x = lerp(a.x, b.x, t) - e.dz * off * side;
       const z = lerp(a.z, b.z, t) + e.dx * off * side;
       const d = Math.hypot(x - px, z - pz);
-      if (d < (cop ? 22 : 26) || d > PED_RADIUS) continue;
+      // Don't spawn on top of the player, but 26 m was far enough that the
+      // pavement directly in front of you was permanently empty -- which is
+      // the stretch of pavement you spend the whole game looking at.
+      if (d < (cop ? 20 : 15) || d > PED_RADIUS) continue;
       if (!G.isBuildable(x, z)) continue;
       const seed = (this.R.n() * 1e6) | 0;
       const h = cop

--- a/apps/auto/src/player.js
+++ b/apps/auto/src/player.js
@@ -163,6 +163,10 @@ export class Player {
   }
 
   blocked(x, z) {
+    // Trunks and poles. `blocked` is tried on each axis separately by the
+    // caller, so a circle here lets you slide around a tree rather than
+    // sticking to it.
+    if (this.city.obstacleHit(x, z, 0.32)) return true;
     const near = this.city.buildingsNear(x, z, 6);
     for (const b of near) {
       const c = Math.cos(-b.rot), s = Math.sin(-b.rot);

--- a/apps/auto/src/postfx.js
+++ b/apps/auto/src/postfx.js
@@ -140,7 +140,7 @@ void main() {
   // on the darkest values keeps detail out of the crush; a shoulder that only
   // acts above the knee keeps the bright faces from flattening.
   c += vec3(0.024) * pow(1.0 - c, vec3(4.0));
-  c -= vec3(0.11) * pow(max(c - 0.62, vec3(0.0)), vec3(1.6));
+  c -= vec3(0.20) * pow(max(c - 0.52, vec3(0.0)), vec3(1.5));
   c = mix(c, c * c * (3.0 - 2.0 * c), 0.05);
   c = mix(vec3(dot(c, vec3(0.2126, 0.7152, 0.0722))), c, 1.12);
   c += vec3(-0.008, 0.0, 0.014) * (1.0 - c);
@@ -265,6 +265,26 @@ export class PostFX {
     this.quadScene = new THREE.Scene();
 
     this.sceneRT = makeRT(2, 2, true);
+    // Make three tone-map INTO this target.
+    //
+    // WebGLRenderer applies `toneMapping` only when the current render target
+    // is null -- i.e. only when drawing straight to the canvas -- or when the
+    // target is flagged as an XR target:
+    //
+    //   if ( currentRenderTarget === null || currentRenderTarget.isXRRenderTarget === true )
+    //
+    // The whole scene is drawn into this target, so ACES and
+    // `toneMappingExposure` were never running at ALL. The consequences were
+    // everywhere and each was chased as something else: highlights had no
+    // shoulder and hard-clipped to flat 255 plateaus (read as missing
+    // textures on the glass towers), and exposure was a dial connected to
+    // nothing -- moving it 1.02 to 1.55 changed the output by less than a
+    // thousandth of a stop, which is what finally gave it away.
+    //
+    // The flag is the documented condition three tests, and it is the only
+    // way to get tone mapping applied before an 8-bit target quantises the
+    // highlights. Pinned to the vendored r160; re-check it on a three bump.
+    this.sceneRT.isXRRenderTarget = true;
     // Integer depth attachment, filled by the scene pass at no extra cost. This
     // is what SSAO reads; a separate depth prepass would double the draw calls.
     this.sceneRT.depthTexture = new THREE.DepthTexture(2, 2);

--- a/apps/auto/src/postfx.js
+++ b/apps/auto/src/postfx.js
@@ -142,7 +142,16 @@ void main() {
   c += vec3(0.024) * pow(1.0 - c, vec3(4.0));
   c -= vec3(0.20) * pow(max(c - 0.52, vec3(0.0)), vec3(1.5));
   c = mix(c, c * c * (3.0 - 2.0 * c), 0.05);
-  c = mix(vec3(dot(c, vec3(0.2126, 0.7152, 0.0722))), c, 1.12);
+  // Saturation compensation for ACES.
+  //
+  // The curve desaturates saturated hues, and greens worst. Measured across
+  // the beauty set the moment tone mapping actually started running, mean
+  // frame saturation fell 32% in the park, 35% in the residential shot and
+  // 59% on the street -- foliage that had been tuned against no curve at all
+  // came out as pale sage. Every engine shipping ACES puts a boost after it
+  // for the same reason; this is not a look choice, it is paying the curve
+  // back what it took.
+  c = mix(vec3(dot(c, vec3(0.2126, 0.7152, 0.0722))), c, 1.45);
   c += vec3(-0.008, 0.0, 0.014) * (1.0 - c);
   c *= vec3(1.015, 1.0, 0.985);
 

--- a/apps/auto/src/postfx.js
+++ b/apps/auto/src/postfx.js
@@ -44,6 +44,44 @@ void main() {
   gl_FragColor = vec4(sum, 1.0);
 }`;
 
+// Depth-aware blur, for the AO buffer only.
+//
+// The Gaussian above is depth-blind, so smoothing the AO with it drags a
+// building's contact darkening several pixels out over the road behind it and
+// washes the crevice darkening back out of the crevice. The result is AO you
+// are paying for and cannot see -- which is why the strength had to stay low
+// to avoid haloing. Weighting each tap by how close its depth is to the
+// centre's keeps the occlusion on the surface that generated it, and lets the
+// strength go up.
+const AOBLUR = `
+precision highp float;
+uniform sampler2D tSrc;
+uniform sampler2D tDepth;
+uniform vec2 dir;
+uniform float depthScale;
+varying vec2 vUv;
+
+void main() {
+  float zc = texture2D(tDepth, vUv).x;
+  float sum = texture2D(tSrc, vUv).r * 0.2270270270;
+  float wsum = 0.2270270270;
+  for (int i = 0; i < 2; i++) {
+    float off = i == 0 ? 1.3846153846 : 3.2307692308;
+    float base = i == 0 ? 0.3162162162 : 0.0702702703;
+    for (int s = 0; s < 2; s++) {
+      vec2 uv = vUv + dir * off * (s == 0 ? 1.0 : -1.0);
+      float z = texture2D(tDepth, uv).x;
+      // Depth here is the non-linear device value, so the same absolute
+      // difference means very different distances near and far. Scaling by the
+      // centre depth's own gradient keeps the falloff usable across the frame.
+      float w = base * exp(-abs(z - zc) * depthScale / max(1.0 - zc, 1e-4));
+      sum += texture2D(tSrc, uv).r * w;
+      wsum += w;
+    }
+  }
+  gl_FragColor = vec4(vec3(sum / wsum), 1.0);
+}`;
+
 const COMPOSITE = `
 uniform sampler2D tScene;
 uniform sampler2D tBloom;
@@ -93,8 +131,17 @@ void main() {
   }
   c += texture2D(tBloom, vUv).rgb * bloomStrength;
 
-  // grade: lift the shadows slightly cool, warm the highlights, add contrast
-  c = mix(c, c * c * (3.0 - 2.0 * c), 0.09);
+  // Toe and shoulder.
+  //
+  // The grade was a smoothstep, which is symmetric: it pushed the shadows
+  // DOWN as hard as it pushed the highlights up. Road, glass and grazing-angle
+  // water all clamped to near zero and the tower tops all clamped near one, so
+  // both ends of the image carried no separation at all. A toe that only acts
+  // on the darkest values keeps detail out of the crush; a shoulder that only
+  // acts above the knee keeps the bright faces from flattening.
+  c += vec3(0.024) * pow(1.0 - c, vec3(4.0));
+  c -= vec3(0.11) * pow(max(c - 0.62, vec3(0.0)), vec3(1.6));
+  c = mix(c, c * c * (3.0 - 2.0 * c), 0.05);
   c = mix(vec3(dot(c, vec3(0.2126, 0.7152, 0.0722))), c, 1.12);
   c += vec3(-0.008, 0.0, 0.014) * (1.0 - c);
   c *= vec3(1.015, 1.0, 0.985);
@@ -102,12 +149,19 @@ void main() {
   float d = distance(vUv, vec2(0.5));
   c *= 1.0 - vignette * smoothstep(0.35, 0.95, d);
 
-  // Screen-space dither at the output, one 8-bit step, unmagnified. Baking
-  // this into the sky equirect instead put clumped multi-pixel grain across the
-  // sky AND the water, and polluted the IBL that the sky feeds.
-  float n1 = fract(sin(dot(vUv, vec2(12.9898, 78.233)) + time) * 43758.5453);
-  float n2 = fract(sin(dot(vUv, vec2(93.9898, 47.233)) + time) * 24634.6345);
-  c += ((n1 - n2) * (1.0 / 255.0)) + (n1 - 0.5) * grain;
+  // Dither from PIXEL coordinates, not from uv.
+  //
+  // A sin-of-dot hash on uv is periodic along both screen axes, so it lays down
+  // a regular comb across the sky and a diagonal weave on the water -- an
+  // aligned pattern beating against a smooth gradient, which reads as a broken
+  // shader and is worse than the banding it was meant to hide. Hashing integer
+  // pixel coordinates with a per-frame offset gives actual noise, and the
+  // triangular PDF (two uniforms differenced) is what removes the banding
+  // rather than merely covering it.
+  vec2 px = vUv / texel + vec2(fract(time * 71.0) * 977.0, fract(time * 53.0) * 331.0);
+  float n1 = fract(sin(dot(floor(px), vec2(12.9898, 78.233))) * 43758.5453);
+  float n2 = fract(sin(dot(floor(px) + 17.0, vec2(39.3468, 11.135))) * 24634.6345);
+  c += (n1 - n2) * (0.5 / 255.0) + (n1 - 0.5) * grain;
 
   gl_FragColor = vec4(clamp(c, 0.0, 1.0), 1.0);
 }`;
@@ -225,13 +279,17 @@ export class PostFX {
       tScene: { value: null }, threshold: { value: 0.86 }, softness: { value: 0.22 },
     });
     this.blur = pass(BLUR, { tSrc: { value: null }, dir: { value: new THREE.Vector2() } });
+    this.aoBlur = pass(AOBLUR, {
+      tSrc: { value: null }, tDepth: { value: null },
+      dir: { value: new THREE.Vector2() }, depthScale: { value: 0.02 },
+    });
     this.ssao = pass(SSAO, {
       tDepth: { value: null },
       projInv: { value: new THREE.Matrix4() },
       proj: { value: new THREE.Matrix4() },
       texel: { value: new THREE.Vector2() },
       radius: { value: 0.85 },
-      strength: { value: 1.5 },
+      strength: { value: 2.1 },
       bias: { value: 0.035 },
     });
     this.composite = pass(COMPOSITE, {
@@ -239,11 +297,11 @@ export class PostFX {
       texel: { value: new THREE.Vector2() },
       bloomStrength: { value: 0.62 },
       vignette: { value: 0.15 },
-      grain: { value: 0.016 },
+      grain: { value: 0.005 },
       time: { value: 0 },
       fxaa: { value: 1 },
       tAO: { value: null },
-      aoAmount: { value: 0.85 },
+      aoAmount: { value: 1.0 },
     });
   }
 
@@ -290,13 +348,14 @@ export class PostFX {
       draw(this.ssao, this.aoA);
       // Two cheap separable passes: the sample kernel is noisy by design and
       // unblurred AO reads as dirt on the lens.
-      const bu2 = this.blur.material.uniforms;
+      const bu2 = this.aoBlur.material.uniforms;
+      bu2.tDepth.value = this.sceneRT.depthTexture;
       bu2.tSrc.value = this.aoA.texture;
       bu2.dir.value.set(1 / this._aw, 0);
-      draw(this.blur, this.aoB);
+      draw(this.aoBlur, this.aoB);
       bu2.tSrc.value = this.aoB.texture;
       bu2.dir.value.set(0, 1 / this._ah);
-      draw(this.blur, this.aoA);
+      draw(this.aoBlur, this.aoA);
       this.composite.material.uniforms.tAO.value = this.aoA.texture;
     }
 
@@ -324,7 +383,7 @@ export class PostFX {
 
   dispose() {
     for (const rt of [this.sceneRT, this.bloomA, this.bloomB, this.aoA, this.aoB]) rt.dispose();
-    for (const m of [this.bright, this.blur, this.composite, this.ssao]) m.material.dispose();
+    for (const m of [this.bright, this.blur, this.aoBlur, this.composite, this.ssao]) m.material.dispose();
     QUAD.dispose();
   }
 
@@ -335,9 +394,11 @@ export class PostFX {
     // for medium too -- dropping it entirely was a visible edge-quality cliff.
     cu.fxaa.value = q === 'low' ? 0 : 1;
     cu.bloomStrength.value = q === 'high' ? 0.62 : 0.5;
-    cu.grain.value = q === 'high' ? 0.016 : 0;
+    // Film grain is separate from the dither and much larger; at 0.016 it was
+    // reading as texture across the sky now that the dither is per-pixel.
+    cu.grain.value = q === 'high' ? 0.005 : 0;
     // SSAO is the most expensive pass here, so it is the first thing to go.
     this.ssaoOn = q === 'high';
-    cu.aoAmount.value = this.ssaoOn ? 0.85 : 0.0;
+    cu.aoAmount.value = this.ssaoOn ? 1.0 : 0.0;
   }
 }

--- a/apps/auto/src/postfx.js
+++ b/apps/auto/src/postfx.js
@@ -53,6 +53,8 @@ uniform float vignette;
 uniform float grain;
 uniform float time;
 uniform float fxaa;
+uniform sampler2D tAO;
+uniform float aoAmount;
 varying vec2 vUv;
 
 // FXAA 3.11 console variant -- cheap, and plenty at phone resolutions.
@@ -83,6 +85,12 @@ vec3 fxaaFilter(vec2 uv) {
 
 void main() {
   vec3 c = fxaa > 0.5 ? fxaaFilter(vUv) : texture2D(tScene, vUv).rgb;
+  // AO before bloom: occlusion belongs to the surface, and applying it after
+  // would let bloom bleed back into the crevices it just darkened.
+  if (aoAmount > 0.0) {
+    float ao = texture2D(tAO, vUv).r;
+    c *= mix(1.0, ao, aoAmount);
+  }
   c += texture2D(tBloom, vUv).rgb * bloomStrength;
 
   // grade: lift the shadows slightly cool, warm the highlights, add contrast
@@ -94,10 +102,77 @@ void main() {
   float d = distance(vUv, vec2(0.5));
   c *= 1.0 - vignette * smoothstep(0.35, 0.95, d);
 
-  float n = fract(sin(dot(vUv * time, vec2(12.9898, 78.233))) * 43758.5453);
-  c += (n - 0.5) * grain;
+  // Screen-space dither at the output, one 8-bit step, unmagnified. Baking
+  // this into the sky equirect instead put clumped multi-pixel grain across the
+  // sky AND the water, and polluted the IBL that the sky feeds.
+  float n1 = fract(sin(dot(vUv, vec2(12.9898, 78.233)) + time) * 43758.5453);
+  float n2 = fract(sin(dot(vUv, vec2(93.9898, 47.233)) + time) * 24634.6345);
+  c += ((n1 - n2) * (1.0 / 255.0)) + (n1 - 0.5) * grain;
 
   gl_FragColor = vec4(clamp(c, 0.0, 1.0), 1.0);
+}`;
+
+// Screen-space ambient occlusion.
+//
+// Reads the DEPTH TEXTURE the scene pass already filled -- an integer depth
+// attachment, not a half-float colour target, so it stays inside the rule that
+// keeps this chain working on iOS. It also costs no extra draw calls: the depth
+// is a by-product of the pass that was happening anyway, where a separate depth
+// prepass would have doubled the scene's 215 draws.
+const SSAO = `
+precision highp float;
+varying vec2 vUv;
+uniform sampler2D tDepth;
+uniform mat4 projInv;
+uniform mat4 proj;
+uniform vec2 texel;
+uniform float radius;
+uniform float strength;
+uniform float bias;
+
+vec3 viewPos(vec2 uv) {
+  float z = texture2D(tDepth, uv).x;
+  vec4 clip = vec4(uv * 2.0 - 1.0, z * 2.0 - 1.0, 1.0);
+  vec4 v = projInv * clip;
+  return v.xyz / v.w;
+}
+
+// 12 points on a hemisphere, weighted toward the centre so near-contact
+// darkening reads without the far samples turning into banding.
+const vec3 K[12] = vec3[12](
+  vec3( 0.5381, 0.1856, 0.4319), vec3( 0.1379, 0.2486, 0.4430),
+  vec3( 0.3371, 0.5679, 0.0057), vec3(-0.6999,-0.0451, 0.0019),
+  vec3( 0.0689,-0.1598, 0.8547), vec3( 0.0560, 0.0069, 0.1843),
+  vec3(-0.0146, 0.1402, 0.0762), vec3( 0.0100,-0.1924, 0.0344),
+  vec3(-0.3577,-0.5301, 0.4358), vec3(-0.3169, 0.1063, 0.0158),
+  vec3( 0.0103,-0.5869, 0.0046), vec3(-0.0897,-0.4940, 0.3287)
+);
+
+void main() {
+  float z = texture2D(tDepth, vUv).x;
+  // Sky: depth 1.0. Occluding it produces a dark halo along every roofline.
+  if (z >= 0.9999) { gl_FragColor = vec4(1.0); return; }
+  vec3 P = viewPos(vUv);
+  vec3 N = normalize(cross(dFdx(P), dFdy(P)));
+  float rnd = fract(sin(dot(vUv, vec2(12.9898, 78.233))) * 43758.5453);
+  float ca = cos(rnd * 6.2831), sa = sin(rnd * 6.2831);
+  float occ = 0.0;
+  for (int i = 0; i < 12; i++) {
+    vec3 k = K[i];
+    k.xy = vec2(k.x * ca - k.y * sa, k.x * sa + k.y * ca);
+    if (dot(k, N) < 0.0) k = -k;
+    vec3 sp = P + k * radius;
+    vec4 cp = proj * vec4(sp, 1.0);
+    vec2 suv = (cp.xy / cp.w) * 0.5 + 0.5;
+    if (suv.x < 0.0 || suv.x > 1.0 || suv.y < 0.0 || suv.y > 1.0) continue;
+    float sz = viewPos(suv).z;
+    // Range check: a foreground object must not occlude the distant ground
+    // behind it, which is what produces black outlines around everything.
+    float rc = smoothstep(0.0, 1.0, radius / abs(P.z - sz));
+    occ += (sz >= sp.z + bias ? 1.0 : 0.0) * rc;
+  }
+  float ao = clamp(1.0 - (occ / 12.0) * strength, 0.0, 1.0);
+  gl_FragColor = vec4(vec3(ao), 1.0);
 }`;
 
 function pass(fragmentShader, uniforms) {
@@ -136,13 +211,29 @@ export class PostFX {
     this.quadScene = new THREE.Scene();
 
     this.sceneRT = makeRT(2, 2, true);
+    // Integer depth attachment, filled by the scene pass at no extra cost. This
+    // is what SSAO reads; a separate depth prepass would double the draw calls.
+    this.sceneRT.depthTexture = new THREE.DepthTexture(2, 2);
+    this.sceneRT.depthTexture.type = THREE.UnsignedIntType;
     this.bloomA = makeRT(2, 2, false);
     this.bloomB = makeRT(2, 2, false);
+    this.aoA = makeRT(2, 2, false);
+    this.aoB = makeRT(2, 2, false);
+    this.ssaoOn = true;
 
     this.bright = pass(BRIGHT, {
-      tScene: { value: null }, threshold: { value: 0.72 }, softness: { value: 0.28 },
+      tScene: { value: null }, threshold: { value: 0.86 }, softness: { value: 0.22 },
     });
     this.blur = pass(BLUR, { tSrc: { value: null }, dir: { value: new THREE.Vector2() } });
+    this.ssao = pass(SSAO, {
+      tDepth: { value: null },
+      projInv: { value: new THREE.Matrix4() },
+      proj: { value: new THREE.Matrix4() },
+      texel: { value: new THREE.Vector2() },
+      radius: { value: 0.85 },
+      strength: { value: 1.5 },
+      bias: { value: 0.035 },
+    });
     this.composite = pass(COMPOSITE, {
       tScene: { value: null }, tBloom: { value: null },
       texel: { value: new THREE.Vector2() },
@@ -151,6 +242,8 @@ export class PostFX {
       grain: { value: 0.016 },
       time: { value: 0 },
       fxaa: { value: 1 },
+      tAO: { value: null },
+      aoAmount: { value: 0.85 },
     });
   }
 
@@ -163,6 +256,15 @@ export class PostFX {
     const bw = Math.max(2, Math.floor(W / 4)), bh = Math.max(2, Math.floor(H / 4));
     this.bloomA.setSize(bw, bh);
     this.bloomB.setSize(bw, bh);
+    this.sceneRT.depthTexture.image.width = W;
+    this.sceneRT.depthTexture.image.height = H;
+    this.sceneRT.depthTexture.needsUpdate = true;
+    // Half res: AO is a low-frequency term and full res buys nothing visible.
+    const aw = Math.max(2, Math.floor(W / 2)), ah = Math.max(2, Math.floor(H / 2));
+    this.aoA.setSize(aw, ah);
+    this.aoB.setSize(aw, ah);
+    this.ssao.material.uniforms.texel.value.set(1 / aw, 1 / ah);
+    this._aw = aw; this._ah = ah;
     this.composite.material.uniforms.texel.value.set(1 / W, 1 / H);
     this._bw = bw; this._bh = bh;
   }
@@ -172,13 +274,31 @@ export class PostFX {
   }
 
   /** Run the chain. The scene must already have been rendered into `target`. */
-  render(time) {
+  render(time, camera) {
     if (!this.enabled) return;
     const r = this.renderer;
     const draw = (mesh, rt) => {
       r.setRenderTarget(rt);
       r.render(mesh.userData.scene, CAM);
     };
+
+    if (this.ssaoOn && camera) {
+      const su = this.ssao.material.uniforms;
+      su.tDepth.value = this.sceneRT.depthTexture;
+      su.proj.value.copy(camera.projectionMatrix);
+      su.projInv.value.copy(camera.projectionMatrixInverse);
+      draw(this.ssao, this.aoA);
+      // Two cheap separable passes: the sample kernel is noisy by design and
+      // unblurred AO reads as dirt on the lens.
+      const bu2 = this.blur.material.uniforms;
+      bu2.tSrc.value = this.aoA.texture;
+      bu2.dir.value.set(1 / this._aw, 0);
+      draw(this.blur, this.aoB);
+      bu2.tSrc.value = this.aoB.texture;
+      bu2.dir.value.set(0, 1 / this._ah);
+      draw(this.blur, this.aoA);
+      this.composite.material.uniforms.tAO.value = this.aoA.texture;
+    }
 
     this.bright.material.uniforms.tScene.value = this.sceneRT.texture;
     draw(this.bright, this.bloomA);
@@ -203,8 +323,8 @@ export class PostFX {
   }
 
   dispose() {
-    for (const rt of [this.sceneRT, this.bloomA, this.bloomB]) rt.dispose();
-    for (const m of [this.bright, this.blur, this.composite]) m.material.dispose();
+    for (const rt of [this.sceneRT, this.bloomA, this.bloomB, this.aoA, this.aoB]) rt.dispose();
+    for (const m of [this.bright, this.blur, this.composite, this.ssao]) m.material.dispose();
     QUAD.dispose();
   }
 
@@ -216,5 +336,8 @@ export class PostFX {
     cu.fxaa.value = q === 'low' ? 0 : 1;
     cu.bloomStrength.value = q === 'high' ? 0.62 : 0.5;
     cu.grain.value = q === 'high' ? 0.016 : 0;
+    // SSAO is the most expensive pass here, so it is the first thing to go.
+    this.ssaoOn = q === 'high';
+    cu.aoAmount.value = this.ssaoOn ? 0.85 : 0.0;
   }
 }

--- a/apps/auto/src/textures.js
+++ b/apps/auto/src/textures.js
@@ -114,7 +114,11 @@ function glassSurface() {
       rgh.g.fillStyle = grey(0.07);
       rgh.g.fillRect(ix, iy, iw, ih);
 
-      const b = 0.6 + v * 0.4;
+      // Per-pane value jitter has to be SMALL. At 0.6..1.0 the panes varied
+      // more than the mullions separating them, so from any distance the
+      // curtain wall resolved as mottled camouflage rather than as a window
+      // grid -- the grid was there, it was just quieter than the noise on it.
+      const b = 0.82 + v * 0.18;
       a.g.fillStyle = `rgb(${Math.round(104 * b)},${Math.round(134 * b)},${Math.round(150 * b)})`;
       a.g.fillRect(ix, iy, iw, ih);
       const grad = a.g.createLinearGradient(ix, iy, ix, iy + ih);
@@ -137,39 +141,113 @@ function glassSurface() {
         emi.g.fillRect(ix, iy, iw, ih);
       }
       // mullions stand proud
-      a.g.fillStyle = '#6e7c85';
-      a.g.fillRect(px, py, 3, ch);
-      a.g.fillRect(px, py + ch - 3, cw, 3);
+      a.g.fillStyle = '#68767f';
+      a.g.fillRect(px, py, 5, ch);
+      a.g.fillRect(px, py + ch - 5, cw, 5);
       hgt.g.fillStyle = grey(1.0);
-      hgt.g.fillRect(px, py, 3, ch);
-      hgt.g.fillRect(px, py + ch - 3, cw, 3);
+      hgt.g.fillRect(px, py, 5, ch);
+      hgt.g.fillRect(px, py + ch - 5, cw, 5);
       rgh.g.fillStyle = grey(0.72);
-      rgh.g.fillRect(px, py, 3, ch);
-      rgh.g.fillRect(px, py + ch - 3, cw, 3);
+      rgh.g.fillRect(px, py, 5, ch);
+      rgh.g.fillRect(px, py + ch - 5, cw, 5);
     }
   }
-  noise(a.g, S, S, 9, 3);
+  for (let y = 0; y < rows; y += 2) {
+    a.g.fillStyle = 'rgba(46,56,64,0.5)';
+    a.g.fillRect(0, y * ch + ch - 7, S, 9);
+    hgt.g.fillStyle = grey(1.0);
+    hgt.g.fillRect(0, y * ch + ch - 7, S, 9);
+  }
+  noise(a.g, S, S, 5, 3);
   return {
     map: tex(a.c), normalMap: normalFrom(hgt.c, 2.6),
     roughnessMap: tex(rgh.c, { srgb: false }), emissiveMap: tex(emi.c),
   };
 }
 
-function masonrySurface() {
+/**
+ * Wall surface generator, shared by the stone and brick materials.
+ *
+ * One texture with one per-building tint was not enough: a family colour can
+ * only scale what the texture already is, so concrete, stucco and red brick
+ * came out as three values of the same material and the whole city read as one
+ * stone. What actually separates brick from stone at street distance is the
+ * COURSING -- a fine mortar grid against a plain banded ashlar -- and no tint
+ * can produce that. Two calls, two textures, one draw call each.
+ *
+ * `opts.course` is the mortar pitch in pixels; 0 draws smooth ashlar banding
+ * instead. `opts.mortar` is the joint colour, which is what makes brick read
+ * as brick from across a street.
+ */
+function masonrySurface(opts = {}) {
+  const {
+    base = '#adaba6', mortar = null, course = 0, seedN = 21,
+    surround = '#c2c0ba', sill = '#cdcbc4', flecks = 900,
+  } = opts;
   const S = 512;
   const a = canvas(S, S), hgt = canvas(S, S), rgh = canvas(S, S), emi = canvas(S, S);
-  const r = mulberry32(21);
-  a.g.fillStyle = '#b4a595'; a.g.fillRect(0, 0, S, S);
+  const r = mulberry32(seedN);
+  // The base has to be NEUTRAL. At the old warm tan (#b4a595) every family
+  // colour multiplied through to the same beige-orange: concrete, painted
+  // stucco and red brick were one material with three names, which is why a
+  // street of five families still read as one. Grey lets the tints separate.
+  a.g.fillStyle = base; a.g.fillRect(0, 0, S, S);
   hgt.g.fillStyle = grey(0.72); hgt.g.fillRect(0, 0, S, S);
   rgh.g.fillStyle = grey(0.88); rgh.g.fillRect(0, 0, S, S);
   emi.g.fillStyle = '#000'; emi.g.fillRect(0, 0, S, S);
 
-  // stone courses
-  for (let y = 0; y < S; y += 16) {
-    a.g.fillStyle = 'rgba(0,0,0,0.05)';
-    a.g.fillRect(0, y + 14, S, 2);
-    hgt.g.fillStyle = grey(0.55);
-    hgt.g.fillRect(0, y + 14, S, 2);
+  // Masonry grain: fine, irregular, and albedo-only.
+  //
+  // This used to be 32 hard courses per tile with a height notch under each.
+  // The tile spans 13.6 m, so those "brick courses" were 42 cm apart and cut
+  // 42 cm deep grooves -- at that pitch and depth they read as clapboard
+  // siding lapped across a masonry wall, which is two material metaphors on
+  // one surface. Real coursing at this texel density is sub-pixel, so it
+  // belongs in the grain rather than as geometry-scale relief.
+  if (course > 0) {
+    // Brick: a real running bond. The mortar is drawn as its own colour rather
+    // than as a black line, because a warm brick against a pale joint is most
+    // of what the eye uses to name the material at a distance, and a grey line
+    // just reads as dirt.
+    const bw = course * 2.4;
+    for (let y = 0, row = 0; y < S; y += course, row++) {
+      a.g.fillStyle = mortar;
+      a.g.fillRect(0, y + course - 2, S, 2);
+      const off = (row % 2) * (bw / 2);
+      for (let x = -bw; x < S + bw; x += bw) {
+        a.g.fillRect(x + off, y, 2, course);
+        // Per-brick value jitter, small enough to stay one material.
+        a.g.fillStyle = r() > 0.5
+          ? `rgba(255,255,255,${0.03 + r() * 0.06})`
+          : `rgba(0,0,0,${0.03 + r() * 0.07})`;
+        a.g.fillRect(x + off + 2, y, bw - 2, course - 2);
+        a.g.fillStyle = mortar;
+      }
+      hgt.g.fillStyle = grey(0.5);
+      hgt.g.fillRect(0, y + course - 2, S, 2);
+    }
+  } else {
+    for (let y = 6; y < S; y += 6) {
+      a.g.fillStyle = `rgba(0,0,0,${0.012 + r() * 0.016})`;
+      a.g.fillRect(0, y, S, 1);
+    }
+    for (let i = 0; i < flecks; i++) {
+      const bx = r() * S, by = ((r() * S) / 6 | 0) * 6;
+      a.g.fillStyle = r() > 0.5 ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.05)';
+      a.g.fillRect(bx, by, 8 + r() * 14, 5);
+    }
+  }
+
+  // One spandrel band per storey -- an actual architectural feature at an
+  // actual architectural pitch, unlike the courses it replaces.
+  const storey = S / 4;
+  for (let y = 0; y < S; y += storey) {
+    a.g.fillStyle = 'rgba(0,0,0,0.07)';
+    a.g.fillRect(0, y + storey - 7, S, 5);
+    hgt.g.fillStyle = grey(0.58);
+    hgt.g.fillRect(0, y + storey - 7, S, 5);
+    hgt.g.fillStyle = grey(0.86);
+    hgt.g.fillRect(0, y + storey - 10, S, 3);
   }
 
   const cols = 4, rows = 4;
@@ -179,7 +257,7 @@ function masonrySurface() {
       const px = x * cw + cw * 0.2, py = y * ch + ch * 0.16;
       const w = cw * 0.6, h = ch * 0.52;
       // surround
-      a.g.fillStyle = '#c8bcab';
+      a.g.fillStyle = surround;
       a.g.fillRect(px - 6, py - 6, w + 12, h + 14);
       hgt.g.fillStyle = grey(0.95);
       hgt.g.fillRect(px - 6, py - 6, w + 12, h + 14);
@@ -189,18 +267,50 @@ function masonrySurface() {
       rgh.g.fillStyle = grey(0.12);
       rgh.g.fillRect(px, py, w, h);
       const v = r();
-      a.g.fillStyle = `rgb(${(36 + v * 26) | 0},${(48 + v * 30) | 0},${(58 + v * 34) | 0})`;
+      // Glazing is BRIGHT, not black.
+      //
+      // The panes were rgb(36,48,58) -- and the whole facade, windows
+      // included, is then multiplied by the building's family colour, so on a
+      // red brick block the windows came out at (29,18,16): solid black holes.
+      // It is also just wrong. A window seen from outside in daylight is
+      // mostly a reflection of the sky, which is the brightest thing around;
+      // it only goes dark where the reveal shades it. Starting bright means
+      // the tint darkens it to a believable place instead of to nothing.
+      a.g.fillStyle = `rgb(${(122 + v * 34) | 0},${(144 + v * 34) | 0},${(164 + v * 32) | 0})`;
       a.g.fillRect(px, py, w, h);
       const grad = a.g.createLinearGradient(px, py, px, py + h);
-      grad.addColorStop(0, 'rgba(214,232,244,0.42)');
-      grad.addColorStop(1, 'rgba(0,0,0,0.3)');
+      grad.addColorStop(0, 'rgba(226,240,250,0.55)');
+      grad.addColorStop(0.55, 'rgba(150,172,190,0.15)');
+      grad.addColorStop(1, 'rgba(28,38,48,0.42)');
       a.g.fillStyle = grad;
       a.g.fillRect(px, py, w, h);
+      // Per-window content. Every window in the city being the identical unit
+      // is what makes a facade read as wallpaper; a floor where one blind is
+      // down and the next is half up is what makes it read as occupied.
+      if (v > 0.30 && v < 0.62) {
+        // blind, pulled to a different height in each
+        const bh = h * (0.18 + v * 0.62);
+        a.g.fillStyle = 'rgba(226,220,202,0.72)';
+        a.g.fillRect(px, py, w, bh);
+        rgh.g.fillStyle = grey(0.6);
+        rgh.g.fillRect(px, py, w, bh);
+      } else if (v > 0.72 && v < 0.80) {
+        // dark interior, a room with nothing behind the glass
+        a.g.fillStyle = 'rgba(22,26,32,0.55)';
+        a.g.fillRect(px, py, w, h);
+      }
       if (v > 0.94) {
         a.g.fillStyle = 'rgba(255,228,172,0.62)';
         a.g.fillRect(px, py, w, h);
         emi.g.fillStyle = 'rgb(250,198,124)';
         emi.g.fillRect(px, py, w, h);
+      }
+      // Air-conditioner in a few openings, hung on the sill.
+      if (v > 0.86 && v < 0.92) {
+        a.g.fillStyle = '#8d8f90';
+        a.g.fillRect(px + w * 0.2, py + h * 0.62, w * 0.6, h * 0.38);
+        hgt.g.fillStyle = grey(0.9);
+        hgt.g.fillRect(px + w * 0.2, py + h * 0.62, w * 0.6, h * 0.38);
       }
       // glazing bars
       a.g.fillStyle = 'rgba(220,214,200,0.7)';
@@ -208,14 +318,14 @@ function masonrySurface() {
       hgt.g.fillStyle = grey(0.5);
       hgt.g.fillRect(px + w / 2 - 1.5, py, 3, h);
       // sill
-      a.g.fillStyle = '#d3c7b4';
+      a.g.fillStyle = sill;
       a.g.fillRect(px - 8, py + h + 4, w + 16, 6);
       hgt.g.fillStyle = grey(1.0);
       hgt.g.fillRect(px - 8, py + h + 4, w + 16, 6);
     }
   }
   noise(a.g, S, S, 16, 9);
-  noise(hgt.g, S, S, 10, 12);
+  noise(hgt.g, S, S, 3, 12);
   return {
     map: tex(a.c), normalMap: normalFrom(hgt.c, 2.2),
     roughnessMap: tex(rgh.c, { srgb: false }), emissiveMap: tex(emi.c),
@@ -335,24 +445,63 @@ function houseSurface() {
 function roadSurface() {
   const S = 512;
   const a = canvas(S, S), hgt = canvas(S, S), rgh = canvas(S, S);
-  a.g.fillStyle = '#56595e'; a.g.fillRect(0, 0, S, S);
+  // Judge the asphalt by its MEAN, not by its base colour.
+  //
+  // The base was #56595e -- about 0.095 linear, which is right for tarmac --
+  // but the aggregate, seams and patches painted on top all skew dark, and the
+  // rendered mean came out at 0.043: less than half of real asphalt. Street
+  // level got away with it because bright facades fill the frame; from the air,
+  // where road is most of what you can see, the whole near-field went black
+  // while the fogged skyline stayed bright and the city read inside-out.
+  a.g.fillStyle = '#63666c'; a.g.fillRect(0, 0, S, S);
   hgt.g.fillStyle = grey(0.5); hgt.g.fillRect(0, 0, S, S);
   rgh.g.fillStyle = grey(0.72); rgh.g.fillRect(0, 0, S, S);
   const r = mulberry32(41);
   // aggregate
   for (let i = 0; i < 5200; i++) {
     const x = r() * S, y = r() * S, s = 1 + r() * 3;
-    const l = 0.3 + r() * 0.5;
+    const l = 0.5 + r() * 0.55;
     a.g.fillStyle = `rgba(${(120 * l) | 0},${(124 * l) | 0},${(130 * l) | 0},0.5)`;
     a.g.fillRect(x, y, s, s);
     hgt.g.fillStyle = grey(0.45 + r() * 0.35);
     hgt.g.fillRect(x, y, s, s);
   }
-  // patches and repairs, greyscale only so the asphalt never tints
-  for (let i = 0; i < 26; i++) {
-    const l = r() > 0.5 ? 255 : 0;
-    a.g.fillStyle = `rgba(${l},${l},${l},0.03)`;
-    a.g.fillRect(r() * S, r() * S, 40 + r() * 120, 16 + r() * 60);
+  // Patches, repairs and crack seams. These were at 3% alpha, which is under
+  // one 8-bit step -- literally invisible, so the asphalt was uniform pepper
+  // noise over a flat value. Greyscale only, so the tarmac never tints.
+  for (let i = 0; i < 22; i++) {
+    const l = r() > 0.5 ? 210 : 40;
+    a.g.fillStyle = `rgba(${l},${l},${l},${0.05 + r() * 0.07})`;
+    const pw = 40 + r() * 130, ph = 20 + r() * 70;
+    const px = r() * S, py = r() * S;
+    a.g.fillRect(px, py, pw, ph);
+    hgt.g.fillStyle = grey(0.42 + r() * 0.2);
+    hgt.g.fillRect(px, py, pw, ph);
+    rgh.g.fillStyle = grey(0.5 + r() * 0.3);
+    rgh.g.fillRect(px, py, pw, ph);
+  }
+  // Crack seams: thin dark lines with a height notch, so they catch the key
+  // light at a grazing angle instead of being a flat decal.
+  for (let i = 0; i < 30; i++) {
+    let cx = r() * S, cy = r() * S;
+    let ang = r() * Math.PI * 2;
+    a.g.strokeStyle = 'rgba(18,18,20,0.5)';
+    a.g.lineWidth = 1 + r();
+    a.g.beginPath();
+    a.g.moveTo(cx, cy);
+    hgt.g.strokeStyle = grey(0.2);
+    hgt.g.lineWidth = 2;
+    hgt.g.beginPath();
+    hgt.g.moveTo(cx, cy);
+    for (let k = 0; k < 5; k++) {
+      ang += (r() - 0.5) * 1.1;
+      cx += Math.cos(ang) * (10 + r() * 24);
+      cy += Math.sin(ang) * (10 + r() * 24);
+      a.g.lineTo(cx, cy);
+      hgt.g.lineTo(cx, cy);
+    }
+    a.g.stroke();
+    hgt.g.stroke();
   }
   // polished wheel tracks: darker and much glossier
   for (const cx of [S * 0.26, S * 0.74]) {
@@ -388,6 +537,20 @@ function sidewalkSurface() {
     a.g.fillStyle = `rgba(${(168 * l) | 0},${(166 * l) | 0},${(158 * l) | 0},0.45)`;
     a.g.fillRect(r() * S, r() * S, 1 + r() * 3, 1 + r() * 3);
   }
+  // Large-scale staining, several times the tile period, so the eye stops
+  // locking onto the 1 m slab grid repeating to the horizon.
+  for (let i = 0; i < 14; i++) {
+    const bx = r() * S, by = r() * S, br = 40 + r() * 90;
+    const sg = a.g.createRadialGradient(bx, by, 0, bx, by, br);
+    const dark = r() > 0.5;
+    sg.addColorStop(0, dark ? 'rgba(96,94,88,0.20)' : 'rgba(206,203,194,0.18)');
+    sg.addColorStop(1, 'rgba(0,0,0,0)');
+    a.g.fillStyle = sg;
+    a.g.beginPath();
+    a.g.ellipse(bx, by, br, br * (0.6 + r() * 0.6), r() * 3.14, 0, Math.PI * 2);
+    a.g.fill();
+  }
+
   // expansion joints
   for (let i = 0; i <= S; i += 64) {
     a.g.fillStyle = 'rgba(0,0,0,0.22)';
@@ -481,18 +644,31 @@ function skyEquirect() {
   g.fillRect(0, 0, W, H);
 
   // Broken overcast: soft banks, flattened and denser toward the horizon.
+  //
+  // These used to be 390 ellipses squashed to about a fifteenth of their width
+  // at 3-11 % alpha. Individually invisible, they stacked into continuous
+  // horizontal streaks right across the equirect -- which reads in-game as a
+  // banded, combed sky and was twice diagnosed as a dither or precision bug in
+  // the post chain. It was never post. Fewer, larger, rounder banks with real
+  // gaps between them, and enough alpha each to be a cloud rather than a wash.
   const r = mulberry32(83);
   for (let layer = 0; layer < 3; layer++) {
-    const count = 120 + layer * 90;
+    const count = 46 + layer * 30;
     for (let i = 0; i < count; i++) {
-      const y = 40 + Math.pow(r(), 0.6) * (H * 0.46);
+      // Keep out of the zenith. Equirect x spans a full 360 deg at every
+      // latitude, so a bank drawn near y=0 is stretched across an enormous arc
+      // and renders as a grey swirl rather than a cloud. From about 25 deg
+      // down to the horizon is the band a player actually looks at anyway.
+      const y = H * 0.17 + Math.pow(r(), 0.75) * (H * 0.30);
       const x = r() * W;
-      const squash = 0.12 + (y / H) * 0.5;
-      const w = (90 + r() * 340) * (1 + layer * 0.4);
-      const h = w * squash * (0.2 + r() * 0.35);
+      // Perspective still flattens a bank toward the horizon, but the floor is
+      // high enough that the shape stays a cloud and not a line.
+      const squash = 0.46 + (y / H) * 0.5;
+      const w = (110 + r() * 260) * (1 + layer * 0.35);
+      const h = w * squash * (0.34 + r() * 0.3);
       const near = 1 - Math.abs(y - sy) / 900;
-      const bright = 0.72 + Math.max(0, near) * 0.28;
-      const alpha = 0.035 + r() * 0.075;
+      const bright = 0.88 + Math.max(0, near) * 0.12;
+      const alpha = 0.07 + r() * 0.11;
       const cg = g.createRadialGradient(x, y, 0, x, y, w);
       const t = Math.round(255 * bright);
       cg.addColorStop(0, `rgba(${t},${t},${Math.round(t * 0.99)},${alpha})`);
@@ -503,7 +679,7 @@ function skyEquirect() {
       g.ellipse(x, y, w, h, 0, 0, Math.PI * 2);
       g.fill();
       // undersides
-      g.fillStyle = `rgba(96,110,124,${alpha * 0.5})`;
+      g.fillStyle = `rgba(138,150,162,${alpha * 0.42})`;
       g.beginPath();
       g.ellipse(x, y + h * 0.55, w * 0.8, h * 0.4, 0, 0, Math.PI * 2);
       g.fill();
@@ -534,10 +710,97 @@ function particleTexture() {
   return tex(c, { repeat: false, aniso: 1, mips: false });
 }
 
+
+/**
+ * Signage atlas: a 4 x 4 grid of shopfront fascia plates.
+ *
+ * There was not one sign anywhere in the city, which is the single loudest
+ * difference between this and an open world of the era -- a real street is
+ * something like a third signage by visual weight. One texture with sixteen
+ * designs lets every shopfront in the map pick a different one through its UVs
+ * and still cost a single draw call for the whole chunk.
+ *
+ * Wordmarks are blocks, not glyphs. At the distance a fascia is ever read the
+ * eye is resolving the rhythm of a word, not its letters, and blocks mip
+ * cleanly where real type turns to mush.
+ */
+function signSurface() {
+  const S = 512, N = 4, C = S / N;
+  const a = canvas(S, S), emi = canvas(S, S), rgh = canvas(S, S);
+  const r = mulberry32(313);
+  a.g.fillStyle = '#1a1c1f'; a.g.fillRect(0, 0, S, S);
+  emi.g.fillStyle = '#000'; emi.g.fillRect(0, 0, S, S);
+  rgh.g.fillStyle = grey(0.6); rgh.g.fillRect(0, 0, S, S);
+
+  // Plate colours a high street actually uses: saturated but not primary.
+  const PLATES = [
+    ['#1f3f6b', '#eef2f6'], ['#7a1f22', '#f2e6d2'], ['#1d4a35', '#f0efe6'],
+    ['#e8e4d8', '#23282e'], ['#2b2f36', '#e6c568'], ['#8a4a12', '#f6efe0'],
+    ['#4a2a5c', '#efe6f4'], ['#0f5566', '#e8f4f2'],
+  ];
+  for (let cy = 0; cy < N; cy++) {
+    for (let cx = 0; cx < N; cx++) {
+      const ox = cx * C, oy = cy * C;
+      const [bg, fg] = PLATES[(cy * N + cx) % PLATES.length];
+      a.g.fillStyle = bg;
+      a.g.fillRect(ox, oy, C, C);
+      // A frame, so the plate has an edge instead of bleeding into the wall.
+      a.g.strokeStyle = 'rgba(0,0,0,0.45)';
+      a.g.lineWidth = 3;
+      a.g.strokeRect(ox + 1.5, oy + 1.5, C - 3, C - 3);
+
+      // Wordmark: one or two words of block "letters" on the middle band.
+      const lit = r() > 0.78;          // a fifth of them are illuminated
+      const words = 1 + (r() > 0.55 ? 1 : 0);
+      const bandY = oy + C * (words === 1 ? 0.40 : 0.30);
+      let wy = bandY;
+      for (let w = 0; w < words; w++) {
+        const gh = C * (words === 1 ? 0.2 : 0.16);
+        const nGlyph = 3 + Math.floor(r() * 5);
+        const gw = C * 0.06 + r() * C * 0.02;
+        const gap = gw * 0.36;
+        const total = nGlyph * gw + (nGlyph - 1) * gap;
+        let gx = ox + (C - total) / 2;
+        for (let g = 0; g < nGlyph; g++) {
+          const hh = gh * (0.72 + r() * 0.28);
+          a.g.fillStyle = fg;
+          a.g.fillRect(gx, wy + (gh - hh), gw, hh);
+          if (lit) { emi.g.fillStyle = fg; emi.g.fillRect(gx, wy + (gh - hh), gw, hh); }
+          gx += gw + gap;
+        }
+        wy += gh * 1.5;
+      }
+      if (lit) {
+        // A lit plate glows a little all over, not only in the letters.
+        emi.g.fillStyle = 'rgba(80,70,50,1)';
+        emi.g.fillRect(ox + 4, oy + 4, C - 8, C - 8);
+        rgh.g.fillStyle = grey(0.3);
+        rgh.g.fillRect(ox, oy, C, C);
+      }
+      // Grime along the bottom lip, where every fascia collects it.
+      const gg = a.g.createLinearGradient(ox, oy + C * 0.7, ox, oy + C);
+      gg.addColorStop(0, 'rgba(0,0,0,0)');
+      gg.addColorStop(1, 'rgba(0,0,0,0.32)');
+      a.g.fillStyle = gg;
+      a.g.fillRect(ox, oy + C * 0.7, C, C * 0.3);
+    }
+  }
+  noise(a.g, S, S, 7, 5);
+  return { map: tex(a.c), emissiveMap: tex(emi.c), roughnessMap: tex(rgh.c, { srgb: false }) };
+}
+
 export function buildTextures() {
   return {
     glass: glassSurface(),
+    signs: signSurface(),
     masonry: masonrySurface(),
+    // Brick is its own texture, not a tint of the stone one. 11 px courses over
+    // a 12 m tile is a ~26 cm brick -- coarser than life, because at 512 px a
+    // true 7 cm course is sub-texel and mips straight to flat grey.
+    brick: masonrySurface({
+      base: '#a89a90', mortar: '#c9c2b4', course: 11, seedN: 47,
+      surround: '#cfc9bc', sill: '#d6d1c6',
+    }),
     industrial: industrialSurface(),
     house: houseSurface(),
     road: roadSurface(),

--- a/apps/auto/src/textures.js
+++ b/apps/auto/src/textures.js
@@ -464,7 +464,6 @@ function skyEquirect() {
   grad.addColorStop(1.00, '#5d6469');
   g.fillStyle = grad;
   g.fillRect(0, 0, W, H);
-
   // Sun: placed to match the key light direction so speculars line up.
   const sx = 207, sy = 221;
   const halo = g.createRadialGradient(sx, sy, 0, sx, sy, 460);

--- a/apps/auto/src/traffic.js
+++ b/apps/auto/src/traffic.js
@@ -10,6 +10,25 @@ const PARKED_RADIUS = 130;
 const DESPAWN = 520;
 
 export function collideWithBuildings(v, city, onHit) {
+  // Street objects first: a tree or a lamp post is closer than the building
+  // line and is what you actually hit coming off a kerb. Until this existed
+  // the only solid thing in the entire map was a building, so every tree in
+  // Seattle was scenery you drove straight through.
+  //
+  // Softer than a wall: a mast shears and a trunk gives, so the car is pushed
+  // out and loses most of its speed rather than stopping dead against it.
+  const ob = city.obstacleHit(v.x, v.z, v.radius * 0.7);
+  if (ob) {
+    v.x += ob.nx * ob.pen;
+    v.z += ob.nz * ob.pen;
+    const f = v.forward;
+    const along = f.x * ob.nx + f.z * ob.nz;
+    const impact = Math.abs(v.vLong) * Math.abs(along) * 0.7 + Math.abs(v.vLat) * 0.3;
+    v.vLong *= along > 0 ? -0.1 : 0.2;
+    v.vLat *= 0.3;
+    if (onHit && impact > 3) onHit(impact);
+    return impact;
+  }
   const near = city.buildingsNear(v.x, v.z, 14);
   for (const b of near) {
     const c = Math.cos(-b.rot), s = Math.sin(-b.rot);
@@ -93,12 +112,17 @@ export class TrafficSystem {
       const slots = Math.floor(e.len / 13);
       for (let s = 1; s < slots; s++) {
         const h = hash2(ei * 31 + s, 7);
-        if (h > 0.32) continue;
+        // Kerbside occupancy. 0.32 across BOTH sides is about one car in six
+        // per kerb, which reads as a street where nobody lives. Parked cars do
+        // more for a populated city than any amount of shader work, and they
+        // share geometry and two of their three materials across every
+        // instance, so the cost is draw calls rather than memory.
+        if (h > 0.48) continue;
         const key = ei * 64 + s;
         seen.add(key);
         if (this.parkedSlots.has(key)) continue;
         const t = s / slots;
-        const side = h < 0.21 ? 1 : -1;
+        const side = h < 0.24 ? 1 : -1;
         const off = e.hw - 1.15;
         const x = lerp(a.x, b.x, t) - e.dz * off * side;
         const z = lerp(a.z, b.z, t) + e.dx * off * side;

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -169,15 +169,26 @@ export class World {
     };
 
     this.mats = {
-      road: surf(tx.road, { env: 0.45, ns: 0.7 }),
-      walk: surf(tx.sidewalk, { env: 0.42, ns: 0.8 }),
-      glass: surf(tx.glass, { env: 1.05, metalness: 0.22, ns: 1.1, emissive: 0.02 }),
-      masonry: surf(tx.masonry, { env: 0.5, ns: 1.0, emissive: 0.015 }),
-      industrial: surf(tx.industrial, { env: 0.5, metalness: 0.25, ns: 1.0 }),
-      house: surf(tx.house, { env: 0.45, ns: 1.0, emissive: 0.015 }),
+      road: surf(tx.road, { env: 0.62, ns: 0.9 }),
+      walk: surf(tx.sidewalk, { env: 0.52, ns: 0.8 }),
+      glass: surf(tx.glass, { env: 1.9, metalness: 0.34, roughness: 0.22, ns: 1.1, emissive: 0.02 }),
+      masonry: surf(tx.masonry, { env: 0.66, ns: 1.5, emissive: 0.015 }),
+      brick: surf(tx.brick, { env: 0.60, ns: 1.5, emissive: 0.015 }),
+      // Signage. Emissive is high because a fifth of the atlas cells are lit
+      // plates and the rest have a black emissive, so the intensity only ever
+      // applies to the ones meant to glow.
+      signs: surf(tx.signs, { env: 0.5, roughness: 0.62, emissive: 1.5 }),
+      industrial: surf(tx.industrial, { env: 0.5, metalness: 0.25, ns: 1.7 }),
+      house: surf(tx.house, { env: 0.45, ns: 1.8, emissive: 0.015 }),
       flat: new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.82, metalness: 0.04, envMapIntensity: 0.45 }),
       glow: new THREE.MeshBasicMaterial({ vertexColors: true, toneMapped: false }),
-      far: new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.85, metalness: 0.05, envMapIntensity: 0.5 }),
+      // The far skyline is a silhouette mesh: what matters is that a mass two
+      // kilometres out sits at a believable fraction of sky luminance, not
+      // that its shaded side has readable detail. At 0.5 its away-from-sun
+      // faces fell to about 4 % of the sky and downtown read as a row of black
+      // cutouts pasted over the horizon -- which looks like a broken renderer,
+      // not like distance.
+      far: new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.9, metalness: 0.02, envMapIntensity: 0.85 }),
     };
     this.group = new THREE.Group();
     scene.add(this.group);
@@ -274,8 +285,20 @@ export class World {
                 GRASS[2] + (built[2] - GRASS[2]) * t,
               ];
             }
+            // Two grass tones, in patches.
+            //
+            // Per-vertex hash noise alone is high-frequency speckle: at 40 m
+            // spacing it varies faster than the eye groups it, so a park read
+            // as one flat saturated carpet however much jitter was on it. A
+            // smooth low-frequency field on top gives patches you can actually
+            // see -- lush against dry, which is what a real park looks like
+            // from any distance.
+            const patch = vnoise(x * 0.35 + 811, z * 0.35 - 553);
+            const dry = (patch - 0.42) * 0.55;
             const n = hash2(gi, gj) * 0.14 + 0.93;
-            col[k] = c[0] * n; col[k + 1] = c[1] * n; col[k + 2] = c[2] * n;
+            col[k] = c[0] * n * (1 + dry * 0.34);
+            col[k + 1] = c[1] * n * (1 - dry * 0.16);
+            col[k + 2] = c[2] * n * (1 - dry * 0.30);
           }
         }
         const idx = [];
@@ -309,8 +332,19 @@ export class World {
       // Roughness up and normal amplitude down: at 0.09 every wavelet past a
       // couple of hundred metres aliased into one blown white specular sheet
       // along the horizon.
-      color: 0x2a4658, normalMap: n, roughness: 0.22, metalness: 0.2,
-      envMapIntensity: 1.0, normalScale: new THREE.Vector2(0.28, 0.28),
+      // 0.22 killed the blown horizon sheet but also every highlight, leaving a
+      // dead black sheet. 0.15 keeps a sun lobe; the tiling weave is broken by
+      // scrolling two copies of the normal map at different rates below.
+      // Water is a DIELECTRIC, and its Fresnel is the whole look. At
+      // metalness 0.22 the surface was mostly a dark diffuse body colour with
+      // a weak reflection on top, so near water sat at about a fifth of the
+      // sky's luminance while far water was carried entirely by fog -- the
+      // same lake reading 34 close in and 151 out at the horizon. Dropping
+      // metalness to near zero gives F0 = 0.04 with a real grazing-angle
+      // ramp, which is what puts the sky into the water and produces the
+      // shore-to-horizon gradient without a reflection pass.
+      color: 0x33556e, normalMap: n, roughness: 0.10, metalness: 0.02,
+      envMapIntensity: 1.4, normalScale: new THREE.Vector2(0.36, 0.36),
     });
     const m = new THREE.Mesh(geo, mat);
     m.position.y = 0;
@@ -345,10 +379,40 @@ export class World {
       if (bd.h < 30) continue;
       const v = 0.86 + hash2(bd.seed, 17) * 0.26;
       const col = bd.style === 'tower'
-        ? [0.5 * v, 0.54 * v, 0.58 * v]
-        : [0.56 * v, 0.52 * v, 0.46 * v];
+        ? [0.54 * v, 0.58 * v, 0.63 * v]
+        : [0.60 * v, 0.56 * v, 0.51 * v];
       const s = 0.985;
-      b.box(bd.x, bd.y - 2, bd.z, bd.w * s, bd.h + 2, bd.d * s, bd.rot, col, { top: true, ao: 0.3 });
+      // A tower is read almost entirely by its top. Extruded to full height
+      // and capped flat, every building in the skyline is the same rectangle
+      // with a different length -- the reason the downtown silhouette scored
+      // worst of anything in the frame. Anything tall enough to stand out of
+      // the mass gets its shaft stopped short and a crown built on top: a
+      // setback, a mechanical penthouse, and sometimes a mast.
+      //
+      // This is the far mesh, so it is silhouette only -- four boxes at most,
+      // and only for the few hundred buildings over 45 m.
+      const crown = bd.h > 45;
+      const shaftH = crown ? bd.h * (0.80 + hash2(bd.seed, 23) * 0.10) : bd.h;
+      b.box(bd.x, bd.y - 2, bd.z, bd.w * s, shaftH + 2, bd.d * s, bd.rot, col, { top: true, ao: 0.3 });
+      if (!crown) continue;
+      const dk = [col[0] * 0.86, col[1] * 0.88, col[2] * 0.92];
+      let cy = bd.y - 2 + shaftH + 2;
+      let cw = bd.w * s, cd = bd.d * s;
+      const style = hash2(bd.seed, 29);
+      const setbacks = style < 0.4 ? 1 : style < 0.8 ? 2 : 3;
+      const rest = bd.h - shaftH;
+      for (let t = 0; t < setbacks; t++) {
+        const th = rest / setbacks;
+        cw *= 0.78; cd *= 0.78;
+        b.box(bd.x, cy, bd.z, cw, th, cd, bd.rot, t % 2 ? col : dk, { top: true, ao: 0 });
+        cy += th;
+      }
+      // Mechanical penthouse: the boxy plant room every real tower carries.
+      b.box(bd.x, cy, bd.z, cw * 0.62, 3.5 + hash2(bd.seed, 31) * 3, cd * 0.62, bd.rot, dk, { top: true });
+      if (bd.h > 80 && hash2(bd.seed, 37) > 0.45) {
+        const mh = 8 + hash2(bd.seed, 41) * 22;
+        b.box(bd.x, cy + 3.5, bd.z, 1.1, mh, 1.1, bd.rot, dk, { top: true });
+      }
     }
     const m = new THREE.Mesh(b.build(), this.mats.far);
     m.frustumCulled = false;
@@ -358,8 +422,13 @@ export class World {
 
   animate(dt, t) {
     if (this.waterNormal) {
-      this.waterNormal.offset.x = (t * 0.004) % 1;
-      this.waterNormal.offset.y = (t * 0.0026) % 1;
+      // Scroll BOTH axes at incommensurate rates. Scrolling x alone slides the
+      // tile along one screen direction and the repeat reads as a fixed diagonal
+      // weave across the open water. MeshStandardMaterial takes a single normal
+      // map, so two summed layers would need a custom shader; two irrational-ish
+      // rates on one map breaks the pattern for nothing.
+      this.waterNormal.offset.x = (t * 0.0040) % 1;
+      this.waterNormal.offset.y = (t * 0.0017) % 1;
     }
   }
 
@@ -403,6 +472,9 @@ export class World {
   }
 
   disposeChunk(c) {
+    // Solid street objects belong to the chunk that drew them, so they go when
+    // it does. Leaving them behind means invisible trees you keep hitting.
+    this.city.clearObstacles(this.city.chunkKey(c.cx, c.cz));
     if (!c.group) return;
     c.group.traverse((o) => {
       if (o.geometry) o.geometry.dispose();
@@ -414,14 +486,18 @@ export class World {
 
   buildChunk(cx, cz, lod) {
     const city = this.city;
-    const ch = city.chunks.get(city.chunkKey(cx, cz));
+    const ck = city.chunkKey(cx, cz);
+    const ch = city.chunks.get(ck);
     if (!ch) return null;
+    city.clearObstacles(ck);
+    this._ck = ck;
     const road = new Builder(true);
     const walk = new Builder(true);
     const flat = new Builder(false);
     const glow = new Builder(false);
     const bl = {
-      glass: new Builder(true), masonry: new Builder(true),
+      glass: new Builder(true), masonry: new Builder(true), brick: new Builder(true),
+      signs: new Builder(true),
       industrial: new Builder(true), house: new Builder(true),
     };
 
@@ -462,6 +538,8 @@ export class World {
     add(glow, this.mats.glow, false, false);
     add(bl.glass, this.mats.glass, true, true);
     add(bl.masonry, this.mats.masonry, true, true);
+    add(bl.brick, this.mats.brick, true, true);
+    add(bl.signs, this.mats.signs, true, false);
     add(bl.industrial, this.mats.industrial, true, true);
     add(bl.house, this.mats.house, true, true);
     return grp.children.length ? grp : null;
@@ -721,7 +799,28 @@ export class World {
     // Queen Anne that put terrain up to 1.39 m above the asphalt, which is the
     // grass growing over the road. The heightfield is 40 m, so cells of roughly
     // 8 m follow it closely without paying for detail that isn't there.
-    const across = Math.max(1, Math.round((hw * 2) / 8));
+    //
+    // Cells are also what carries the cross-section shading below, and a road
+    // shaded from its four corners has no cross-section at all, so anything
+    // over about three lanes gets at least three cells. Three is the cheapest
+    // count that can put a bright band down the middle and grime at both kerbs;
+    // four looked no better and cost 40 % more road triangles.
+    const across = Math.max(hw > 4.5 ? 3 : 1, Math.round((hw * 2) / 8));
+    /**
+     * Traffic polishes the middle of a carriageway and grime collects at its
+     * edges. Without it the asphalt is one flat value from kerb to kerb --
+     * which is exactly what made the largest surface in every street-level
+     * frame read as a hole in the image rather than as a road.
+     *
+     * `f` is the distance from the centreline as a fraction of the half-width.
+     */
+    const wear = (o) => {
+      const f = Math.min(1, Math.abs(o) / Math.max(hw, 0.01));
+      const polish = 1 + 0.12 * (1 - f * f);        // worn smooth down the middle
+      const edge = 1 - 0.30 * Math.max(0, f - 0.55) / 0.45;  // grime at the kerb
+      const k = polish * edge;
+      return [col[0] * k, col[1] * k, col[2] * k];
+    };
     for (let s = 0; s < steps; s++) {
       const t0 = s / steps, t1 = (s + 1) / steps;
       const seg = e.len / steps;
@@ -747,7 +846,8 @@ export class World {
           [bx, yAt(bx, bz), bz],
           [cx, yAt(cx, cz), cz],
           [dx, yAt(dx, dz), dz],
-          [0, 1, 0], [u0, v0, u1, v0, u1, v1, u0, v1], col
+          [0, 1, 0], [u0, v0, u1, v0, u1, v1, u0, v1],
+          [wear(o0), wear(o1), wear(o1), wear(o0)]
         );
       }
     }
@@ -810,10 +910,37 @@ export class World {
           const q = sg > 0
             ? [[i0x, y(i0x, i0z), i0z], [o0x, y(o0x, o0z), o0z], [o1x, y(o1x, o1z), o1z], [i1x, y(i1x, i1z), i1z]]
             : [[o0x, y(o0x, o0z), o0z], [i0x, y(i0x, i0z), i0z], [i1x, y(i1x, i1z), i1z], [o1x, y(o1x, o1z), o1z]];
-          walk.quad(q[0], q[1], q[2], q[3], [0, 1, 0], [0, v0, 1, v0, 1, v1, 0, v1], [1, 1, 1]);
+          // Per-piece value jitter, plus a darker inner edge against the
+          // building line. Every slab drawn at exactly 1.0 left a perfect
+          // lattice of identical slabs running to the horizon; the texture's
+          // own staining can only break the tile, not the repeat of the tile.
+          const wj = 0.9 + hash2(Math.round(x0 * 0.7), Math.round(z0 * 0.7)) * 0.2;
+          const wIn = [wj, wj, wj];
+          const wOut = [wj * 0.9, wj * 0.9, wj * 0.91];
+          const wc = sg > 0 ? [wIn, wOut, wOut, wIn] : [wOut, wIn, wIn, wOut];
+          walk.quad(q[0], q[1], q[2], q[3], [0, 1, 0], [0, v0, 1, v0, 1, v1, 0, v1], wc);
           const cy0 = G.terrainHeight(i0x, i0z), cy1 = G.terrainHeight(i1x, i1z);
           const cc = [0.72, 0.72, 0.7];
           const ccLo = [0.4, 0.4, 0.39];
+          // Gutter. Road met pavement on a mathematically clean seam, which is
+          // the single loudest "this is a textured plane, not a street" tell --
+          // every real kerb has a strip of accumulated grime against it. Drawn
+          // here rather than in the road loop so it stays registered with the
+          // kerb face by construction, on the same lift the lane markings use.
+          const gW = 0.5;
+          const gv0 = (t0 * e.len) / ROAD_TILE, gv1 = (t1 * e.len) / ROAD_TILE;
+          const gy0 = cy0 + MARK_Y + bias, gy1 = cy1 + MARK_Y + bias;
+          const j0x = i0x - ox * gW, j0z = i0z - oz * gW;
+          const j1x = i1x - ox * gW, j1z = i1z - oz * gW;
+          const gDark = [0.44, 0.45, 0.46];
+          const gLite = [0.92, 0.93, 0.93];
+          road.quad(
+            [i0x, gy0, i0z], [j0x, G.terrainHeight(j0x, j0z) + MARK_Y + bias, j0z],
+            [j1x, G.terrainHeight(j1x, j1z) + MARK_Y + bias, j1z], [i1x, gy1, i1z],
+            [0, 1, 0],
+            [0, gv0, gW / ROAD_TILE, gv0, gW / ROAD_TILE, gv1, 0, gv1],
+            [gDark, gLite, gLite, gDark]
+          );
           if (sg > 0) {
             flat.quad([i0x, cy0 + ROAD_Y, i0z], [i1x, cy1 + ROAD_Y, i1z],
               [i1x, cy1 + WALK_Y, i1z], [i0x, cy0 + WALK_Y, i0z], [-ox, 0, -oz],
@@ -865,7 +992,7 @@ export class World {
     // Eaves corners
     const c00 = P(-hw, -hd, y0), c10 = P(hw, -hd, y0);
     const c11 = P(hw, hd, y0), c01 = P(-hw, hd, y0);
-    const dark = [col[0] * 0.82, col[1] * 0.82, col[2] * 0.84];
+    const dark = [col[0] * 0.62, col[1] * 0.62, col[2] * 0.66];
     if (alongX) {
       flat.quad(c00, c10, Bp, A, [0, 0.72, -0.7], ZERO_UV, col);      // slope -z
       flat.quad(c11, c01, A, Bp, [0, 0.72, 0.7], ZERO_UV, dark);      // slope +z
@@ -1013,15 +1140,22 @@ export class World {
     // Taller and newer skews to glass and dark curtain wall; low and old skews
     // to brick and stucco, which is roughly how a city stratifies by era.
     const modern = clamp((bd.h - 18) / 55, 0, 1);
+    // A named palette, not a jitter. Every family carries its own hue AND its
+    // own material, so a street reads as a mix of buildings put up in different
+    // decades out of different stuff -- which is the thing a tint of one shared
+    // texture cannot express however far you push it.
     const FAMS = [
-      { m: 'masonry', c: [0.74, 0.73, 0.70], u: 14, v: 13.6 },   // concrete
+      { m: 'masonry', c: [0.76, 0.75, 0.72], u: 14, v: 13.6 },   // grey concrete
       { m: 'glass', c: [0.78, 0.86, 0.92], u: 14, v: 13.6 },     // curtain wall
-      { m: 'masonry', c: [0.72, 0.46, 0.38], u: 12, v: 12 },     // red brick
-      { m: 'masonry', c: [0.86, 0.82, 0.74], u: 13, v: 13 },     // painted stucco
-      { m: 'glass', c: [0.42, 0.46, 0.50], u: 14, v: 13.6 },     // dark modern
+      { m: 'brick', c: [0.80, 0.38, 0.28], u: 12, v: 12 },       // red brick
+      { m: 'brick', c: [0.86, 0.72, 0.46], u: 12, v: 12 },       // buff brick
+      { m: 'masonry', c: [0.92, 0.90, 0.84], u: 13, v: 13 },     // painted white
+      { m: 'brick', c: [0.74, 0.44, 0.34], u: 12, v: 12 },       // terracotta
+      { m: 'masonry', c: [0.52, 0.62, 0.58], u: 13, v: 13 },     // painted-over green
+      { m: 'glass', c: [0.56, 0.60, 0.64], u: 14, v: 13.6 },     // dark modern
     ];
-    const wOld = [0.30, 0.06, 0.34, 0.26, 0.04];
-    const wNew = [0.26, 0.34, 0.10, 0.08, 0.22];
+    const wOld = [0.20, 0.04, 0.26, 0.16, 0.16, 0.10, 0.05, 0.03];
+    const wNew = [0.22, 0.30, 0.08, 0.06, 0.08, 0.04, 0.02, 0.20];
     let acc = 0;
     for (let i = 0; i < FAMS.length; i++) {
       acc += wOld[i] + (wNew[i] - wOld[i]) * modern;
@@ -1037,11 +1171,15 @@ export class World {
       || bd.style === 'brick' || bd.style === 'lowrise')
       ? this.buildingFamily(bd) : null;
     if (fam) {
-      target = fam.m === 'glass' ? bl.glass : bl.masonry;
+      target = fam.m === 'glass' ? bl.glass : fam.m === 'brick' ? bl.brick : bl.masonry;
       // Jitter stays INSIDE the family, so a brick street varies in weathering
       // rather than becoming a different material every other lot.
       col = tint(seed, fam.c, 0.26);
-      uS = fam.u; vS = fam.v;
+      uS = fam.u;
+      // Snap the vertical repeat so a whole number of tiles spans the wall.
+      // Each tile is four window rows; at an arbitrary vScale the top row is
+      // sliced through by the parapet on every building in the city.
+      vS = bd.h / Math.max(1, Math.round(bd.h / fam.v));
     } else if (bd.style === 'industrial') {
       target = bl.industrial; col = tint(seed, [0.84, 0.86, 0.86], 0.3); uS = 16; vS = 16;
     } else {
@@ -1057,8 +1195,12 @@ export class World {
     if (bd.style === 'house') {
       const wallH = bd.h * 0.72;
       target.box(bd.x, base, bd.z, bd.w, wallH + 2, bd.d, bd.rot, col, { top: false, uScale: 0, vScale: 0, ao: 0.3 });
-      const rc = tint(seed, [0.36, 0.31, 0.29], 0.14);
-      flat.box(bd.x, base + wallH + 2, bd.z, bd.w + 0.7, 0.26, bd.d + 0.7, bd.rot, rc);
+      // Roofs were a flat near-black polygon that can fill a third of a frame
+      // with no material at all. Route them through the industrial builder so
+      // they take a texture, and lift them off black.
+      const rc = tint(seed, [0.46, 0.43, 0.41], 0.16);
+      bl.industrial.box(bd.x, base + wallH + 2, bd.z, bd.w + 0.7, 0.26, bd.d + 0.7, bd.rot, rc,
+        { uScale: 5, vScale: 5 });
       // A gable that fits the house it sits on.
       //
       // This used to be `cone(..., max(w, d) * 0.74, ..., 4, ...)` -- a square
@@ -1067,6 +1209,9 @@ export class World {
       // bd.rot. On a 6 x 14 m house that is a 10 m roof, square, at the wrong
       // angle: the overhang misses the walls entirely on the narrow axis, which
       // is why roofs looked detached and randomly oriented.
+      // Gable stays on `flat`: Builder.tri takes no UVs, so a textured builder
+      // would sample one texel across the whole slope. Its believability comes
+      // from the two slopes shading differently against the key light instead.
       this.meshGable(flat, bd, base + wallH + 2.26, rc, seed);
       const [sx, sz] = off(0, bd.d / 2 + 0.5);
       flat.box(sx, base + 1.6, sz, 2.0, 0.22, 1.2, bd.rot, [0.62, 0.6, 0.57]);
@@ -1082,7 +1227,12 @@ export class World {
       // Roofs vary per building. One flat grey across a whole downtown reads
       // as untextured cap geometry from every elevated view, which is the
       // angle roofs are actually seen from.
-      const rv = 0.30 + hash2(seed, 91) * 0.22;
+      // Tar-and-gravel is about 0.22 albedo, not 0.05, and a roof is the
+      // largest surface in any elevated view. At the old values the whole
+      // near-field went near-black from above while the fogged far skyline
+      // stayed bright, so the city read inside-out: the closest thing in the
+      // frame was the darkest. Roofs are a light-to-mid grey with real spread.
+      const rv = 0.42 + hash2(seed, 91) * 0.16;
       const rc2 = [rv, rv * 1.01, rv * 1.05];
       const n = 1 + Math.floor(hash2(seed, 51) * 3);
       for (let i = 0; i < n; i++) {
@@ -1093,9 +1243,40 @@ export class World {
         const bh2 = 0.9 + hash2(seed, 81 + i) * 1.5;
         flat.box(gx, rt, gz, bw2, bh2, bw2 * 0.8, bd.rot, rc2);
       }
+      // Roof kit. A correctly-exposed roof is still a blank lid, and roofs are
+      // in shot from every elevated view in the game. A stair bulkhead, a vent
+      // cluster and a tank are what a real roof carries, and they cost a
+      // handful of boxes that merge into the chunk's existing flat mesh.
+      const dk = [rv * 0.74, rv * 0.75, rv * 0.78];
+      if (bd.w > 13 && bd.d > 13) {
+        // stair bulkhead -- the one thing on a roof with a door in it
+        const [sx2, sz2] = off(bd.w * 0.24, -bd.d * 0.22);
+        flat.box(sx2, rt, sz2, 3.0, 2.6, 2.4, bd.rot, dk);
+        flat.box(sx2, rt + 2.6, sz2, 3.3, 0.2, 2.7, bd.rot, rc2);
+      }
+      // vent stacks
+      const vn = 2 + Math.floor(hash2(seed, 93) * 3);
+      for (let i = 0; i < vn; i++) {
+        const [vx, vz] = off((hash2(seed, 94 + i) - 0.5) * (bd.w - 3),
+          (hash2(seed, 97 + i) - 0.5) * (bd.d - 3));
+        flat.prism(vx, rt, vz, 0.16, 0.7 + hash2(seed, 99 + i) * 0.8, 6, dk);
+      }
+      // water tank, on a minority of mid-rises
+      if (bd.h > 16 && hash2(seed, 88) > 0.82) {
+        const [tx2, tz2] = off(-bd.w * 0.2, bd.d * 0.18);
+        for (const lg of [[-1, -1], [1, -1], [-1, 1], [1, 1]]) {
+          flat.box(tx2 + lg[0] * 1.1, rt, tz2 + lg[1] * 1.1, 0.18, 1.8, 0.18, bd.rot, dk);
+        }
+        flat.prism(tx2, rt + 1.8, tz2, 1.5, 2.4, 8, [0.42, 0.34, 0.27]);
+        flat.cone(tx2, rt + 4.2, tz2, 1.55, 0.7, 8, [0.36, 0.29, 0.23]);
+      }
       // parapet lip, so the roof edge has a silhouette rather than a clean cut
       flat.box(bd.x, rt, bd.z, bd.w + 0.5, 0.85, bd.d + 0.5, bd.rot,
-        [rv * 1.25, rv * 1.25, rv * 1.22]);
+        [rv * 1.2, rv * 1.2, rv * 1.17]);
+      // The lid itself, on a textured builder. A roof is seen from every
+      // elevated view in the game and it was one flat untextured colour.
+      bl.industrial.box(bd.x, rt - 0.12, bd.z, bd.w + 0.2, 0.14, bd.d + 0.2, bd.rot,
+        [rv * 0.92, rv * 0.93, rv * 0.96], { uScale: 7, vScale: 7 });
     }
 
     const dense = bd.style !== 'industrial';
@@ -1104,16 +1285,29 @@ export class World {
     let remaining = bd.h + 2;
 
     if (plinthH > 2) {
-      // ground-floor storefront: darker glazing under a cornice
-      const sc = [col[0] * 0.5, col[1] * 0.54, col[2] * 0.6];
+      // Ground-floor storefront.
+      //
+      // This is the most-looked-at surface in the game -- it wraps every
+      // commercial building at exactly eye level -- and it was the curtain-wall
+      // texture at uScale/vScale 9. The glass tile carries eight panes each
+      // way, so nine metres per tile made them 1.1 m across and a whole storey
+      // tall stack of them fitted in the plinth: every shopfront in the city
+      // read as a band of blue fish scales.
+      //
+      // A shopfront is ONE row of tall panes. Pick the scales so exactly that
+      // lands in the plinth: 8 panes over 18 m is a 2.25 m bay, and a vScale of
+      // 8x the plinth height puts the plinth on row 0 -- full-height glazing
+      // with the spandrel above it, which is what a shopfront is.
+      const sc = [col[0] * 0.74, col[1] * 0.78, col[2] * 0.84];
       bl.glass.box(bd.x, y, bd.z, bd.w + 0.3, plinthH, bd.d + 0.3, bd.rot, sc,
-        { uScale: 9, vScale: 9, top: false, ao: 0.5 });
+        { uScale: 18, vScale: plinthH * 8, top: false, ao: 0.5 });
       flat.box(bd.x, y + plinthH, bd.z, bd.w + 1.0, 0.5, bd.d + 1.0, bd.rot, TRIM);
       if (hash2(seed, 41) > 0.55) {
         const ac = AWNING[Math.floor(hash2(seed, 42) * AWNING.length)];
         const [ax, az] = off(0, bd.d / 2 + 0.9);
         flat.box(ax, y + plinthH - 1.4, az, bd.w * 0.62, 0.22, 1.8, bd.rot, ac);
       }
+      this.meshSigns(bl.signs, flat, bd, y + plinthH, plinthH, seed, off);
       y += plinthH + 0.5;
       remaining -= plinthH + 0.5;
     }
@@ -1215,6 +1409,113 @@ export class World {
     flat.prism(bd.x, y, bd.z, 0.3, 10, 4, [0.4, 0.4, 0.42]);
   }
 
+  /**
+   * Shopfront signage.
+   *
+   * Signs are the largest single thing separating this from an open world of
+   * the era -- there was not one anywhere in the city. Everything here hangs
+   * off the shopfront band the plinth already establishes, so the fascia lands
+   * exactly on top of the glazing on every building without a second set of
+   * measurements to keep in sync.
+   *
+   * UVs index a 4 x 4 atlas cell, so sixteen designs cost one draw call for the
+   * whole chunk. Quads rather than boxes: a fascia is seen from the front and
+   * from below, and the two faces it would gain are two faces of overdraw on
+   * every commercial building in the map.
+   */
+  meshSigns(sg, flat, bd, topY, plinthH, seed, off) {
+    if (bd.w < 6 && bd.d < 6) return;
+    const N = 4, C = 1 / N;
+    const cell = (k) => {
+      const i = Math.floor(hash2(seed, k) * 16);
+      return [(i % N) * C, Math.floor(i / N) * C];
+    };
+    // Everything is expressed in the building's OWN frame and pushed through
+    // `off`, which is the one rotation the rest of this function already
+    // trusts. Writing the face normals out by hand got the sign of the x term
+    // wrong and buried every sign inside its own building on any lot that was
+    // not axis-aligned -- which, with real OSM footprints, is nearly all of
+    // them.
+    const dirOf = (lx, lz) => {
+      const [wx, wz] = off(lx, lz);
+      return [wx - bd.x, 0, wz - bd.z];
+    };
+    const fh = Math.min(1.25, plinthH * 0.3);
+    const faces = [
+      { half: bd.d / 2, span: bd.w, out: [0, 1], along: [1, 0] },
+      { half: bd.w / 2, span: bd.d, out: [1, 0], along: [0, 1] },
+    ];
+    for (let f = 0; f < faces.length; f++) {
+      const fc = faces[f];
+      // Two faces of a corner lot front a street; one of a mid-block lot does.
+      // Signing every face of every building makes the city a retail park.
+      if (f === 1 && hash2(seed, 200) > 0.55) continue;
+      if (fc.span < 5) continue;
+      const [u0, v0] = cell(201 + f * 7);
+      const nrm = dirOf(fc.out[0], fc.out[1]);
+      const halfW = fc.span * 0.38;
+      // Stand a little proud of the plinth, which is itself 0.15 m wider than
+      // the wall, so the plate catches its own edge light.
+      const d = fc.half + 0.24;
+      const pt = (t, yy) => {
+        const [wx, wz] = off(fc.out[0] * d + fc.along[0] * t, fc.out[1] * d + fc.along[1] * t);
+        return [wx, yy, wz];
+      };
+      const yTop = topY - 0.18, yBot = yTop - fh;
+      sg.quad(pt(-halfW, yBot), pt(halfW, yBot), pt(halfW, yTop), pt(-halfW, yTop),
+        nrm, [u0, v0, u0 + C, v0, u0 + C, v0 + C, u0, v0 + C], [1, 1, 1]);
+
+      // Projecting blade sign: hung near one end and read from ALONG the
+      // street rather than across it, which is the whole point of a blade.
+      if (hash2(seed, 210 + f) > 0.62) {
+        const [bu, bv] = cell(220 + f * 3);
+        const bt = halfW * (hash2(seed, 230 + f) > 0.5 ? 0.72 : -0.72);
+        const bladeN = dirOf(fc.along[0], fc.along[1]);
+        const byTop = yTop + 0.4, byBot = byTop - 1.5;
+        const q = (proj, yy) => {
+          const [wx, wz] = off(fc.out[0] * (fc.half + proj) + fc.along[0] * bt,
+            fc.out[1] * (fc.half + proj) + fc.along[1] * bt);
+          return [wx, yy, wz];
+        };
+        sg.quad(q(0.05, byBot), q(1.0, byBot), q(1.0, byTop), q(0.05, byTop),
+          bladeN, [bu, bv, bu + C, bv, bu + C, bv + C, bu, bv + C], [1, 1, 1]);
+      }
+    }
+
+    // Rooftop billboard, on low and mid buildings only: on a tower it sits
+    // 150 m up where nobody reads it, and on a house it is absurd.
+    if (bd.h > 10 && bd.h < 42 && bd.w > 14 && hash2(seed, 240) > 0.72) {
+      const [bu, bv] = cell(241);
+      const bw = Math.min(bd.w * 0.7, 16), bh = bw * 0.42;
+      const yb = bd.y - 2 + bd.h + 3.4;
+      const p0 = off(-bw / 2, bd.d * 0.2), p1 = off(bw / 2, bd.d * 0.2);
+      const nrm = dirOf(0, 1);
+      sg.quad([p0[0], yb, p0[1]], [p1[0], yb, p1[1]],
+        [p1[0], yb + bh, p1[1]], [p0[0], yb + bh, p0[1]],
+        nrm, [bu, bv, bu + C, bv, bu + C, bv + C, bu, bv + C], [1, 1, 1]);
+      // Legs, so it stands on the roof instead of floating over it.
+      for (const lt of [-bw * 0.34, bw * 0.34]) {
+        const [lx, lz] = off(lt, bd.d * 0.2);
+        flat.box(lx, yb - 3.4, lz, 0.22, 3.4, 0.22, bd.rot, [0.25, 0.26, 0.28]);
+      }
+    }
+  }
+
+  /**
+   * Is this point inside a building footprint? Shared by every scatter, since
+   * "the data says this is open ground" and "there is nothing standing here"
+   * are different questions and only the second one matters to a prop.
+   */
+  inBuilding(x, z, pad) {
+    for (const b of this.city.buildingsNear(x, z, 30)) {
+      const c = Math.cos(-b.rot), s = Math.sin(-b.rot);
+      const dx = x - b.x, dz = z - b.z;
+      const lx = dx * c - dz * s, lz = dx * s + dz * c;
+      if (Math.abs(lx) < b.w / 2 + pad && Math.abs(lz) < b.d / 2 + pad) return true;
+    }
+    return false;
+  }
+
   // --- street furniture -----------------------------------------------------
 
   meshProps(flat, glow, ch, cx, cz) {
@@ -1252,6 +1553,7 @@ export class World {
           // street light: base, tapered mast, cranked arm, lit lens
           flat.box(ox, gy, oz, 0.42, 0.22, 0.42, armRot, [0.24, 0.25, 0.27]);
           flat.prism(ox, gy + 0.2, oz, 0.115, 6.4, 8, poleCol);
+          this.city.addObstacle(this._ck, ox, oz, 0.35);
           flat.prism(ox - px * sg * 0.28, gy + 6.6, oz - pz * sg * 0.28, 0.1, 0.9, 6, poleCol);
           flat.box(ox - px * sg * 1.0, gy + 7.4, oz - pz * sg * 1.0, 1.9, 0.16, 0.16, armRot, poleCol);
           flat.box(ox - px * sg * 1.85, gy + 7.15, oz - pz * sg * 1.85, 0.85, 0.26, 0.42, armRot, [0.3, 0.31, 0.33]);
@@ -1262,11 +1564,15 @@ export class World {
           flat.box(ox, gy - 0.02, oz, 1.5, 0.06, 1.5, armRot, [0.3, 0.3, 0.31]);
           flat.prism(ox, gy, oz, 0.26 + h * 0.1, th * 0.5, 6, trunk);
           flat.prism(ox, gy + th * 0.42, oz, 0.16, th * 0.28, 5, trunk);
-          const g = [0.2 + h * 0.16, 0.4 + h * 0.2, 0.16 + h * 0.12];
-          const gd = [g[0] * 0.72, g[1] * 0.72, g[2] * 0.72];
-          flat.cone(ox, gy + th * 0.4, oz, 1.7 + h * 1.4, th * 0.42, 7, gd);
-          flat.cone(ox, gy + th * 0.62, oz, 1.5 + h * 1.2, th * 0.42, 7, g);
-          flat.cone(ox, gy + th * 0.84, oz, 1.0 + h * 0.9, th * 0.38, 6, g);
+          // Same muted range as the park canopies, or a street of trees reads
+          // brighter than the buildings behind them.
+          const vw = 0.74 + h * 0.46;
+          const g = [0.21 * vw, 0.30 * vw, 0.18 * vw];
+          const gd = [g[0] * 0.64, g[1] * 0.64, g[2] * 0.70];
+          // Street trees are broadleaf: a row of conifers down a city block is
+          // the giveaway that one asset is doing all the work.
+          this.meshCanopy(flat, ox, gy, oz, th, 1, h, g, gd);
+          this.city.addObstacle(this._ck, ox, oz, 0.5);
         } else if (h < 0.88) {
           flat.prism(ox, gy, oz, 0.2, 0.55, 8, [0.72, 0.16, 0.12]);
           flat.prism(ox, gy + 0.55, oz, 0.15, 0.24, 8, [0.72, 0.16, 0.12]);
@@ -1287,6 +1593,69 @@ export class World {
           glow.box(ox + px * sg * 0.5, gy + 1.7, oz + pz * sg * 0.5, 0.9, 1.2, 0.06, along, [0.8, 0.86, 0.95]);
         }
       }
+      // --- small clutter ----------------------------------------------------
+      //
+      // The structural pass above places one item every 30-34 m, ALTERNATING
+      // sides, so a given kerb gets a lamp or a tree about every 65 m and
+      // nothing in between. That is an empty street: a real block carries a
+      // hydrant, a bin, a meter, a mailbox and a sign between every pair of
+      // lamps.
+      //
+      // Kept separate rather than folded into the cascade above because these
+      // want a different cadence and a much smaller triangle budget -- they are
+      // knee-height objects whose whole job is to interrupt the kerb line, so
+      // six-sided prisms and boxes are enough. Both sides, every ~22 m.
+      if (e.cls !== 'ramp') {
+        const cSpace = 22;
+        const cCount = Math.floor(e.len / cSpace);
+        for (let i = 1; i <= cCount; i++) {
+          const t = (i - 0.5) / (cCount + 1);
+          const x = lerp(a.x, b.x, t), z = lerp(a.z, b.z, t);
+          const hc = hash2(Math.round(x * 7) + 3, Math.round(z * 7) + 11);
+          const sg = hc < 0.5 ? 1 : -1;
+          // Sit tight against the kerb, where street furniture actually goes.
+          const ox = x + px * sg * (e.hw + 0.85);
+          const oz = z + pz * sg * (e.hw + 0.85);
+          if (!G.isBuildable(ox, oz)) continue;
+          if (city.onRoad(ox, oz, 0.4)) { cityStats.propsSkipped++; continue; }
+          const gy = G.terrainHeight(ox, oz) + WALK_Y;
+          const rot = Math.atan2(-px * sg, -pz * sg);
+          const k = hash2(Math.round(x * 13) + 5, Math.round(z * 13) + 29);
+          if (k < 0.20) {
+            // fire hydrant
+            const hy = [0.68, 0.16, 0.12];
+            flat.prism(ox, gy, oz, 0.17, 0.6, 6, hy);
+            flat.prism(ox, gy + 0.6, oz, 0.12, 0.14, 6, hy);
+            flat.box(ox, gy + 0.34, oz, 0.52, 0.14, 0.16, rot, hy);
+          } else if (k < 0.40) {
+            // litter bin
+            const bc = [0.22, 0.26, 0.24];
+            flat.prism(ox, gy, oz, 0.34, 0.9, 8, bc);
+            flat.prism(ox, gy + 0.9, oz, 0.37, 0.09, 8, [0.14, 0.16, 0.15]);
+          } else if (k < 0.58) {
+            // parking meter or ticket machine
+            flat.prism(ox, gy, oz, 0.06, 1.05, 6, [0.3, 0.32, 0.34]);
+            flat.box(ox, gy + 1.05, oz, 0.2, 0.34, 0.16, rot, [0.36, 0.38, 0.4]);
+          } else if (k < 0.72) {
+            // mailbox / newspaper box
+            const mc = k < 0.65 ? [0.16, 0.28, 0.44] : [0.5, 0.14, 0.14];
+            flat.box(ox, gy, oz, 0.48, 0.5, 0.4, rot, [0.24, 0.25, 0.26]);
+            flat.box(ox, gy + 0.5, oz, 0.56, 0.66, 0.46, rot, mc);
+          } else if (k < 0.86) {
+            // sign on a post -- the tallest of the clutter, so it breaks the
+            // kerb line against the facades behind it
+            flat.prism(ox, gy, oz, 0.045, 2.3, 5, [0.4, 0.42, 0.44]);
+            flat.box(ox, gy + 2.3, oz, 0.5, 0.42, 0.05, rot, [0.72, 0.74, 0.76]);
+          } else {
+            // bollards, in a short run
+            for (let bIdx = -1; bIdx <= 1; bIdx++) {
+              const bx = ox + e.dx * bIdx * 1.4, bz = oz + e.dz * bIdx * 1.4;
+              flat.prism(bx, gy, bz, 0.09, 0.85, 6, [0.3, 0.31, 0.33]);
+            }
+          }
+        }
+      }
+
       // traffic signals at busy corners
       if (e.cls === 'art' && e.len > 40) {
         for (const nid of [e.a, e.b]) {
@@ -1330,17 +1699,66 @@ export class World {
       // middle of the road. Nothing else filters this: `inPark` knows about
       // grass, not about tarmac.
       if (this.city.onRoad(x, z, 2.5)) { treeSkip++; continue; }
+      // ...nor inside a building. Parks and footprints come from two different
+      // OSM layers and they overlap: greenspace is mapped right up to and over
+      // the museum, pavilion or house standing in it, so `inPark` happily says
+      // yes in the middle of a building. Measured, 9.3 % of surviving park
+      // candidates stood inside a footprint -- trees growing through roofs.
+      if (this.inBuilding(x, z, 0.8)) { treeSkip++; continue; }
       const h = hash2(Math.round(x), Math.round(z));
       const gy = G.terrainHeight(x, z);
-      const th = 7 + h * 7;
-      flat.prism(x, gy, z, 0.34 + h * 0.2, th * 0.46, 6, trunk);
-      flat.prism(x, gy + th * 0.4, z, 0.2, th * 0.3, 5, trunk);
-      const g = [0.17 + h * 0.15, 0.38 + h * 0.22, 0.14 + h * 0.12];
-      const gd = [g[0] * 0.7, g[1] * 0.7, g[2] * 0.7];
-      flat.cone(x, gy + th * 0.34, z, 2.4 + h * 2, th * 0.42, 7, gd);
-      flat.cone(x, gy + th * 0.58, z, 2.1 + h * 1.7, th * 0.44, 7, g);
-      flat.cone(x, gy + th * 0.82, z, 1.4 + h * 1.2, th * 0.4, 6, g);
+      // Foliage that isn't one emerald cone.
+      //
+      // A single saturated green was the most out-of-gamut thing in every frame
+      // -- once the rest of the palette was pulled toward grey it stopped
+      // reading as a tree and started reading as a marker. Real canopies are
+      // desaturated, vary between individuals, and are darker underneath than
+      // on top. Three silhouettes keep a stand from looking stamped.
+      const h2 = hash2(Math.round(x * 3), Math.round(z * 3));
+      const th = 6 + h * 8;
+      const kind = h2 < 0.42 ? 0 : h2 < 0.78 ? 1 : 2;   // conifer, broadleaf, scrub
+      flat.prism(x, gy, z, 0.28 + h * 0.18, th * (kind === 1 ? 0.52 : 0.4), 6, trunk);
+      // Hue drifts a little yellow-to-blue between individuals; value does most
+      // of the work, exactly as with the building palette.
+      const warm = (h2 - 0.5) * 0.06;
+      const v = 0.72 + h * 0.5;
+      const g = [(0.20 + warm) * v, (0.29 + h * 0.05) * v, (0.17 - warm * 0.5) * v];
+      const gd = [g[0] * 0.62, g[1] * 0.62, g[2] * 0.68];
+      this.meshCanopy(flat, x, gy, z, th, kind, h, g, gd);
+      // A tree is solid. Radius is the trunk, not the canopy: you walk and
+      // drive under a canopy, and blocking its full spread would make a park
+      // impassable.
+      this.city.addObstacle(this._ck, x, z, 0.45 + h * 0.25);
     }
     cityStats.treesSkipped += treeSkip;
+  }
+
+  /**
+   * One tree crown. Shared by park scatter and street trees so the two can't
+   * drift apart -- a street of one species beside a park of another was how the
+   * old duplicated code read.
+   *
+   * `prism` is open at both ends: a squashed one seen from eye level is a
+   * single band of vertical wall with no top and no bottom, which is why the
+   * broadleaf canopy rendered as a flat green slab on a stick. Crowns are
+   * closed spheroids now.
+   */
+  meshCanopy(flat, x, gy, z, th, kind, h, g, gd) {
+    if (kind === 0) {
+      // Conifer: a stack of narrowing cones, widest and darkest at the bottom.
+      flat.cone(x, gy + th * 0.26, z, 1.9 + h * 1.6, th * 0.40, 7, gd);
+      flat.cone(x, gy + th * 0.48, z, 1.55 + h * 1.3, th * 0.40, 7, g);
+      flat.cone(x, gy + th * 0.70, z, 1.05 + h * 0.95, th * 0.40, 6, g);
+    } else if (kind === 1) {
+      // Broadleaf: three overlapping lobes, the lower one wider and in shade,
+      // so the crown has a lumpy silhouette rather than one clean ball.
+      const cr = 2.1 + h * 1.8;
+      flat.spheroid(x, gy + th * 0.62, z, cr, 7, 3, gd, 0.74, 0.26);
+      flat.spheroid(x + cr * 0.3, gy + th * 0.8, z - cr * 0.2, cr * 0.66, 6, 3, g, 0.88, 0.3);
+    } else {
+      // Scrub: low, wide and squat.
+      const cr = 1.5 + h * 1.1;
+      flat.spheroid(x, gy + th * 0.36, z, cr, 6, 3, gd, 0.7, 0.34);
+    }
   }
 }

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -171,7 +171,12 @@ export class World {
     this.mats = {
       road: surf(tx.road, { env: 0.62, ns: 0.9 }),
       walk: surf(tx.sidewalk, { env: 0.52, ns: 0.8 }),
-      glass: surf(tx.glass, { env: 1.9, metalness: 0.34, roughness: 0.22, ns: 1.1, emissive: 0.02 }),
+      // Glass was the one material already sitting at clamp. env 1.9 on a
+      // 0.9-albedo curtain wall survived the old ambient floor and saturates
+      // through ACES once the scene moves up the curve -- hard-edged white
+      // polygon faces that read as a missing texture, not as sunlight. Pulling
+      // it down is what makes the exposure headroom available.
+      glass: surf(tx.glass, { env: 0.9, metalness: 0.34, roughness: 0.22, ns: 1.1, emissive: 0.02 }),
       masonry: surf(tx.masonry, { env: 0.66, ns: 1.5, emissive: 0.015 }),
       brick: surf(tx.brick, { env: 0.60, ns: 1.5, emissive: 0.015 }),
       // Signage. Emissive is high because a fifth of the atlas cells are lit
@@ -400,18 +405,27 @@ export class World {
       let cw = bd.w * s, cd = bd.d * s;
       const style = hash2(bd.seed, 29);
       const setbacks = style < 0.4 ? 1 : style < 0.8 ? 2 : 3;
+      // The crown has to fit INSIDE the building's own height. Built on top of
+      // it, the penthouse and mast stood proud of the real roofline drawn by
+      // the near-chunk mesh -- so every tall building in the city wore an
+      // untextured pale box floating above its actual roof, which clipped to
+      // white slabs across downtown.
       const rest = bd.h - shaftH;
+      const plant = Math.min(4.5, rest * 0.35);
+      const stepped = rest - plant;
       for (let t = 0; t < setbacks; t++) {
-        const th = rest / setbacks;
+        const th = stepped / setbacks;
         cw *= 0.78; cd *= 0.78;
         b.box(bd.x, cy, bd.z, cw, th, cd, bd.rot, t % 2 ? col : dk, { top: true, ao: 0 });
         cy += th;
       }
       // Mechanical penthouse: the boxy plant room every real tower carries.
-      b.box(bd.x, cy, bd.z, cw * 0.62, 3.5 + hash2(bd.seed, 31) * 3, cd * 0.62, bd.rot, dk, { top: true });
+      b.box(bd.x, cy, bd.z, cw * 0.62, plant, cd * 0.62, bd.rot, dk, { top: true });
+      // A mast is the one thing that legitimately stands above the parapet, and
+      // it is thin enough not to read as a slab.
       if (bd.h > 80 && hash2(bd.seed, 37) > 0.45) {
         const mh = 8 + hash2(bd.seed, 41) * 22;
-        b.box(bd.x, cy + 3.5, bd.z, 1.1, mh, 1.1, bd.rot, dk, { top: true });
+        b.box(bd.x, cy + plant, bd.z, 0.9, mh, 0.9, bd.rot, dk, { top: true });
       }
     }
     const m = new THREE.Mesh(b.build(), this.mats.far);
@@ -1146,7 +1160,7 @@ export class World {
     // texture cannot express however far you push it.
     const FAMS = [
       { m: 'masonry', c: [0.76, 0.75, 0.72], u: 14, v: 13.6 },   // grey concrete
-      { m: 'glass', c: [0.78, 0.86, 0.92], u: 14, v: 13.6 },     // curtain wall
+      { m: 'glass', c: [0.55, 0.60, 0.66], u: 14, v: 13.6 },     // curtain wall
       { m: 'brick', c: [0.80, 0.38, 0.28], u: 12, v: 12 },       // red brick
       { m: 'brick', c: [0.86, 0.72, 0.46], u: 12, v: 12 },       // buff brick
       { m: 'masonry', c: [0.92, 0.90, 0.84], u: 13, v: 13 },     // painted white
@@ -1232,7 +1246,7 @@ export class World {
       // near-field went near-black from above while the fogged far skyline
       // stayed bright, so the city read inside-out: the closest thing in the
       // frame was the darkest. Roofs are a light-to-mid grey with real spread.
-      const rv = 0.42 + hash2(seed, 91) * 0.16;
+      const rv = 0.32 + hash2(seed, 91) * 0.14;
       const rc2 = [rv, rv * 1.01, rv * 1.05];
       const n = 1 + Math.floor(hash2(seed, 51) * 3);
       for (let i = 0; i < n; i++) {

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -107,20 +107,34 @@ function halfFloatRenders(renderer) {
   }
 }
 
+/**
+ * Per-building colour variation.
+ *
+ * Jittering R, G and B INDEPENDENTLY is what manufactured the candy palette:
+ * three uncorrelated offsets push a muted base straight off into saturated
+ * primaries, so a street of weathered brick came out fluorescent pink, lime and
+ * orange. Real variation between buildings is mostly TONAL -- the same material
+ * dirtier or paler -- with only a slight drift in hue. So the brightness jitter
+ * is shared across all three channels, the chroma jitter is a fifth of it, and
+ * everything is pulled toward its own grey.
+ */
+const SATURATION = 0.62;
 function tint(seed, base, spread) {
-  const r = hash2(seed, 1), g = hash2(seed, 2), b = hash2(seed, 3);
-  return [
-    clamp(base[0] + (r - 0.5) * spread, 0.15, 1.4),
-    clamp(base[1] + (g - 0.5) * spread, 0.15, 1.4),
-    clamp(base[2] + (b - 0.5) * spread, 0.15, 1.4),
-  ];
+  const v = 1 + (hash2(seed, 1) - 0.5) * spread * 0.85;
+  const dr = (hash2(seed, 2) - 0.5) * spread * 0.18;
+  const db = (hash2(seed, 3) - 0.5) * spread * 0.18;
+  const lum = base[0] * 0.2126 + base[1] * 0.7152 + base[2] * 0.0722;
+  const mute = (c, d) => clamp((lum + (c - lum) * SATURATION + d) * v, 0.12, 1.35);
+  return [mute(base[0], dr), mute(base[1], 0), mute(base[2], db)];
 }
 
 const DARK = [0.26, 0.27, 0.29];
 const TRIM = [0.55, 0.55, 0.56];
+// Accents stay the one place saturated colour is allowed, but pulled back:
+// these are awnings and shopfronts, not the whole facade.
 const AWNING = [
-  [0.55, 0.12, 0.12], [0.12, 0.28, 0.5], [0.14, 0.34, 0.22],
-  [0.42, 0.34, 0.16], [0.2, 0.2, 0.24], [0.5, 0.42, 0.3],
+  [0.42, 0.16, 0.15], [0.15, 0.25, 0.38], [0.16, 0.29, 0.21],
+  [0.36, 0.30, 0.18], [0.21, 0.21, 0.24], [0.42, 0.37, 0.29],
 ];
 
 // ---------------------------------------------------------------------------
@@ -155,15 +169,15 @@ export class World {
     };
 
     this.mats = {
-      road: surf(tx.road, { env: 0.9, ns: 0.7 }),
-      walk: surf(tx.sidewalk, { env: 0.85, ns: 0.8 }),
-      glass: surf(tx.glass, { env: 1.5, metalness: 0.18, ns: 1.1, emissive: 0.12 }),
-      masonry: surf(tx.masonry, { env: 1.05, ns: 1.0, emissive: 0.1 }),
-      industrial: surf(tx.industrial, { env: 1.0, metalness: 0.25, ns: 1.0 }),
-      house: surf(tx.house, { env: 0.95, ns: 1.0, emissive: 0.1 }),
-      flat: new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.82, metalness: 0.04, envMapIntensity: 1.0 }),
+      road: surf(tx.road, { env: 0.45, ns: 0.7 }),
+      walk: surf(tx.sidewalk, { env: 0.42, ns: 0.8 }),
+      glass: surf(tx.glass, { env: 1.05, metalness: 0.22, ns: 1.1, emissive: 0.02 }),
+      masonry: surf(tx.masonry, { env: 0.5, ns: 1.0, emissive: 0.015 }),
+      industrial: surf(tx.industrial, { env: 0.5, metalness: 0.25, ns: 1.0 }),
+      house: surf(tx.house, { env: 0.45, ns: 1.0, emissive: 0.015 }),
+      flat: new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.82, metalness: 0.04, envMapIntensity: 0.45 }),
       glow: new THREE.MeshBasicMaterial({ vertexColors: true, toneMapped: false }),
-      far: new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.85, metalness: 0.05, envMapIntensity: 0.95 }),
+      far: new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.85, metalness: 0.05, envMapIntensity: 0.5 }),
     };
     this.group = new THREE.Group();
     scene.add(this.group);
@@ -292,8 +306,11 @@ export class World {
     const n = this.tx.water.normalMap;
     n.repeat.set(520, 520);
     const mat = new THREE.MeshStandardMaterial({
-      color: 0x2c4d63, normalMap: n, roughness: 0.09, metalness: 0.25,
-      envMapIntensity: 1.6, normalScale: new THREE.Vector2(0.55, 0.55),
+      // Roughness up and normal amplitude down: at 0.09 every wavelet past a
+      // couple of hundred metres aliased into one blown white specular sheet
+      // along the horizon.
+      color: 0x2a4658, normalMap: n, roughness: 0.22, metalness: 0.2,
+      envMapIntensity: 1.0, normalScale: new THREE.Vector2(0.28, 0.28),
     });
     const m = new THREE.Mesh(geo, mat);
     m.position.y = 0;
@@ -980,30 +997,55 @@ export class World {
 
   // --- buildings ------------------------------------------------------------
 
+  /**
+   * Material families.
+   *
+   * Per-building random jitter around ONE base colour per style gave a downtown
+   * that was almost entirely the same beige-orange brick -- the palette fix
+   * removed the candy colours but replaced them with monotony. Real cities are a
+   * handful of distinct material families (concrete, curtain-wall glass, red
+   * brick, painted stucco, dark modern) mixed on one street, with variation
+   * INSIDE each family rather than across the whole city.
+   */
+  buildingFamily(bd) {
+    const seed = bd.seed;
+    const pick = hash2(seed, 101);
+    // Taller and newer skews to glass and dark curtain wall; low and old skews
+    // to brick and stucco, which is roughly how a city stratifies by era.
+    const modern = clamp((bd.h - 18) / 55, 0, 1);
+    const FAMS = [
+      { m: 'masonry', c: [0.74, 0.73, 0.70], u: 14, v: 13.6 },   // concrete
+      { m: 'glass', c: [0.78, 0.86, 0.92], u: 14, v: 13.6 },     // curtain wall
+      { m: 'masonry', c: [0.72, 0.46, 0.38], u: 12, v: 12 },     // red brick
+      { m: 'masonry', c: [0.86, 0.82, 0.74], u: 13, v: 13 },     // painted stucco
+      { m: 'glass', c: [0.42, 0.46, 0.50], u: 14, v: 13.6 },     // dark modern
+    ];
+    const wOld = [0.30, 0.06, 0.34, 0.26, 0.04];
+    const wNew = [0.26, 0.34, 0.10, 0.08, 0.22];
+    let acc = 0;
+    for (let i = 0; i < FAMS.length; i++) {
+      acc += wOld[i] + (wNew[i] - wOld[i]) * modern;
+      if (pick <= acc) return FAMS[i];
+    }
+    return FAMS[0];
+  }
+
   meshBuilding(bl, flat, glow, bd) {
     const seed = bd.seed;
     let target, col, uS = 14, vS = 13.6;
-    switch (bd.style) {
-      case 'tower':
-        if (hash2(seed, 11) > 0.55) { target = bl.glass; col = tint(seed, [0.92, 0.97, 1.0], 0.28); }
-        else { target = bl.masonry; col = tint(seed, [0.9, 0.85, 0.78], 0.3); }
-        break;
-      case 'midrise':
-        if (hash2(seed, 11) > 0.62) { target = bl.glass; col = tint(seed, [0.9, 0.95, 1.0], 0.3); }
-        else { target = bl.masonry; col = tint(seed, [0.92, 0.84, 0.72], 0.34); }
-        break;
-      case 'brick':
-        target = bl.masonry; col = tint(seed, [0.82, 0.55, 0.44], 0.34); uS = 12; vS = 12;
-        break;
-      case 'lowrise':
-        if (hash2(seed, 11) > 0.62) { target = bl.glass; col = tint(seed, [0.88, 0.94, 1.0], 0.3); }
-        else { target = bl.masonry; col = tint(seed, [0.92, 0.86, 0.76], 0.36); }
-        break;
-      case 'industrial':
-        target = bl.industrial; col = tint(seed, [0.84, 0.86, 0.86], 0.3); uS = 16; vS = 16;
-        break;
-      default:
-        target = bl.house; col = tint(seed, [0.94, 0.92, 0.88], 0.36); uS = 0; vS = 0;
+    const fam = (bd.style === 'tower' || bd.style === 'midrise'
+      || bd.style === 'brick' || bd.style === 'lowrise')
+      ? this.buildingFamily(bd) : null;
+    if (fam) {
+      target = fam.m === 'glass' ? bl.glass : bl.masonry;
+      // Jitter stays INSIDE the family, so a brick street varies in weathering
+      // rather than becoming a different material every other lot.
+      col = tint(seed, fam.c, 0.26);
+      uS = fam.u; vS = fam.v;
+    } else if (bd.style === 'industrial') {
+      target = bl.industrial; col = tint(seed, [0.84, 0.86, 0.86], 0.3); uS = 16; vS = 16;
+    } else {
+      target = bl.house; col = tint(seed, [0.94, 0.92, 0.88], 0.36); uS = 0; vS = 0;
     }
 
     if (bd.kind) return this.meshLandmarkTower(bl, flat, bd, col);
@@ -1029,6 +1071,31 @@ export class World {
       const [sx, sz] = off(0, bd.d / 2 + 0.5);
       flat.box(sx, base + 1.6, sz, 2.0, 0.22, 1.2, bd.rot, [0.62, 0.6, 0.57]);
       return;
+    }
+
+    // Roof clutter. The top face is the most-seen surface of a low building
+    // from any elevated view, and a bare extrusion cap is the loudest tell that
+    // this is untextured programmer geometry. A handful of boxes per roof is
+    // within budget because they merge into the chunk's existing flat mesh.
+    if (bd.h < 70 && bd.w > 9 && bd.d > 9) {
+      const rt = base + bd.h + 2;
+      // Roofs vary per building. One flat grey across a whole downtown reads
+      // as untextured cap geometry from every elevated view, which is the
+      // angle roofs are actually seen from.
+      const rv = 0.30 + hash2(seed, 91) * 0.22;
+      const rc2 = [rv, rv * 1.01, rv * 1.05];
+      const n = 1 + Math.floor(hash2(seed, 51) * 3);
+      for (let i = 0; i < n; i++) {
+        const ux = (hash2(seed, 52 + i) - 0.5) * (bd.w - 6);
+        const uz = (hash2(seed, 61 + i) - 0.5) * (bd.d - 6);
+        const [gx, gz] = off(ux, uz);
+        const bw2 = 1.4 + hash2(seed, 71 + i) * 2.2;
+        const bh2 = 0.9 + hash2(seed, 81 + i) * 1.5;
+        flat.box(gx, rt, gz, bw2, bh2, bw2 * 0.8, bd.rot, rc2);
+      }
+      // parapet lip, so the roof edge has a silhouette rather than a clean cut
+      flat.box(bd.x, rt, bd.z, bd.w + 0.5, 0.85, bd.d + 0.5, bd.rot,
+        [rv * 1.25, rv * 1.25, rv * 1.22]);
     }
 
     const dense = bd.style !== 'industrial';

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -1580,8 +1580,8 @@ export class World {
           flat.prism(ox, gy + th * 0.42, oz, 0.16, th * 0.28, 5, trunk);
           // Same muted range as the park canopies, or a street of trees reads
           // brighter than the buildings behind them.
-          const vw = 0.74 + h * 0.46;
-          const g = [0.21 * vw, 0.30 * vw, 0.18 * vw];
+          const vw = 0.72 + h * 0.44;
+          const g = [0.165 * vw, 0.315 * vw, 0.14 * vw];
           const gd = [g[0] * 0.64, g[1] * 0.64, g[2] * 0.70];
           // Street trees are broadleaf: a row of conifers down a city block is
           // the giveaway that one asset is doing all the work.
@@ -1734,9 +1734,25 @@ export class World {
       flat.prism(x, gy, z, 0.28 + h * 0.18, th * (kind === 1 ? 0.52 : 0.4), 6, trunk);
       // Hue drifts a little yellow-to-blue between individuals; value does most
       // of the work, exactly as with the building palette.
+      // Canopies were pulled toward grey back when the emerald cone was the
+      // most out-of-gamut thing in every frame -- but that was tuned with no
+      // tone curve in front of it. With ACES running and its saturation paid
+      // back, the same values leave a tree paler than the lawn it stands on.
+      // Foliage carries more chroma than grass and sits darker, which is also
+      // what a conifer against a mown park actually looks like.
       const warm = (h2 - 0.5) * 0.06;
-      const v = 0.72 + h * 0.5;
-      const g = [(0.20 + warm) * v, (0.29 + h * 0.05) * v, (0.17 - warm * 0.5) * v];
+      const v = 0.70 + h * 0.48;
+      const g = [(0.155 + warm) * v, (0.305 + h * 0.05) * v, (0.13 - warm * 0.5) * v];
+      // A conifer is not a green tree, it is a DARK one.
+      //
+      // Sharing one foliage colour across all three silhouettes left the
+      // Douglas firs the same value as the lawn they stand on, which is the
+      // one thing a Pacific Northwest park never looks like. Deep forest green
+      // is darker and cooler than broadleaf, not merely a shade of it -- so
+      // red comes down hardest and blue is held up.
+      if (kind === 0) {
+        g[0] *= 0.60; g[1] *= 0.76; g[2] *= 0.82;
+      }
       const gd = [g[0] * 0.62, g[1] * 0.62, g[2] * 0.68];
       this.meshCanopy(flat, x, gy, z, th, kind, h, g, gd);
       // A tree is solid. Radius is the trunk, not the canopy: you walk and

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v29';
+const CACHE = 'auto-v30';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v28';
+const CACHE = 'auto-v29';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',

--- a/tools/beauty.mjs
+++ b/tools/beauty.mjs
@@ -12,6 +12,10 @@ import { writeFileSync, mkdirSync } from 'node:fs';
 import { setTimeout as sleep } from 'node:timers/promises';
 
 const PORT = 9228;
+// The page port is overridable so a second checkout -- a worktree at master,
+// say -- can be captured with THIS harness for an honest before/after. Framing
+// has to come from the same code or the two sets are not comparable.
+const HTTP_PORT = process.env.AUTO_HTTP_PORT || 8000;
 const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 const TAG = process.argv[2] || 'now';
 const OUT = `tools/data/beauty/${TAG}`;
@@ -145,7 +149,7 @@ async function main() {
     await send('Network.setBypassServiceWorker', { bypass: true });
     await send('Network.setCacheDisabled', { cacheDisabled: true });
     await send('Page.addScriptToEvaluateOnNewDocument', { source: 'window.__noAutoQuality = true;' });
-    await send('Page.navigate', { url: 'http://localhost:8000/apps/auto/' });
+    await send('Page.navigate', { url: `http://localhost:${HTTP_PORT}/apps/auto/` });
     for (let i = 0; i < 400; i++) {
       await sleep(500);
       if (await evaluate('!!window.__dbg')) break;

--- a/tools/beauty.mjs
+++ b/tools/beauty.mjs
@@ -1,0 +1,116 @@
+// Beauty shots for judging visual quality.
+//
+//   node tools/beauty.mjs [tag]
+//
+// A fixed set of framed views, captured identically every time so two runs can
+// be compared honestly. The HUD is hidden and the quality tier is locked to
+// `high` -- SwiftShader's ~4 fps otherwise trips the adaptive downgrade and
+// every shot silently comes back at the low-quality settings.
+
+import { spawn } from 'node:child_process';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const PORT = 9228;
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const TAG = process.argv[2] || 'now';
+const OUT = `tools/data/beauty/${TAG}`;
+
+// name, [camera x, HEIGHT ABOVE GROUND, z], [look-at x, height above ground, z].
+//
+// Heights are relative to the ground at that point, not absolute. Absolute
+// heights put the Green Lake camera at y=30 under a lake whose surface is at
+// 50 m, so the shot came back as the underside of the water plane with the
+// neighbourhood apparently floating over a void -- which reads exactly like a
+// broken renderer and is entirely the harness's fault.
+const VIEWS = [
+  ['street',      [250, 2.4, 780],    [250, 1.6, 300]],
+  ['downtown',    [520, 80, 1250],    [420, 20, 500]],
+  ['skyline',     [-1900, 150, 1900], [200, 30, 700]],
+  ['waterfront',  [-900, 14, 640],    [-200, 2, 900]],
+  ['residential', [-3400, 6, -6180],  [-3500, 2, -6600]],
+  ['park',        [-700, 8, -4700],   [-350, 2, -5100]],
+];
+
+function launch() {
+  return spawn(CHROME, [
+    `--remote-debugging-port=${PORT}`, '--headless=new', '--use-gl=swiftshader',
+    '--enable-unsafe-swiftshader', '--autoplay-policy=no-user-gesture-required',
+    '--window-size=1280,720', '--no-first-run',
+    '--user-data-dir=/tmp/auto-beauty-profile', 'about:blank',
+  ], { stdio: 'ignore' });
+}
+
+async function main() {
+  const chrome = launch();
+  try {
+    let page;
+    for (let i = 0; i < 90 && !page; i++) {
+      try {
+        page = (await (await fetch(`http://127.0.0.1:${PORT}/json/list`)).json())
+          .find((t) => t.type === 'page');
+      } catch { /* not up */ }
+      if (!page) await sleep(300);
+    }
+    const ws = new WebSocket(page.webSocketDebuggerUrl);
+    await new Promise((r, j) => { ws.addEventListener('open', r); ws.addEventListener('error', j); });
+    let id = 0; const pend = new Map();
+    ws.addEventListener('message', (ev) => {
+      const m = JSON.parse(ev.data);
+      if (m.id && pend.has(m.id)) { pend.get(m.id)(m); pend.delete(m.id); }
+    });
+    const send = (method, params = {}) => new Promise((res) => {
+      ws.send(JSON.stringify({ id: ++id, method, params })); pend.set(id, res);
+    });
+    const evaluate = async (e) => {
+      const r = await send('Runtime.evaluate', { expression: e, returnByValue: true });
+      if (r.result?.exceptionDetails) throw new Error(r.result.exceptionDetails.exception?.description);
+      return r.result?.result?.value;
+    };
+    await send('Runtime.enable');
+    await send('Page.enable');
+    await send('Network.enable');
+    await send('Network.setBypassServiceWorker', { bypass: true });
+    await send('Network.setCacheDisabled', { cacheDisabled: true });
+    await send('Page.addScriptToEvaluateOnNewDocument', { source: 'window.__noAutoQuality = true;' });
+    await send('Page.navigate', { url: 'http://localhost:8000/apps/auto/' });
+    for (let i = 0; i < 400; i++) {
+      await sleep(500);
+      if (await evaluate('!!window.__dbg')) break;
+    }
+    await evaluate(`(() => {
+      const d = window.__dbg;
+      d.applyQuality('high', true);
+      for (const id of ['hud','pad','stickZone','lookZone','objective','toast','rotate'])
+        { const e = document.getElementById(id); if (e) e.style.display = 'none'; }
+      d.game.paused = true;
+    })()`);
+
+    mkdirSync(OUT, { recursive: true });
+    for (const [name, pos, look] of VIEWS) {
+      await evaluate(`(() => {
+        const d = window.__dbg;
+        d.world.update(${pos[0]}, ${pos[2]}, 60);
+        const gy = (x, z) => Math.max(0, d.city.groundAt(x, z, null));
+        const cy = gy(${pos[0]}, ${pos[2]}) + ${pos[1]};
+        const ly = gy(${look[0]}, ${look[2]}) + ${look[1]};
+        d.camera.position.set(${pos[0]}, cy, ${pos[2]});
+        d.camera.lookAt(${look[0]}, ly, ${look[2]});
+        d.camera.updateMatrixWorld(true);
+        d.sun.position.set(${pos[0]} - 160, cy + 240, ${pos[2]} - 110);
+        d.sun.target.position.set(${look[0]}, ly, ${look[2]});
+        d.sun.target.updateMatrixWorld();
+      })()`);
+      await sleep(9000);
+      const { result } = await send('Page.captureScreenshot', { format: 'png' });
+      writeFileSync(`${OUT}/${name}.png`, Buffer.from(result.data, 'base64'));
+      console.log(`  ${OUT}/${name}.png`);
+    }
+    const stats = await evaluate('({calls: __dbg.sceneStats.calls, tris: __dbg.sceneStats.tris})');
+    console.log(`  scene: ${stats.calls} draws, ${stats.tris} triangles`);
+  } finally {
+    chrome.kill('SIGKILL');
+  }
+}
+
+main().catch((e) => { console.error('beauty failed:', e.message); process.exitCode = 1; });

--- a/tools/beauty.mjs
+++ b/tools/beauty.mjs
@@ -16,21 +16,93 @@ const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 const TAG = process.argv[2] || 'now';
 const OUT = `tools/data/beauty/${TAG}`;
 
-// name, [camera x, HEIGHT ABOVE GROUND, z], [look-at x, height above ground, z].
+// Views are CHOSEN FROM THE MAP, not hardcoded.
+//
+// Fixed coordinates went stale as soon as the city became real data: the shot
+// named `park` contained no park and `residential` framed a four-storey office
+// block, so vegetation and housing were never actually being looked at. Each
+// entry names a query run against the loaded city; the harness resolves it to a
+// camera and a look-at at capture time.
 //
 // Heights are relative to the ground at that point, not absolute. Absolute
 // heights put the Green Lake camera at y=30 under a lake whose surface is at
-// 50 m, so the shot came back as the underside of the water plane with the
-// neighbourhood apparently floating over a void -- which reads exactly like a
-// broken renderer and is entirely the harness's fault.
+// 50 m, so the shot came back as the underside of the water plane -- which
+// reads exactly like a broken renderer and is entirely the harness's fault.
 const VIEWS = [
-  ['street',      [250, 2.4, 780],    [250, 1.6, 300]],
-  ['downtown',    [520, 80, 1250],    [420, 20, 500]],
-  ['skyline',     [-1900, 150, 1900], [200, 30, 700]],
-  ['waterfront',  [-900, 14, 640],    [-200, 2, 900]],
-  ['residential', [-3400, 6, -6180],  [-3500, 2, -6600]],
-  ['park',        [-700, 8, -4700],   [-350, 2, -5100]],
+  { name: 'street', pick: 'commercial', eye: 1.7, look: 1.7, back: 26, ahead: 70 },
+  { name: 'shopfront', pick: 'commercial', eye: 1.7, look: 3.0, back: 15, ahead: 0 },
+  { name: 'residential', pick: 'houses', eye: 4, look: 1.5, back: 55, ahead: 0 },
+  { name: 'park', pick: 'park', eye: 5, look: 2, back: 70, ahead: 0 },
+  { name: 'downtown', pick: 'downtown', eye: 70, look: 20, back: 340, ahead: 0 },
+  { name: 'skyline', pick: 'downtown', eye: 150, look: 30, back: 2400, ahead: 0 },
+  { name: 'waterfront', pick: 'waterfront', eye: 12, look: 2, back: 90, ahead: 0 },
 ];
+
+// Runs in the page. Returns the world point each view should look AT, chosen by
+// querying the city rather than by a coordinate written down months ago.
+const PICKERS = `(() => {
+  const d = window.__dbg, city = d.city, G = d.G;
+  const out = {};
+
+  // Densest cluster of the class we want, on a 300 m grid over the buildings.
+  const cluster = (want, minH, maxH) => {
+    const cells = new Map();
+    for (const b of city.buildings) {
+      if (!want(b) || b.h < minH || b.h > maxH) continue;
+      const k = Math.round(b.x / 300) * 100000 + Math.round(b.z / 300);
+      let c = cells.get(k);
+      if (!c) cells.set(k, (c = { n: 0, x: 0, z: 0 }));
+      c.n++; c.x += b.x; c.z += b.z;
+    }
+    let best = null;
+    for (const c of cells.values()) if (!best || c.n > best.n) best = c;
+    return best ? { x: best.x / best.n, z: best.z / best.n } : { x: 0, z: 0 };
+  };
+
+  out.downtown = cluster((b) => b.h > 60, 0, 1e9);
+  out.houses = cluster((b) => b.style === 'house', 0, 1e9);
+  // A commercial frontage with a shopfront band: that is what carries signage,
+  // and it is the thing the street and shopfront shots exist to look at.
+  out.commercial = cluster(
+    (b) => (b.style === 'brick' || b.style === 'lowrise' || b.style === 'midrise')
+      && b.w > 18, 12, 45);
+
+  // Park: a patch of green mask that is fully green over a 240 m window, is
+  // inland, and is the closest such patch to downtown -- so the shot is a city
+  // park and not the forest in the corner of the map, which is where scanning
+  // from one edge and stopping at the first hit used to land it.
+  {
+    const d0 = out.downtown;
+    let best = null;
+    for (let x = -5000; x <= 5000; x += 200) {
+      for (let z = -5000; z <= 5000; z += 200) {
+        let n = 0;
+        for (let dx = -120; dx <= 120; dx += 60) {
+          for (let dz = -120; dz <= 120; dz += 60) {
+            if (G.inPark(x + dx, z + dz)) n++;
+          }
+        }
+        if (n < 25) continue;
+        const dd = (x - d0.x) * (x - d0.x) + (z - d0.z) * (z - d0.z);
+        if (!best || dd < best.dd) best = { x, z, dd };
+      }
+    }
+    out.park = best || { x: 0, z: 0 };
+  }
+
+  // Waterfront: walk west from downtown until the surface mask says water, then
+  // stand back on the land side of it.
+  {
+    const d0 = out.downtown;
+    let wx = d0.x, wz = d0.z;
+    for (let i = 0; i < 400; i++) {
+      if (G.isWater && G.isWater(wx, wz)) break;
+      wx -= 20;
+    }
+    out.waterfront = { x: wx, z: wz };
+  }
+  return JSON.stringify(out);
+})()`;
 
 function launch() {
   return spawn(CHROME, [
@@ -87,24 +159,81 @@ async function main() {
     })()`);
 
     mkdirSync(OUT, { recursive: true });
-    for (const [name, pos, look] of VIEWS) {
-      await evaluate(`(() => {
+    const picks = JSON.parse(await evaluate(PICKERS));
+    console.log('  targets: ' + Object.entries(picks)
+      .map(([k, v]) => `${k}(${v.x | 0},${v.z | 0})`).join(' '));
+
+    for (const V of VIEWS) {
+      const t = picks[V.pick];
+      // Stand back along a fixed bearing so two runs frame the same thing, and
+      // push the look-at past the subject for the street shot so the frame has
+      // a receding street in it rather than a wall.
+      const bear = 0.9;
+      const cx = t.x - Math.sin(bear) * V.back;
+      const cz = t.z - Math.cos(bear) * V.back;
+      const lx = t.x + Math.sin(bear) * V.ahead;
+      const lz = t.z + Math.cos(bear) * V.ahead;
+      const counts = await evaluate(`(() => {
         const d = window.__dbg;
-        d.world.update(${pos[0]}, ${pos[2]}, 60);
+        d.world.update(${cx}, ${cz}, 60);
         const gy = (x, z) => Math.max(0, d.city.groundAt(x, z, null));
-        const cy = gy(${pos[0]}, ${pos[2]}) + ${pos[1]};
-        const ly = gy(${look[0]}, ${look[2]}) + ${look[1]};
-        d.camera.position.set(${pos[0]}, cy, ${pos[2]});
-        d.camera.lookAt(${look[0]}, ly, ${look[2]});
+        const cy = gy(${cx}, ${cz}) + ${V.eye};
+        const ly = gy(${lx}, ${lz}) + ${V.look};
+        d.camera.position.set(${cx}, cy, ${cz});
+        d.camera.lookAt(${lx}, ly, ${lz});
         d.camera.updateMatrixWorld(true);
-        d.sun.position.set(${pos[0]} - 160, cy + 240, ${pos[2]} - 110);
-        d.sun.target.position.set(${look[0]}, ly, ${look[2]});
+        // The sun is a DIRECTION, and it has to be the game's direction.
+        //
+        // Aiming it from the camera at the look-at point works by accident for
+        // a close shot and is badly wrong for a far one: on the 2400 m skyline
+        // view the light ended up 240 m above a target 2400 m away, which is a
+        // sun 5.7 deg above the horizon. Every up-facing surface in the aerial
+        // was getting a tenth of the key, and the whole mid-ground rendered as
+        // a black band -- read for four passes as an albedo problem, then as a
+        // missing ambient term, and it was neither.
+        //
+        // main.js uses an offset of (-215, 200, -150) from the point of
+        // interest, about 38 deg. Reproduce it exactly, anchored partway into
+        // the shot so the shadow box covers what is in frame.
+        const ax = ${cx} + (${lx} - ${cx}) * 0.25, az = ${cz} + (${lz} - ${cz}) * 0.25;
+        const ay = gy(ax, az);
+        d.sun.position.set(ax - 215, ay + 200, az - 150);
+        d.sun.target.position.set(ax, ay, az);
         d.sun.target.updateMatrixWorld();
+        // Populate the shot. The game is paused so the camera can be flown, and
+        // traffic only spawns from its own update -- so every shot used to come
+        // back with an empty city and the world-density read was the harness's,
+        // not the game's. Seed around the VIEW, not the player.
+        const dir = new d.THREE.Vector3(${lx} - ${cx}, 0, ${lz} - ${cz}).normalize();
+        d.traffic.updateParked(${cx}, ${cz});
+        for (let i = 0; i < 26; i++) d.traffic.spawnTraffic(${cx}, ${cz}, dir);
+        if (d.peds && d.peds.spawn) for (let i = 0; i < 40; i++) d.peds.spawn(${cx}, ${cz});
+        // Spawning sets logical positions; the MESHES are only moved by each
+        // system's update, which the pause stops from ever running. Without
+        // these steps the shot counted a dozen cars in frame and rendered
+        // none of them -- the counts were right and the picture was empty.
+        for (let i = 0; i < 4; i++) {
+          d.traffic.update(0.016, ${cx}, ${cz}, dir, d.player);
+          d.peds.update(0.016, ${cx}, ${cz}, d.player, d.traffic);
+        }
+        // Count what is actually IN FRAME, so a density claim is a number and
+        // not an impression. Anything else is scoring the harness.
+        d.scene.updateMatrixWorld(true);
+        const fr = new d.THREE.Frustum().setFromProjectionMatrix(
+          new d.THREE.Matrix4().multiplyMatrices(
+            d.camera.projectionMatrix, d.camera.matrixWorldInverse));
+        const v = new d.THREE.Vector3();
+        const inView = (x, y, z) => fr.containsPoint(v.set(x, y, z));
+        let cars = 0, people = 0;
+        for (const c of d.traffic.cars) if (inView(c.x, c.y + 1, c.z)) cars++;
+        for (const p of d.peds.peds) if (inView(p.x, p.y + 1, p.z)) people++;
+        return JSON.stringify({ cars, people });
       })()`);
       await sleep(9000);
       const { result } = await send('Page.captureScreenshot', { format: 'png' });
-      writeFileSync(`${OUT}/${name}.png`, Buffer.from(result.data, 'base64'));
-      console.log(`  ${OUT}/${name}.png`);
+      writeFileSync(`${OUT}/${V.name}.png`, Buffer.from(result.data, 'base64'));
+      const c = JSON.parse(counts);
+      console.log(`  ${OUT}/${V.name}.png  in frame: ${c.cars} vehicles, ${c.people} pedestrians`);
     }
     const stats = await evaluate('({calls: __dbg.sceneStats.calls, tris: __dbg.sceneStats.tris})');
     console.log(`  scene: ${stats.calls} draws, ${stats.tris} triangles`);

--- a/tools/values.py
+++ b/tools/values.py
@@ -1,0 +1,54 @@
+"""Value structure of a beauty shot, in LINEAR luminance.
+
+    tools/.venv/bin/python tools/values.py <tag> [tag2]
+
+Four passes of albedo tuning were spent on what turned out to be a missing
+ambient term, because everything was being judged from the raw scene pass or by
+eye. The post chain -- AO, grade, vignette -- is a large part of the final value
+structure, so the only honest measurement is of the composited PNG.
+
+Reports the lower half of the frame (the ground/urban fabric, not the sky) and
+the ratio between the lit and shadowed quartiles, which is the number that says
+whether shadow is reading as shade or as night. Daylight open-worlds of the
+target era ran roughly 2.2-3.3:1.
+"""
+import sys
+from pathlib import Path
+from PIL import Image
+
+def to_linear(v):
+    v /= 255.0
+    return v / 12.92 if v <= 0.04045 else ((v + 0.055) / 1.055) ** 2.4
+
+LUT = [to_linear(i) for i in range(256)]
+
+def stats(path):
+    im = Image.open(path).convert('RGB')
+    w, h = im.size
+    px = im.load()
+    lum = []
+    for y in range(h // 2, h, 2):
+        for x in range(0, w, 2):
+            r, g, b = px[x, y]
+            lum.append(0.2126 * LUT[r] + 0.7152 * LUT[g] + 0.0722 * LUT[b])
+    lum.sort()
+    n = len(lum)
+    q = lambda p: lum[int(n * p)]
+    lo = lum[: n // 4]
+    hi = lum[3 * n // 4 :]
+    shadow = lo[len(lo) // 2]
+    lit = hi[len(hi) // 2]
+    clipped = sum(1 for y in range(0, h, 2) for x in range(0, w, 2)
+                  if min(px[x, y]) > 250) / ((h // 2) * (w // 2))
+    return dict(p5=q(0.05), median=q(0.5), p95=q(0.95),
+                shadow=shadow, lit=lit, ratio=lit / max(shadow, 1e-5),
+                clip=clipped * 100)
+
+for tag in sys.argv[1:]:
+    d = Path('tools/data/beauty') / tag
+    print(f'--- {tag}')
+    print(f'{"shot":<12}{"p5":>8}{"median":>9}{"p95":>8}{"shadowQ":>9}{"litQ":>8}{"ratio":>7}{"clip%":>7}')
+    for p in sorted(d.glob('*.png')):
+        s = stats(p)
+        print(f'{p.stem:<12}{s["p5"]:>8.4f}{s["median"]:>9.4f}{s["p95"]:>8.4f}'
+              f'{s["shadow"]:>9.4f}{s["lit"]:>8.4f}{s["ratio"]:>7.1f}{s["clip"]:>7.2f}')

--- a/tools/values.py
+++ b/tools/values.py
@@ -40,15 +40,26 @@ def stats(path):
     lit = hi[len(hi) // 2]
     clipped = sum(1 for y in range(0, h, 2) for x in range(0, w, 2)
                   if min(px[x, y]) > 250) / ((h // 2) * (w // 2))
+    # Mean HSV saturation of the same region. ACES desaturates saturated hues,
+    # and greens worst -- once the curve was actually running, foliage that had
+    # been tuned against no curve at all came out as pale sage.
+    sat, n2 = 0.0, 0
+    for y in range(h // 2, h, 4):
+        for x in range(0, w, 4):
+            r, g, b = px[x, y]
+            mx, mn = max(r, g, b), min(r, g, b)
+            sat += 0.0 if mx == 0 else (mx - mn) / mx
+            n2 += 1
     return dict(p5=q(0.05), median=q(0.5), p95=q(0.95),
                 shadow=shadow, lit=lit, ratio=lit / max(shadow, 1e-5),
-                clip=clipped * 100)
+                clip=clipped * 100, sat=sat / n2)
 
 for tag in sys.argv[1:]:
     d = Path('tools/data/beauty') / tag
     print(f'--- {tag}')
-    print(f'{"shot":<12}{"p5":>8}{"median":>9}{"p95":>8}{"shadowQ":>9}{"litQ":>8}{"ratio":>7}{"clip%":>7}')
+    print(f'{"shot":<12}{"p5":>8}{"median":>9}{"p95":>8}{"shadowQ":>9}{"litQ":>8}{"ratio":>7}{"clip%":>7}{"sat":>7}')
     for p in sorted(d.glob('*.png')):
         s = stats(p)
         print(f'{p.stem:<12}{s["p5"]:>8.4f}{s["median"]:>9.4f}{s["p95"]:>8.4f}'
-              f'{s["shadow"]:>9.4f}{s["lit"]:>8.4f}{s["ratio"]:>7.1f}{s["clip"]:>7.2f}')
+              f'{s["shadow"]:>9.4f}{s["lit"]:>8.4f}{s["ratio"]:>7.1f}{s["clip"]:>7.2f}'
+              f'{s["sat"]:>7.3f}')


### PR DESCRIPTION
A large visual pass on `apps/auto`, judged against measured values rather than
by eye. Build **v30** (`auto-v30`).

## Before / after

Both sets were captured by the **same** harness, the "before" run against a
worktree at `ba97034` — the commit this branch starts from. Framing, sun
direction and population seeding are identical between the two, which they would
not be if older captures had been reused. Images live on the `pr-343-shots`
branch so they stay out of the source history.

<details open><summary><b>Street level</b></summary>

![shopfront](https://raw.githubusercontent.com/maattp/maattp.github.io/pr-343-shots/auto/shopfront.jpg)

![street](https://raw.githubusercontent.com/maattp/maattp.github.io/pr-343-shots/auto/street.jpg)

</details>

<details><summary><b>Residential and park</b></summary>

![residential](https://raw.githubusercontent.com/maattp/maattp.github.io/pr-343-shots/auto/residential.jpg)

![park](https://raw.githubusercontent.com/maattp/maattp.github.io/pr-343-shots/auto/park.jpg)

</details>

<details><summary><b>Aerial and water</b></summary>

![downtown](https://raw.githubusercontent.com/maattp/maattp.github.io/pr-343-shots/auto/downtown.jpg)

![waterfront](https://raw.githubusercontent.com/maattp/maattp.github.io/pr-343-shots/auto/waterfront.jpg)

![skyline](https://raw.githubusercontent.com/maattp/maattp.github.io/pr-343-shots/auto/skyline.jpg)

</details>

Worth looking at specifically: the candy palette and the cartoon conifer are
gone; brick reads as brick rather than as a tint of stone; windows are glazing
instead of black holes; shopfronts, fascia signs and street clutter exist at all;
and the sky is no longer combed with horizontal bands.

Measured, before → after (`tools/values.py`, linear luminance, lit-to-shadow
ratio — target band 2.2–3.3:1):

| shot | before | after |
|---|---|---|
| shopfront | 17.4 | **7.2** |
| residential | 15.1 | **4.5** |
| waterfront | 8.9 | **3.5** |
| downtown | 8.5 | **7.3** |
| street | 3.1 | **2.4** |
| park | 1.6 | **1.4** |
| skyline | 6.3 | **10.9** |

`skyline` is the one shot that moved the wrong way, and it is a real
regression rather than a measurement artefact: height-falloff fog stops washing
distant ground toward the sky, so the deep shade between towers in the aerial now
sits lower than it did. The street-level shots are where the work was aimed and
they are all inside or near the band.

Mean frame saturation is **lower** after, deliberately: the "before" build had
no tone curve in front of it at all, which is why its park measured 0.568 and
read as AstroTurf. ACES then took roughly a third of the chroma back out, which
is over-correction the other way, so the grade pays part of it back — park lands
at 0.470. Conifers carry their own colour rather than sharing one foliage value
with the broadleaf and scrub crowns; sharing left the firs at the same value as
the lawn they stand on.

## Tone mapping was never running

`WebGLRenderer` applies `toneMapping` only when the current render target is
null — when it draws straight to the canvas — or when the target is flagged
`isXRRenderTarget`. The whole scene is drawn into postfx's 8-bit target, so
**ACES and `toneMappingExposure` had never run**, despite `CLAUDE.md` documenting
the pipeline as tone-mapped during the scene pass.

Three consequences, each of which had been chased as something else:

- Highlights had no shoulder and hard-clipped to flat 255 plateaus with a
  four-pixel edge. They read as missing textures on the glass towers, and no
  amount of pulling material values down addressed the class of the problem.
- The scene floor sat where the toe should have been, so light added at the
  source was eaten before reaching the framebuffer — hemisphere and ambient
  pushed 2.6× bought 1.6× on screen — and several value bugs were attacked
  through albedo instead.
- Exposure was a dial connected to nothing. Moving it 1.02 → 1.55 changed the
  measured output by under a thousandth of a stop, which is what gave it away.

Flagging the scene target is the only way to get the curve applied before an
8-bit target quantises the highlights. Pinned to the vendored r160; re-check on
a three bump. The light rig was then re-tuned against measured values: exposure
0.46, key 4.3, hemisphere 0.72, ambient 0.36.

Measured on the composited frames (`tools/values.py`, linear luminance):

| shot | median | shadowQ | litQ | ratio | clip% |
|---|---|---|---|---|---|
| street | 0.0859 | 0.0676 | 0.1622 | 2.4 | 0.00 |
| waterfront | 0.0989 | 0.0513 | 0.1814 | 3.5 | 0.00 |
| residential | 0.1340 | 0.0483 | 0.2151 | 4.5 | 0.00 |
| park | 0.2021 | 0.1604 | 0.2270 | 1.4 | 0.00 |

Lit-to-shadow was 13.8:1 before this work; a daylight open world of this era
runs 2.2–3.3:1. Clipped pixels are zero in every shot, against 1.15 % of the
downtown frame.

## Shadows

The shadow map's ortho box was 190 m. Shadowing simply stops at its edge, so a
tower's shadow was sliced off mid-facade in a straight vertical line with no
bottom — reported as a black band and diagnosed three times as a material fault.
The proof it was the box: widening it turns previously **lit** pixels dark, which
no real shadow does. 260 m now, higher far plane, aimed 90 m down the view
instead of at the player's feet.

## Facades

- `masonrySurface()` is parameterised and called twice, for stone and for a real
  **brick** surface with a running bond and its own mortar colour. One texture
  with one per-building tint could not express brick against stone — concrete,
  stucco and red brick were three values of the same material. Eight named
  families now carry their own hue **and** their own material.
- Glazing was `rgb(36,48,58)` and then multiplied by the family tint, so on red
  brick the windows resolved to `(29,18,16)`: solid black holes, on brick
  buildings only. Panes start bright — a daylight window is mostly a sky
  reflection — with blinds at varying heights, dark-interior units and AC boxes.
- The masonry "courses" were 32 per tile over 13.6 m: 42 cm grooves, which is
  clapboard lapped onto masonry. Replaced with fine grain and one spandrel band
  per storey.
- The shopfront band was the curtain-wall texture at 9 m/tile, so every
  commercial building wore 1.1 m blue fish-scales at eye level.

## Signage

New procedural 4×4 atlas of fascia plates — plate colour, block wordmarks, ~20 %
illuminated, grime along the bottom lip. Placed as shopfront fascias, projecting
blade signs and rooftop billboards; one draw call per chunk.

## Ground and street

- Asphalt patches were at 3 % alpha, under one 8-bit step and therefore
  invisible. Real patches, crack seams with a height notch, a polished centre
  falling to grime at the kerbs, and a gutter strip registered to the kerb face.
- Sidewalks get a large-scale stain layer and per-piece value jitter.
- Second clutter pass at ~22 m: hydrants, bins, meters, mailboxes, signs,
  bollards. Kerbside parking occupancy 0.32 → 0.48, `MAX_PEDS` 26 → 34, and the
  minimum pedestrian spawn distance 26 m → 15 m, which had been leaving the
  pavement directly in front of the player permanently empty.

## Trees are solid, and stop growing through buildings

Until now the **only** solid thing in the entire map was a building. Trunks and
poles are registered into a per-chunk obstacle store and collided against by both
vehicles and the player on foot. Verified: a car at 16 m/s into a pole stops
1.74 m short instead of driving through.

Greenspace and footprints are separate OSM layers and they overlap — park
polygons are mapped straight over the building standing in them, so `inPark()`
says yes in the middle of a museum. 9.3 % of surviving park-tree candidates stood
inside a footprint; now filtered.

`Builder.prism` is an open drum, so a squashed one is a band of vertical wall
with no top or bottom — the green slab canopies rendered as. Added a closed
`spheroid`; crowns are lobed spheroids, shared by park and street trees.

## Also

Height-falloff fog patched into three's fog chunks (the scale height is a shader
constant, not a uniform: `ShaderLib` copies `UniformsLib.fog` at module
evaluation). Sky cloud generator rewritten — 390 ellipses squashed to a fifteenth
of their width stacked into horizontal streaks across the equirect and had twice
been blamed on dither in the post chain. Water behaves as a dielectric so the
shore-to-horizon gradient comes from Fresnel rather than fog. Tower crowns on the
far skyline mesh (fitted inside the building's own height — built on top, the
penthouse stood proud of the real roofline and every tall building wore an
untextured box above its roof). Roof kit, bilateral depth-aware SSAO blur, two
grass tones.

## Tools

- `tools/beauty.mjs` picks its views from the map instead of from coordinates
  written down months ago — the shot named `park` contained no park. It seeds
  **and steps** traffic and pedestrians (spawning sets logical positions; only
  each system's `update()` moves the meshes, so shots counted a dozen vehicles
  and drew none), reports in-frustum counts, and uses the game's own sun
  direction. It had been aiming the sun from the camera at the look-at point,
  which on the 2400 m skyline shot put it 5.7° above the horizon.
- `tools/values.py` reports the linear value structure of a shot. The post chain
  is part of that structure, so neither the raw scene pass nor the eye is a
  usable judge of where the shadows sit.

## Known gaps

Geometric window reveals (facades are still flat extrusions), planar water
reflection, park ground dressing (paths, undergrowth, rocks), a second sky
octave. The aerial views still run ~11:1 in the deep shade between towers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B


