### PR TITLE
Auto: performance cuts and a debug switch for every screen-space pass

### DIFF
--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -292,6 +292,13 @@
     white-space: pre;
   }
   #debugStats.on { display: block; }
+  .dbgrid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 6px; margin: 2px 0 10px; }
+  .dbg {
+    font: 600 11px/1 ui-sans-serif, system-ui; padding: 8px 4px; border-radius: 8px;
+    border: 1px solid rgba(255,255,255,0.16); background: rgba(255,255,255,0.06);
+    color: #97a2ad; -webkit-tap-highlight-color: transparent;
+  }
+  .dbg.on { background: rgba(90,190,140,0.22); border-color: rgba(90,190,140,0.5); color: #dff3e8; }
 </style>
 </head>
 <body>
@@ -369,6 +376,20 @@
       <div class="row"><span>Sound effects</span><div class="toggle" id="setSound"></div></div>
       <div class="row"><span>Camera speed</span><input type="range" id="setSens" min="0.4" max="2.2" step="0.1" value="1"></div>
       <div class="row"><span>Debug stats</span><div class="toggle" id="setDebug"></div></div>
+      <!-- One switch per screen-space pass. A single "post on/off" cannot answer
+           "which of these is hazing the picture", and that is the question that
+           actually gets asked. -->
+      <div class="row"><span>Post effects</span><div class="toggle" id="setPost"></div></div>
+      <div class="dbgrid">
+        <button class="dbg on" data-fx="bloom">Bloom</button>
+        <button class="dbg on" data-fx="ssao">SSAO</button>
+        <button class="dbg on" data-fx="grade">Grade</button>
+        <button class="dbg on" data-fx="vignette">Vignette</button>
+        <button class="dbg on" data-fx="grain">Grain</button>
+        <button class="dbg on" data-fx="dither">Dither</button>
+        <button class="dbg on" data-fx="fxaa">FXAA</button>
+        <button class="dbg on" data-world="fog">Fog</button>
+      </div>
       <p class="help">
         Left thumb steers and walks. Right side: drag to look, buttons to drive.
         Walk up to any car and hit ENTER to take it. Deliveries pay — the gold ring
@@ -393,7 +414,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v33</div>
+    <div id="build">v34</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/src/main.js
+++ b/apps/auto/src/main.js
@@ -23,6 +23,11 @@ const loadBar = document.getElementById('loadBar');
 const loadMsg = document.getElementById('loadMsg');
 const loading = document.getElementById('loading');
 
+// One definition of "is this a phone", used by the light rig, the starting
+// quality tier and the pixel-ratio cap. Three separate copies of this test had
+// already started to drift.
+const ON_PHONE = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+
 const STAR_POINTS = [0, 30, 90, 190, 340, 560];
 const HOSPITAL = G.RESPAWN; // kept clear of buildings by citygen, via G.KEEP_CLEAR
 
@@ -46,6 +51,7 @@ class Game {
       sound: true,
       sensitivity: 1,
       debug: false,
+      post: true,
     };
   }
 
@@ -264,7 +270,11 @@ async function boot() {
   const viewH = () => canvas.clientHeight || window.innerHeight;
   renderer.setSize(viewW(), viewH(), false);
   renderer.shadowMap.enabled = true;
-  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+  // PCFSoft is the most expensive filter three offers and it is a fill-rate
+  // cost paid on every shadowed pixel. On a phone that is not where the budget
+  // should go; plain PCF is a fraction of the cost and the difference at this
+  // resolution is a slightly harder shadow edge.
+  renderer.shadowMap.type = ON_PHONE ? THREE.PCFShadowMap : THREE.PCFSoftShadowMap;
   renderer.outputColorSpace = THREE.SRGBColorSpace;
 
 /**
@@ -320,7 +330,7 @@ function installHeightFog() {
   // than giving it depth. Aerial perspective should separate planes, not erase
   // them, and the fog is tinted slightly cooler than the horizon so towers
   // still read against it.
-  scene.fog = new THREE.FogExp2(0xb9c3cf, 0.00040);
+  scene.fog = new THREE.FogExp2(0xb9c3cf, 0.00026);
   installHeightFog();
   camera = new THREE.PerspectiveCamera(62, viewW() / viewH(), 0.5, 9000);
 
@@ -355,9 +365,13 @@ function installHeightFog() {
   // shot has a lit face and a shadowed one.
   sun.position.set(-215, 200, -150);
   sun.castShadow = true;
-  sun.shadow.mapSize.set(2048, 2048);
+  sun.shadow.mapSize.set(ON_PHONE ? 1024 : 2048, ON_PHONE ? 1024 : 2048);
   sun.shadow.camera.near = 20;
-  sun.shadow.camera.far = 1150;
+  // 1150 was set to stop tall casters falling out of the frustum at the box
+  // edge. That is still the reason, but the far plane costs geometry in the
+  // shadow pass every frame, and the pass measured 152 draw calls and 318k
+  // triangles -- a third of the whole frame.
+  sun.shadow.camera.far = 980;
   // 105 m covered barely a block: buildings cast no shadow on the streets they
   // line, which is most of why the city read as flat. 190 m reaches across a
   // downtown block and its far side at the cost of shadow-map resolution,
@@ -374,7 +388,7 @@ function installHeightFog() {
   // 260 m at 2048 is 0.25 m per texel, which is inside the range this era of
   // console shadow ran at. `far` goes up with it, or tall casters fall out of
   // the frustum at the same edge for the same reason.
-  const S = 260;
+  const S = ON_PHONE ? 190 : 260;
   sun.shadow.camera.left = -S;
   sun.shadow.camera.right = S;
   sun.shadow.camera.top = S;
@@ -383,7 +397,7 @@ function installHeightFog() {
   // back as dark blotches across sunlit facades. normalBias scales with texel
   // size, so it goes up whenever S does.
   sun.shadow.bias = -0.0006;
-  sun.shadow.normalBias = 0.12;
+  sun.shadow.normalBias = ON_PHONE ? 0.09 : 0.12;
   scene.add(sun);
   scene.add(sun.target);
 
@@ -444,7 +458,10 @@ function installHeightFog() {
   window.__dbg = { game, city, player, world, traffic, peds, scene, camera, renderer, G, fx, hud, controls, audio, pickups, THREE, postfx, applyQuality, sun, sceneStats, cityStats, animateWalk, collideWithBuildings, TYPES: VEHICLE_TYPES };
   wireUi();
   game.newTarget();
-  applyQuality('high', false);
+  // A phone starts on medium. `high` was only ever reachable downward, so
+  // every player paid 2.5 s of stutter to discover their device could not run
+  // the desktop preset.
+  applyQuality(ON_PHONE ? 'medium' : 'high', false);
   startedAt = performance.now();
   loading.classList.add('hide');
   setTimeout(() => loading.remove(), 700);
@@ -770,6 +787,25 @@ function wireUi() {
   bind('setMusic', 'music', (v) => { audio.musicOn = v; });
   bind('setSound', 'sound', (v) => { audio.enabled = v; });
   bind('setDebug', 'debug', (v) => { debugEl.classList.toggle('on', v); });
+  bind('setPost', 'post', (v) => { postfx.setPostEnabled(v); });
+
+  // Per-pass switches. `scene.fog` is nulled rather than zeroed because the fog
+  // term is compiled into every material -- setting density to 0 still pays for
+  // it, and the question being answered is what things cost as well as what
+  // they look like.
+  let savedFog = null;
+  for (const b of document.querySelectorAll('.dbg')) {
+    b.addEventListener('click', () => {
+      const on = !b.classList.contains('on');
+      b.classList.toggle('on', on);
+      if (b.dataset.fx) postfx.setFx(b.dataset.fx, on);
+      else if (b.dataset.world === 'fog') {
+        if (on) { scene.fog = savedFog || scene.fog; }
+        else { savedFog = scene.fog; scene.fog = null; }
+        scene.traverse((o) => { if (o.material) o.material.needsUpdate = true; });
+      }
+    });
+  }
 
   const sens = document.getElementById('setSens');
   sens.addEventListener('input', () => {
@@ -1013,8 +1049,11 @@ function autoQuality(dt) {
   if (qualityLocked || tierIdx >= TIERS.length - 1) return;
   if (performance.now() - startedAt < 4000) return;
   if (window.__noAutoQuality) return;
-  slowFor = fps < 40 ? slowFor + dt : 0;
-  if (slowFor > 2.5) {
+  slowFor = fps < 45 ? slowFor + dt : 0;
+  // 2.5 s at under 40 fps is a long time to be stuttering before anything
+  // happens, and 40 is already well into "feels wrong" -- by the time it fired
+  // the player had formed an opinion.
+  if (slowFor > 1.2) {
     slowFor = 0;
     applyQuality(TIERS[++tierIdx], false);
     hud.showToast(`Graphics: ${TIERS[tierIdx]}`);
@@ -1022,12 +1061,19 @@ function autoQuality(dt) {
 }
 
 function applyQuality(q, manual) {
-  if (manual) { qualityLocked = true; tierIdx = TIERS.indexOf(q); }
+  if (manual) qualityLocked = true;
+  // Keep the ladder position in step whether the change was manual or not --
+  // starting a phone on `medium` with tierIdx still at 0 made the first
+  // automatic step down re-apply medium and waste a rung.
+  tierIdx = Math.max(0, TIERS.indexOf(q));
   game.settings.quality = q;
   postfx.setQuality(q);
   renderer.shadowMap.enabled = q !== 'low' && game.settings.shadows;
-  const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
-  const cap = q === 'high' ? (isMobile ? 2 : 1.6) : q === 'medium' ? 1.5 : 1.15;
+  // Pixel ratio is the single biggest fill-rate dial there is: 2.0 against
+  // 1.45 is 1.9x the pixels through every one of the post chain's fullscreen
+  // passes. A phone was capped at 2 on `high`, which is where most of the cost
+  // went.
+  const cap = q === 'high' ? (ON_PHONE ? 1.45 : 1.6) : q === 'medium' ? (ON_PHONE ? 1.3 : 1.5) : 1.15;
   renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, cap));
   renderer.setSize(renderer.domElement.clientWidth, renderer.domElement.clientHeight, false);
   postfx.setSize(renderer.domElement.clientWidth, renderer.domElement.clientHeight, renderer.getPixelRatio());

--- a/apps/auto/src/peds.js
+++ b/apps/auto/src/peds.js
@@ -644,7 +644,7 @@ export function animateWalk(h, amp, dt, speed) {
 // nobody on it at any given moment. Characters are one draw call each -- the
 // cheapest population in the game -- so this is the least expensive density
 // there is to buy.
-const MAX_PEDS = 34;
+const MAX_PEDS = 24;
 const PED_RADIUS = 150;
 
 export class PedSystem {

--- a/apps/auto/src/postfx.js
+++ b/apps/auto/src/postfx.js
@@ -91,6 +91,8 @@ uniform float vignette;
 uniform float grain;
 uniform float time;
 uniform float fxaa;
+uniform float grade;
+uniform float dither;
 uniform sampler2D tAO;
 uniform float aoAmount;
 varying vec2 vUv;
@@ -131,6 +133,7 @@ void main() {
   }
   c += texture2D(tBloom, vUv).rgb * bloomStrength;
 
+  if (grade > 0.5) {
   // Toe and shoulder.
   //
   // The grade was a smoothstep, which is symmetric: it pushed the shadows
@@ -139,8 +142,8 @@ void main() {
   // both ends of the image carried no separation at all. A toe that only acts
   // on the darkest values keeps detail out of the crush; a shoulder that only
   // acts above the knee keeps the bright faces from flattening.
-  c += vec3(0.024) * pow(1.0 - c, vec3(4.0));
-  c -= vec3(0.20) * pow(max(c - 0.52, vec3(0.0)), vec3(1.5));
+  c += vec3(0.010) * pow(1.0 - c, vec3(4.0));
+  c -= vec3(0.09) * pow(max(c - 0.62, vec3(0.0)), vec3(1.5));
   c = mix(c, c * c * (3.0 - 2.0 * c), 0.05);
   // Saturation compensation for ACES.
   //
@@ -154,6 +157,7 @@ void main() {
   c = mix(vec3(dot(c, vec3(0.2126, 0.7152, 0.0722))), c, 1.45);
   c += vec3(-0.008, 0.0, 0.014) * (1.0 - c);
   c *= vec3(1.015, 1.0, 0.985);
+  }
 
   float d = distance(vUv, vec2(0.5));
   c *= 1.0 - vignette * smoothstep(0.35, 0.95, d);
@@ -170,7 +174,7 @@ void main() {
   vec2 px = vUv / texel + vec2(fract(time * 71.0) * 977.0, fract(time * 53.0) * 331.0);
   float n1 = fract(sin(dot(floor(px), vec2(12.9898, 78.233))) * 43758.5453);
   float n2 = fract(sin(dot(floor(px) + 17.0, vec2(39.3468, 11.135))) * 24634.6345);
-  c += (n1 - n2) * (0.5 / 255.0) + (n1 - 0.5) * grain;
+  c += dither * ((n1 - n2) * (0.5 / 255.0)) + (n1 - 0.5) * grain;
 
   gl_FragColor = vec4(clamp(c, 0.0, 1.0), 1.0);
 }`;
@@ -273,6 +277,13 @@ export class PostFX {
     this.scenePass = new THREE.Scene();
     this.quadScene = new THREE.Scene();
 
+    this.fx = { bloom: true, ssao: true, grain: true, vignette: true, fxaa: true, grade: true, dither: true };
+    this.base = { bloom: 0.34, grain: 0.0025, vignette: 0.10, fxaa: 1, ao: 1.0 };
+    this.bloomPasses = 2;
+    // Set by the pause-menu switch; kept apart from the tier so a debug session
+    // survives an automatic quality change.
+    this.forceOff = false;
+    this._tierEnabled = true;
     this.sceneRT = makeRT(2, 2, true);
     // Make three tone-map INTO this target.
     //
@@ -324,11 +335,13 @@ export class PostFX {
     this.composite = pass(COMPOSITE, {
       tScene: { value: null }, tBloom: { value: null },
       texel: { value: new THREE.Vector2() },
-      bloomStrength: { value: 0.62 },
-      vignette: { value: 0.15 },
-      grain: { value: 0.005 },
+      bloomStrength: { value: 0.34 },
+      vignette: { value: 0.10 },
+      grain: { value: 0.0025 },
       time: { value: 0 },
       fxaa: { value: 1 },
+      grade: { value: 1 },
+      dither: { value: 1 },
       tAO: { value: null },
       aoAmount: { value: 1.0 },
     });
@@ -369,7 +382,7 @@ export class PostFX {
       r.render(mesh.userData.scene, CAM);
     };
 
-    if (this.ssaoOn && camera) {
+    if (this.ssaoOn && this.fx.ssao && camera) {
       const su = this.ssao.material.uniforms;
       su.tDepth.value = this.sceneRT.depthTexture;
       su.proj.value.copy(camera.projectionMatrix);
@@ -388,11 +401,12 @@ export class PostFX {
       this.composite.material.uniforms.tAO.value = this.aoA.texture;
     }
 
+    if (this.fx.bloom) {
     this.bright.material.uniforms.tScene.value = this.sceneRT.texture;
     draw(this.bright, this.bloomA);
 
     const bu = this.blur.material.uniforms;
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < this.bloomPasses; i++) {
       const spread = 1 + i * 1.6;
       bu.tSrc.value = this.bloomA.texture;
       bu.dir.value.set(spread / this._bw, 0);
@@ -400,6 +414,7 @@ export class PostFX {
       bu.tSrc.value = this.bloomB.texture;
       bu.dir.value.set(0, spread / this._bh);
       draw(this.blur, this.bloomA);
+    }
     }
 
     const cu = this.composite.material.uniforms;
@@ -416,18 +431,54 @@ export class PostFX {
     QUAD.dispose();
   }
 
-  setQuality(q) {
+  /**
+   * Individual effect switches, for finding out which pass is responsible for
+   * something. A single "post on/off" is no use when the question is *which*
+   * of eight screen-space passes is putting a haze over the picture -- the only
+   * way to answer that is to turn them off one at a time while looking at it.
+   *
+   * Quality sets the BASE strengths; these flags gate them. Keeping the two
+   * separate matters because `setQuality` runs on every tier change and would
+   * otherwise wipe whatever was being debugged.
+   */
+  /** Master switch for the whole chain, independent of the quality tier. */
+  setPostEnabled(on) {
+    this.forceOff = !on;
+    this.enabled = this._tierEnabled && !this.forceOff;
+  }
+
+  setFx(name, on) {
+    this.fx[name] = on;
+    this.applyFx();
+  }
+
+  applyFx() {
     const cu = this.composite.material.uniforms;
-    this.enabled = q !== 'low';
+    const f = this.fx;
+    cu.bloomStrength.value = f.bloom ? this.base.bloom : 0;
+    cu.grain.value = f.grain ? this.base.grain : 0;
+    cu.vignette.value = f.vignette ? this.base.vignette : 0;
+    cu.fxaa.value = f.fxaa ? this.base.fxaa : 0;
+    cu.grade.value = f.grade ? 1 : 0;
+    cu.dither.value = f.dither ? 1 : 0;
+    cu.aoAmount.value = this.ssaoOn && f.ssao ? this.base.ao : 0;
+  }
+
+  setQuality(q) {
+    this.enabled = q !== 'low' && !this.forceOff;
+    this._tierEnabled = q !== 'low';
     // FXAA is a single fullscreen tap and the context has no MSAA, so keep it on
     // for medium too -- dropping it entirely was a visible edge-quality cliff.
-    cu.fxaa.value = q === 'low' ? 0 : 1;
-    cu.bloomStrength.value = q === 'high' ? 0.62 : 0.5;
+    this.base.fxaa = q === 'low' ? 0 : 1;
+    this.base.bloom = q === 'high' ? 0.34 : 0.26;
+    // Three blur iterations is six fullscreen passes. Two is most of the look
+    // for two thirds of the fill cost, and fill is what a phone runs out of.
+    this.bloomPasses = q === 'high' ? 2 : 1;
     // Film grain is separate from the dither and much larger; at 0.016 it was
     // reading as texture across the sky now that the dither is per-pixel.
-    cu.grain.value = q === 'high' ? 0.005 : 0;
+    this.base.grain = q === 'high' ? 0.0025 : 0;
     // SSAO is the most expensive pass here, so it is the first thing to go.
     this.ssaoOn = q === 'high';
-    cu.aoAmount.value = this.ssaoOn ? 1.0 : 0.0;
+    this.applyFx();
   }
 }

--- a/apps/auto/src/textures.js
+++ b/apps/auto/src/textures.js
@@ -469,9 +469,9 @@ function roadSurface() {
   // Patches, repairs and crack seams. These were at 3% alpha, which is under
   // one 8-bit step -- literally invisible, so the asphalt was uniform pepper
   // noise over a flat value. Greyscale only, so the tarmac never tints.
-  for (let i = 0; i < 22; i++) {
-    const l = r() > 0.5 ? 210 : 40;
-    a.g.fillStyle = `rgba(${l},${l},${l},${0.05 + r() * 0.07})`;
+  for (let i = 0; i < 8; i++) {
+    const l = r() > 0.5 ? 190 : 70;
+    a.g.fillStyle = `rgba(${l},${l},${l},${0.03 + r() * 0.03})`;
     const pw = 40 + r() * 130, ph = 20 + r() * 70;
     const px = r() * S, py = r() * S;
     a.g.fillRect(px, py, pw, ph);
@@ -480,28 +480,26 @@ function roadSurface() {
     rgh.g.fillStyle = grey(0.5 + r() * 0.3);
     rgh.g.fillRect(px, py, pw, ph);
   }
-  // Crack seams: thin dark lines with a height notch, so they catch the key
-  // light at a grazing angle instead of being a flat decal.
-  for (let i = 0; i < 30; i++) {
+  // Crack seams: a FEW, faint.
+  //
+  // This was 30 seams per tile at 50 % opacity. The tile repeats every few
+  // metres of road, so the whole city ended up under a dense net of black
+  // squiggles and the tarmac read as dried mud rather than asphalt. A road has
+  // the odd seam, not a craquelure.
+  for (let i = 0; i < 5; i++) {
     let cx = r() * S, cy = r() * S;
     let ang = r() * Math.PI * 2;
-    a.g.strokeStyle = 'rgba(18,18,20,0.5)';
-    a.g.lineWidth = 1 + r();
+    a.g.strokeStyle = 'rgba(38,38,42,0.20)';
+    a.g.lineWidth = 1 + r() * 0.6;
     a.g.beginPath();
     a.g.moveTo(cx, cy);
-    hgt.g.strokeStyle = grey(0.2);
-    hgt.g.lineWidth = 2;
-    hgt.g.beginPath();
-    hgt.g.moveTo(cx, cy);
-    for (let k = 0; k < 5; k++) {
-      ang += (r() - 0.5) * 1.1;
-      cx += Math.cos(ang) * (10 + r() * 24);
-      cy += Math.sin(ang) * (10 + r() * 24);
+    for (let k = 0; k < 4; k++) {
+      ang += (r() - 0.5) * 0.9;
+      cx += Math.cos(ang) * (14 + r() * 26);
+      cy += Math.sin(ang) * (14 + r() * 26);
       a.g.lineTo(cx, cy);
-      hgt.g.lineTo(cx, cy);
     }
     a.g.stroke();
-    hgt.g.stroke();
   }
   // polished wheel tracks: darker and much glossier
   for (const cx of [S * 0.26, S * 0.74]) {

--- a/apps/auto/src/traffic.js
+++ b/apps/auto/src/traffic.js
@@ -6,7 +6,9 @@ import { clamp, lerp, angleWrap, hash2, rng, dist2 } from './util.js';
 import * as G from './geo.js';
 
 const TRAFFIC_TARGET = 26;
-const PARKED_RADIUS = 130;
+// Parked cars only exist within this radius, and each is 3 draw calls, so this
+// is a draw-call dial as much as a distance one.
+const PARKED_RADIUS = 105;
 const DESPAWN = 520;
 
 export function collideWithBuildings(v, city, onHit) {
@@ -117,7 +119,11 @@ export class TrafficSystem {
         // more for a populated city than any amount of shader work, and they
         // share geometry and two of their three materials across every
         // instance, so the cost is draw calls rather than memory.
-        if (h > 0.48) continue;
+        // Kerbside occupancy. Every parked car is 3 draw calls and there are a
+        // lot of kerbs in view at once -- measured on device, 67 vehicles were
+        // alive at once and the fleet was over half the frame's draw calls.
+        // 0.30 still reads as a lived-in street.
+        if (h > 0.30) continue;
         const key = ei * 64 + s;
         seen.add(key);
         if (this.parkedSlots.has(key)) continue;

--- a/apps/auto/src/vehicles.js
+++ b/apps/auto/src/vehicles.js
@@ -44,6 +44,20 @@ const DRAG = 0.00040;
 const ROLL = 0.020;
 const V0_100 = 100 / 3.6;
 
+// How much punchier than real the throttle is.
+//
+// The bench measures against real-world 0-100 figures and the table declares
+// them, which is the right way to keep a bus from out-dragging a hatchback --
+// but a real family sedan takes 8.6 s to 100 km/h and in a game that feels
+// broken. You spend the whole time waiting for the car to do something.
+//
+// So the ratios between vehicles stay real and the whole scale is compressed:
+// everything accelerates ARCADE_PUNCH times harder than its spec sheet, which
+// keeps a sports car quicker than a van by the right margin while making both
+// enjoyable. Top speed, braking and grip stay honest -- those are what make a
+// corner dangerous, and they are not what makes a car feel slow.
+const ARCADE_PUNCH = 2.4;
+
 export const TYPES = {
   sedan: deriveSpec({ wheelbase: 2.98,len: 5.06, wid: 1.90, wheelR: 0.34, sill: 0.30, belt: 1.06, roof: 1.50, cab: [-0.26, 0.10], hand: 'sedan', mass: 1.0, acc: 4.1, topKph: 205, brakeM: 40, latG: 0.88 }),
   hatch: deriveSpec({ wheelbase: 2.6,len: 4.10, wid: 1.76, wheelR: 0.31, sill: 0.29, belt: 0.96, roof: 1.50, cab: [-0.30, 0.16], mass: 0.9, acc: 3.6, topKph: 185, brakeM: 41, latG: 0.85 }),
@@ -76,7 +90,7 @@ export const TYPES = {
   bus: deriveSpec({ wheelbase: 6.0,len: 12.0, wid: 2.55, wheelR: 0.50, sill: 0.50, belt: 1.30, roof: 3.10, cab: [-0.48, 0.48], bus: true, boxy: 3, mass: 4.5, acc: 1.4, topKph: 95, brakeM: 52, latG: 0.62 }),
   boxtruck: deriveSpec({ wheelbase: 4.3,len: 7.5, wid: 2.38, wheelR: 0.46, sill: 0.62, belt: 1.55, roof: 2.55, cab: [0.14, 0.46], cargo: 2.55, boxy: 2, mass: 3.0, acc: 2.5, topKph: 125, brakeM: 51, latG: 0.66 }),
   ambulance: deriveSpec({ wheelbase: 3.9,len: 6.3, wid: 2.28, wheelR: 0.42, sill: 0.56, belt: 1.42, roof: 2.35, cab: [0.16, 0.46], cargo: 2.25, boxy: 2, emergency: true, mass: 2.4, acc: 3.2, topKph: 155, brakeM: 48, latG: 0.72 }),
-  garbage: deriveSpec({ wheelbase: 4.6,len: 8.1, wid: 2.48, wheelR: 0.50, sill: 0.66, belt: 1.62, roof: 2.6, cab: [0.20, 0.46], cargo: 2.5, boxy: 2, mass: 4.0, acc: 1.2, topKph: 90, brakeM: 55, latG: 0.61 }),
+  garbage: deriveSpec({ wheelbase: 4.6,len: 8.1, wid: 2.48, wheelR: 0.50, sill: 0.66, belt: 1.62, roof: 2.6, cab: [0.20, 0.46], cargo: 2.5, boxy: 2, mass: 4.0, acc: 1.45, topKph: 90, brakeM: 55, latG: 0.61 }),
 };
 
 /**
@@ -100,6 +114,7 @@ function deriveSpec(s) {
   // The EV's pull tails off as sqrt(fade), not linearly, so the same parameter
   // carries it a good deal further -- solved as if it were linear it overshot
   // its declared top by 47 km/h.
+  s.acc *= ARCADE_PUNCH;
   const frac = s.ev ? 1 - (resist / s.acc) ** 2 : 1 - resist / s.acc;
   // A vehicle whose launch acceleration cannot even overcome its own drag at
   // the declared top speed is a table error, not a tuning choice.

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -1516,6 +1516,22 @@ export class World {
   }
 
   /**
+   * Height of the water surface covering a point, or null if it is dry.
+   *
+   * The sea is at y=0 and every labelled lake gets its own plane at its own
+   * level -- Green Lake really is at 50 m -- so "is this under water" is not a
+   * comparison against zero, and anything measuring clearance over water has to
+   * ask for the LOCAL surface. A fixed 5.5 m bridge floor put decks under the
+   * lakes they crossed by assuming otherwise.
+   */
+  waterLevelAt(x, z) {
+    for (const l of (this.lakeSpecs || [])) {
+      if (x >= l.x0 && x <= l.x1 && z >= l.z0 && z <= l.z1) return l.level;
+    }
+    return G.isWater(x, z) ? 0 : null;
+  }
+
+  /**
    * Is this point inside a building footprint? Shared by every scatter, since
    * "the data says this is open ground" and "there is nothing standing here"
    * are different questions and only the second one matters to a prop.

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v33';
+const CACHE = 'auto-v34';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',

--- a/tools/jank.mjs
+++ b/tools/jank.mjs
@@ -1,0 +1,379 @@
+// City jank hunter: geometric defects, counted across the whole map.
+//
+//   node tools/jank.mjs [--json] [--only=name,name]
+//
+// The defects this looks for -- pavement that does not meet, props standing in
+// water, terrain poking through the asphalt, roofs that miss their building,
+// things you sink into -- are all things a screenshot can only find one at a
+// time, by luck, in whichever direction the camera happened to be pointing.
+// They are also all *measurable*, which means they can be counted over the
+// whole 16 km map and driven to zero, and a regression shows up as a number
+// rather than as someone noticing months later.
+//
+// Every check reports a count, a rate against however many samples it took, and
+// the worst offenders with coordinates -- so a bad one can be walked to with
+// `AUTO_PROBE` or photographed with tools/survey.mjs instead of being argued
+// about.
+//
+// The lesson this codebase keeps relearning (road z-fighting, the wheel-well
+// slab, the shadow-map band, the sunset harness) is that a render tells you
+// something looks wrong and almost never tells you why. Measure it.
+
+import { spawn } from 'node:child_process';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const PORT = 9235;
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const HTTP_PORT = process.env.AUTO_HTTP_PORT || 8000;
+const JSON_OUT = process.argv.includes('--json');
+const ONLY = (process.argv.find((a) => a.startsWith('--only=')) || '').slice(7);
+
+function launch() {
+  return spawn(CHROME, [
+    `--remote-debugging-port=${PORT}`, '--headless=new', '--use-gl=swiftshader',
+    '--enable-unsafe-swiftshader', '--window-size=900,640', '--no-first-run',
+    '--user-data-dir=/tmp/auto-jank-profile', 'about:blank',
+  ], { stdio: 'ignore' });
+}
+
+const CHECKS = `(() => {
+  const d = window.__dbg, G = d.G, city = d.city, world = d.world;
+  const THREE = d.THREE;
+  const only = ${JSON.stringify(ONLY)};
+  const want = (n) => !only || only.split(',').includes(n);
+  const out = [];
+  const R = (seed) => { let s = seed >>> 0; return () => (s = (s * 1664525 + 1013904223) >>> 0) / 4294967296; };
+
+  // Sample points spread over the land area of the map, deterministically.
+  const landPoints = (n, seed) => {
+    const r = R(seed), pts = [];
+    let guard = 0;
+    while (pts.length < n && guard++ < n * 60) {
+      const x = (r() - 0.5) * 2 * (G.MAP_HALF - 200);
+      const z = (r() - 0.5) * 2 * (G.MAP_HALF - 200);
+      if (G.isWater(x, z)) continue;
+      pts.push([x, z]);
+    }
+    return pts;
+  };
+
+  const add = (name, n, of, worst, note) =>
+    out.push({ name, n, of, rate: of ? +(100 * n / of).toFixed(2) : 0, worst: worst.slice(0, 6), note });
+
+  // --- props and trees standing in water ---------------------------------
+  //
+  // The park scatter filters on the green mask and on roads. The green mask and
+  // the water mask are different rasters and the shoreline does not agree
+  // between them to the metre, so a tree can be planted in Puget Sound.
+  if (want('tree-in-water')) {
+    const CHUNK = 400;
+    let cand = 0, wet = 0;
+    const worst = [];
+    const h2 = (a, b) => { const t = Math.sin(a * 127.1 + b * 311.7) * 43758.5453; return t - Math.floor(t); };
+    for (let cx = -18; cx <= 18; cx++) {
+      for (let cz = -18; cz <= 18; cz++) {
+        const x0 = cx * CHUNK, z0 = cz * CHUNK;
+        for (let i = 0; i < 230; i += 5) {
+          const x = x0 + h2(cx * 71 + i, cz * 131 + 7) * CHUNK;
+          const z = z0 + h2(cx * 37 + i, cz * 53 + 13) * CHUNK;
+          if (!G.inPark(x, z)) continue;
+          if (city.onRoad(x, z, 2.5)) continue;
+          if (world.inBuilding && world.inBuilding(x, z, 0.8)) continue;
+          cand++;
+          if (G.isWater(x, z) || G.terrainHeight(x, z) < 0.35) {
+            wet++;
+            if (worst.length < 6) worst.push({ x: Math.round(x), z: Math.round(z), y: +G.terrainHeight(x, z).toFixed(2) });
+          }
+        }
+      }
+    }
+    add('tree-in-water', wet, cand, worst, 'park trees standing in water or below the tide line');
+  }
+
+  // --- ground that stands above the water covering it --------------------
+  //
+  // The minimap comes from the water mask and the world from the DEM, so the
+  // two disagreeing renders as an island that is not on the map.
+  if (want('island')) {
+    const r = R(7), worst = [];
+    let n = 0, of = 0;
+    for (let i = 0; i < 40000; i++) {
+      const x = (r() - 0.5) * 2 * (G.MAP_HALF - 100);
+      const z = (r() - 0.5) * 2 * (G.MAP_HALF - 100);
+      if (!G.isWater(x, z)) continue;
+      of++;
+      const level = world.waterLevelAt(x, z);
+      if (level === null) continue;
+      const h = G.terrainHeight(x, z);
+      if (h > level + 0.05) {
+        n++;
+        if (worst.length < 6) worst.push({ x: Math.round(x), z: Math.round(z), above: +(h - level).toFixed(2) });
+      }
+    }
+    worst.sort((a, b) => b.above - a.above);
+    add('island', n, of, worst, 'wet cells standing above their own water surface');
+  }
+
+  // --- water with no surface drawn over it -------------------------------
+  //
+  // The sea plane is at y=0 and each labelled lake gets its own plane. A body
+  // that got neither renders as a dry hole in the middle of a lake.
+  if (want('missing-water')) {
+    const r = R(11), worst = [];
+    let n = 0, of = 0;
+    for (let i = 0; i < 40000; i++) {
+      const x = (r() - 0.5) * 2 * (G.MAP_HALF - 100);
+      const z = (r() - 0.5) * 2 * (G.MAP_HALF - 100);
+      if (!G.isWater(x, z)) continue;
+      of++;
+      const h = G.terrainHeight(x, z);
+      // Sea level covers anything at or below 0. Anything higher needs a lake
+      // plane over it, or there is nothing between the player and the bed.
+      if (h <= 0.05) continue;
+      let covered = false;
+      for (const l of (world.lakes || [])) {
+        const p = l.position, g = l.geometry.parameters;
+        if (Math.abs(x - p.x) <= g.width / 2 && Math.abs(z - p.z) <= g.height / 2 && p.y > h) { covered = true; break; }
+      }
+      if (!covered) {
+        n++;
+        if (worst.length < 6) worst.push({ x: Math.round(x), z: Math.round(z), h: +h.toFixed(2) });
+      }
+    }
+    add('missing-water', n, of, worst, 'water cells with no plane above them');
+  }
+
+  // --- terrain poking through the road surface ---------------------------
+  //
+  // A road quad is a chord and the heightfield bulges under it. ROAD_LIFT is
+  // 30 cm; anything above that is grass growing through the tarmac.
+  if (want('road-poke')) {
+    const worst = [];
+    let n = 0, of = 0;
+    const step = Math.max(1, Math.floor(city.edges.length / 4000));
+    for (let ei = 0; ei < city.edges.length; ei += step) {
+      const e = city.edges[ei];
+      if (e.elev || e.len < 8) continue;
+      const a = city.nodes[e.a], b = city.nodes[e.b];
+      for (let s = 1; s < 5; s++) {
+        const t = s / 5;
+        const x = a.x + (b.x - a.x) * t, z = a.z + (b.z - a.z) * t;
+        // The drawn surface interpolates the ends; the ground is what is really
+        // there. The gap is what pokes through.
+        const drawn = (a.y + (b.y - a.y) * t);
+        const real = G.terrainHeight(x, z);
+        of++;
+        const over = real - drawn;
+        if (over > 0.30) {
+          n++;
+          if (worst.length < 40) worst.push({ x: Math.round(x), z: Math.round(z), over: +over.toFixed(2), cls: e.cls });
+        }
+      }
+    }
+    worst.sort((a, b) => b.over - a.over);
+    add('road-poke', n, of, worst, 'terrain standing more than ROAD_LIFT above the road it carries');
+  }
+
+  // --- things you sink into ----------------------------------------------
+  //
+  // roadLift() reports the paved lift at a point and groundAt() puts you on it.
+  // If the query and the drawn surface disagree you stand inside the pavement
+  // or float above it. Raycast the actual mesh and compare.
+  if (want('sink')) {
+    d.scene.updateMatrixWorld(true);
+    const rc = new THREE.Raycaster();
+    const down = new THREE.Vector3(0, -1, 0);
+    const worst = [];
+    let n = 0, of = 0;
+    // Sample on the paved surface specifically -- that is where the two
+    // sources of truth exist and can disagree.
+    const nodes = city.nodes;
+    const stepN = Math.max(1, Math.floor(nodes.length / 900));
+    for (let ni = 0; ni < nodes.length; ni += stepN) {
+      const nd = nodes[ni];
+      if (nd.elev) continue;
+      for (const [ox, oz] of [[0, 0], [4, 0], [0, 4], [-4, 0], [0, -4], [5, 5]]) {
+        const x = nd.x + ox, z = nd.z + oz;
+        if (!city.onRoad(x, z, 1.5, false) && city.roadLift(x, z) <= 0) continue;
+        world.update(x, z, 60);
+        const lift = city.roadLift(x, z);
+        const stand = city.groundAt(x, z, null, lift);
+        rc.set(new THREE.Vector3(x, stand + 12, z), down);
+        rc.far = 24;
+        const hits = rc.intersectObject(world.group, true).filter((h) => h.object.isMesh);
+        if (!hits.length) continue;
+        of++;
+        const surf = hits[0].point.y;
+        const gap = surf - stand;   // positive: the mesh is above where you stand
+        if (Math.abs(gap) > 0.10) {
+          n++;
+          if (worst.length < 40) worst.push({ x: Math.round(x), z: Math.round(z), gap: +gap.toFixed(2) });
+        }
+      }
+    }
+    worst.sort((a, b) => Math.abs(b.gap) - Math.abs(a.gap));
+    add('sink', n, of, worst, 'drawn pavement disagreeing with the height you stand at');
+  }
+
+  // --- roofs that miss their building ------------------------------------
+  if (want('roof')) {
+    const worst = [];
+    let n = 0, of = 0;
+    const step = Math.max(1, Math.floor(city.buildings.length / 6000));
+    for (let bi = 0; bi < city.buildings.length; bi += step) {
+      const bd = city.buildings[bi];
+      if (bd.style !== 'house') continue;
+      of++;
+      // meshGable builds in the building's own frame; the failure mode this
+      // catches is a roof sized off the wrong axis, which leaves the gable
+      // hanging past the wall on the narrow side.
+      const over = Math.max(bd.w, bd.d) / Math.min(bd.w, bd.d);
+      if (over > 4.5) {
+        n++;
+        if (worst.length < 6) worst.push({ x: Math.round(bd.x), z: Math.round(bd.z), w: +bd.w.toFixed(1), d: +bd.d.toFixed(1) });
+      }
+    }
+    add('roof', n, of, worst, 'houses so elongated a gable cannot sit on them');
+  }
+
+  // --- buildings standing in water ---------------------------------------
+  if (want('building-in-water')) {
+    const worst = [];
+    let n = 0;
+    const of = city.buildings.length;
+    for (let bi = 0; bi < of; bi += 1) {
+      const bd = city.buildings[bi];
+      if (!G.isWater(bd.x, bd.z)) continue;
+      // Piers and houseboats are real. A building whose base is well under the
+      // water surface is not.
+      const level = world.waterLevelAt(bd.x, bd.z);
+      if (level === null) continue;
+      if (bd.y > level - 1.2) continue;
+      n++;
+      if (worst.length < 6) worst.push({ x: Math.round(bd.x), z: Math.round(bd.z), under: +(level - bd.y).toFixed(1) });
+    }
+    worst.sort((a, b) => b.under - a.under);
+    add('building-in-water', n, of, worst, 'buildings with their base well below the water covering them');
+  }
+
+  // --- elevated decks ----------------------------------------------------
+  //
+  // A deck that sits below the terrain it spans is a bridge through a hill; one
+  // that meets its neighbour at a different height is a step in the road.
+  if (want('bridge')) {
+    const worst = [];
+    let n = 0, of = 0;
+    for (let ei = 0; ei < city.edges.length; ei++) {
+      const e = city.edges[ei];
+      if (!e.elev) continue;
+      const a = city.nodes[e.a], b = city.nodes[e.b];
+      for (let s = 0; s <= 4; s++) {
+        const t = s / 4;
+        const x = a.x + (b.x - a.x) * t, z = a.z + (b.z - a.z) * t;
+        const deck = a.y + (b.y - a.y) * t;
+        const ground = G.terrainHeight(x, z);
+        of++;
+        if (ground > deck + 0.5) {
+          n++;
+          if (worst.length < 40) worst.push({ x: Math.round(x), z: Math.round(z), buried: +(ground - deck).toFixed(2) });
+        }
+      }
+    }
+    worst.sort((a, b) => b.buried - a.buried);
+    add('bridge', n, of, worst, 'elevated deck buried under the terrain it spans');
+  }
+
+  // --- pavement crossing a carriageway -----------------------------------
+  if (want('walk-on-road')) {
+    const worst = [];
+    let n = 0, of = 0;
+    const step = Math.max(1, Math.floor(city.edges.length / 2500));
+    for (let ei = 0; ei < city.edges.length; ei += step) {
+      const e = city.edges[ei];
+      if (e.elev || e.len < 20) continue;
+      if (e.cls !== 'st' && e.cls !== 'art' && e.cls !== 'res') continue;
+      const a = city.nodes[e.a], b = city.nodes[e.b];
+      const px = -e.dz, pz = e.dx;
+      const sw = e.cls === 'art' ? 3.2 : 2.6;
+      for (const sg of [-1, 1]) {
+        for (let s = 1; s < 4; s++) {
+          const t = s / 4;
+          const x = a.x + (b.x - a.x) * t + px * sg * (e.hw + sw * 0.5);
+          const z = a.z + (b.z - a.z) * t + pz * sg * (e.hw + sw * 0.5);
+          of++;
+          if (city.onRoad(x, z, 0, false)) {
+            n++;
+            if (worst.length < 6) worst.push({ x: Math.round(x), z: Math.round(z), cls: e.cls });
+          }
+        }
+      }
+    }
+    add('walk-on-road', n, of, worst, 'pavement mid-line sitting on a carriageway');
+  }
+
+  return JSON.stringify(out);
+})()`;
+
+async function main() {
+  const chrome = launch();
+  try {
+    let page;
+    for (let i = 0; i < 90 && !page; i++) {
+      try {
+        page = (await (await fetch(`http://127.0.0.1:${PORT}/json/list`)).json())
+          .find((t) => t.type === 'page');
+      } catch { /* not up */ }
+      if (!page) await sleep(300);
+    }
+    const ws = new WebSocket(page.webSocketDebuggerUrl);
+    await new Promise((r, j) => { ws.addEventListener('open', r); ws.addEventListener('error', j); });
+    let id = 0; const pend = new Map();
+    ws.addEventListener('message', (ev) => {
+      const m = JSON.parse(ev.data);
+      if (m.id && pend.has(m.id)) { pend.get(m.id)(m); pend.delete(m.id); }
+    });
+    const send = (method, params = {}) => new Promise((res) => {
+      ws.send(JSON.stringify({ id: ++id, method, params })); pend.set(id, res);
+    });
+    const evaluate = async (e) => {
+      const r = await send('Runtime.evaluate', { expression: e, returnByValue: true, awaitPromise: true });
+      if (r.result?.exceptionDetails) throw new Error(r.result.exceptionDetails.exception?.description);
+      return r.result?.result?.value;
+    };
+    await send('Runtime.enable');
+    await send('Page.enable');
+    await send('Network.enable');
+    await send('Network.setBypassServiceWorker', { bypass: true });
+    await send('Network.setCacheDisabled', { cacheDisabled: true });
+    await send('Page.addScriptToEvaluateOnNewDocument', { source: 'window.__noAutoQuality = true;' });
+    await send('Page.navigate', { url: `http://localhost:${HTTP_PORT}/apps/auto/` });
+    for (let i = 0; i < 400; i++) {
+      await sleep(500);
+      if (await evaluate('!!window.__dbg')) break;
+    }
+    const res = JSON.parse(await evaluate(CHECKS));
+
+    if (JSON_OUT) { console.log(JSON.stringify(res, null, 2)); return; }
+
+    let bad = 0;
+    console.log('check                 count   sampled     rate  worst');
+    for (const c of res) {
+      if (c.n > 0) bad++;
+      const w = c.worst.map((o) => {
+        const k = Object.keys(o).filter((k2) => k2 !== 'x' && k2 !== 'z')[0];
+        return `(${o.x},${o.z}${k ? ' ' + o[k] : ''})`;
+      }).join(' ');
+      console.log(
+        `${c.name.padEnd(20)}${String(c.n).padStart(6)}${String(c.of).padStart(10)}`
+        + `${(c.rate + '%').padStart(9)}  ${w}`
+      );
+    }
+    console.log('');
+    for (const c of res) if (c.n > 0) console.log(`  ${c.name}: ${c.note}`);
+    console.log(`\n${bad} of ${res.length} checks found something.`);
+  } finally {
+    chrome.kill('SIGKILL');
+  }
+}
+
+main().catch((e) => { console.error('jank failed:', e.message); process.exitCode = 1; });

--- a/tools/vehicles.mjs
+++ b/tools/vehicles.mjs
@@ -24,6 +24,8 @@ const PORT = 9231;
 const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 const HTTP_PORT = process.env.AUTO_HTTP_PORT || 8000;
 const JSON_OUT = process.argv.includes('--json');
+// Keep in step with ARCADE_PUNCH in apps/auto/src/vehicles.js.
+const ARCADE_PUNCH = 2.4;
 
 // Real-world bands per class, for the types we ship. 0-100 km/h in seconds,
 // top speed in km/h, 100-0 braking in metres, lateral grip in g.
@@ -31,6 +33,13 @@ const JSON_OUT = process.argv.includes('--json');
 // These are ranges a competent example of the class actually occupies, not
 // targets to hit exactly -- the point is to catch a bus that out-accelerates a
 // hatchback, not to argue about a tenth.
+//
+// ACCELERATION is the exception. The game applies ARCADE_PUNCH to every
+// throttle, because a real sedan's 8.6 s to 100 km/h feels broken to drive --
+// you spend the whole time waiting. The RATIOS between classes stay real, so
+// the accel band is divided by the same constant here and the check still
+// catches a van out-dragging a sports car. Top speed, braking and grip are
+// compared against the real figures unchanged.
 const BANDS = {
   sedan: { name: 'mid-size sedan', accel: [7.5, 11], top: [190, 235], brake: [36, 44], lat: [0.82, 0.92] },
   hatch: { name: 'small hatchback', accel: [9, 13], top: [170, 200], brake: [36, 45], lat: [0.80, 0.90] },
@@ -196,7 +205,7 @@ async function main() {
       const b = BANDS[name];
       if (!b) { console.log(`${name}: no band`); continue; }
       const marks = [
-        band(r.accel, b.accel), band(r.top, b.top),
+        band(r.accel, b.accel.map((v) => v / ARCADE_PUNCH)), band(r.top, b.top),
         band(r.brake, b.brake), band(r.lat, b.lat),
       ];
       bad += marks.filter((m) => m !== 'ok').length;


### PR DESCRIPTION
First time this has been tested on an actual device (iPhone 17 Pro). Build
**v34**.

The readout said **56 fps, min 56** while the game felt unplayable — so almost
none of this was frame rate, and I had been about to optimise the wrong thing.
The graphics pass shipped against a documented budget that was never a
measurement on any device.

## A switch per pass

Pause menu now has bloom, SSAO, grade, vignette, grain, dither, FXAA and fog,
plus a master post toggle. A single post on/off cannot answer *which* of eight
screen-space passes is hazing the picture, and that is the question that
actually gets asked.

The flags are kept apart from the quality tier, so an automatic downgrade
mid-session does not wipe whatever is being bisected. Fog nulls `scene.fog`
rather than zeroing density — the fog term is compiled into every material, so
density 0 still pays for it, and the point is to measure cost as well as look.

## Frame cost, measured properly

An earlier probe reported 11 draw calls, because `postfx.render` does not
re-render the scene — it measured the post chain alone. Counting the real frame
in downtown: **509 draw calls and 989k triangles**, of which the **shadow pass
alone was 152 calls and 318k triangles** — a third of the frame, re-rendering
every tree, pole and bin.

Cuts, phone-only where a desktop can afford it:

| | before | after |
|---|---|---|
| shadow filter | `PCFSoftShadowMap` | `PCFShadowMap` on phone |
| shadow map | 2048² | 1024² on phone |
| shadow box / far | 260 m / 1150 | 190 m / 980 |
| pixel ratio cap, high | 2.0 | 1.45 |
| pixel ratio cap, medium | 1.5 | 1.3 |
| bloom blur iterations | 3 | 2 (1 below high) |
| kerbside parking occupancy | 0.48 | 0.30 |
| `PARKED_RADIUS` | 130 m | 105 m |
| `MAX_PEDS` | 34 | 24 |

Pixel ratio is the largest fill dial there is: 2.0 against 1.45 is 1.9× the
pixels through every fullscreen pass. Bloom passes are now skipped entirely
rather than computed and multiplied by zero.

**Phones start on `medium`.** `high` was only ever reachable *downward*, so every
player paid 2.5 s of visible stutter to discover their device could not run the
desktop preset. Auto-quality reacts at 45 fps after 1.2 s now rather than 40 fps
after 2.5 s — and `applyQuality` keeps the ladder index in step whether the
change was manual or automatic, because starting on `medium` with the index
still at 0 wasted the first step down re-applying the tier it was already on.

## The look

Reported as "crazy haze and filter … follows wherever I pan", which is
screen-space by definition. Bloom 0.62 → 0.34, vignette 0.15 → 0.10, grain
halved, fog density 0.00040 → 0.00026, and the grade's toe and shoulder cut by
more than half — together they were compressing *both* ends of the histogram,
which reads as a filter laid over the picture rather than as tone mapping.

Asphalt crack seams went from 30 per tile at 50 % opacity to 5 at 20 %. The tile
repeats every few metres of road, so the whole city was under a net of black
squiggles and the tarmac read as dried mud.

## Cars felt like treacle, and that was the real "slow"

Acceleration had been rescaled to real-world figures in the vehicle pass, which
put a family sedan at 8.6 s to 100 km/h. Accurate, and miserable to drive — you
spend the whole time waiting for the car to do something.

`ARCADE_PUNCH` compresses the whole acceleration scale by 2.4× while leaving the
*ratios* between classes real, so a sports car stays quicker than a van by the
right margin. Top speed, braking and grip are untouched: those are what make a
corner dangerous, and they are not what makes a car feel slow. The bench divides
its acceleration band by the same constant, so it still catches a van
out-dragging a sports car.

Also fixed: `ARCADE_PUNCH` was declared *below* `TYPES`, which calls
`deriveSpec` at module evaluation — a `const` in the temporal dead zone, and the
game did not boot at all.

## Checks

- `node tools/verify.mjs` → `OK: 0 exceptions`
- `node tools/vehicles.mjs` → `0 figures outside their band, of 72`

## Still open

The city-jank pass this branch was originally opened for — misaligned
pavements, trees in water, roofs that miss their building — is not in here. The
probe harness for it (`tools/jank.mjs`) is written but unrun; it got set aside
when the device test came back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B