### PR TITLE
Auto: stop drawing shadows nobody can see

### DIFF
--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -414,7 +414,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v34</div>
+    <div id="build">v35</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/src/peds.js
+++ b/apps/auto/src/peds.js
@@ -1,6 +1,8 @@
 // Pedestrians: civilians wandering the sidewalks and cops on foot.
 
 import * as THREE from './three.js';
+
+const ON_PHONE = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
 import { Builder } from './build.js';
 import { clamp, lerp, angleWrap, hash2, rng, dist2 } from './util.js';
 import * as G from './geo.js';
@@ -335,7 +337,12 @@ export function makeHumanoid(opts = {}) {
   const mesh = new THREE.SkinnedMesh(geo, pedMat);
   mesh.add(bones[B.root]);
   mesh.bind(new THREE.Skeleton(bones));
-  mesh.castShadow = true;
+  // A background pedestrian's shadow is a few dozen pixels at street level and
+  // costs a whole extra draw call plus a second pass over an 18-bone skinned
+  // mesh -- measured, 21 pedestrians were 21 draws and 27k triangles of shadow.
+  // The player is the exception: their own shadow is how you read where you are
+  // standing.
+  mesh.castShadow = !ON_PHONE || !!opts.unique;
   mesh.frustumCulled = false;
 
   const g = new THREE.Group();

--- a/apps/auto/src/traffic.js
+++ b/apps/auto/src/traffic.js
@@ -138,6 +138,11 @@ export class TrafficSystem {
         const tn = CIVILIAN_TYPES[Math.floor(hash2(ei + s * 7, 11) * CIVILIAN_TYPES.length)];
         if (tn === 'bus' || tn === 'garbage') continue;
         const v = this.spawnAt(x, z, heading, tn, randomCarColor(ei * 13 + s), 'parked');
+        // A parked car sits against a kerb with buildings behind it, so its
+        // shadow lands almost entirely on ground that is already shaded -- and
+        // it is three more meshes through the shadow pass. Measured, the parked
+        // cars in one downtown frame were 10 draws and 19k triangles of it.
+        v.group.traverse((o) => { if (o.isMesh) o.castShadow = false; });
         v.slot = key;
         this.parkedSlots.add(key);
       }

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -3,6 +3,10 @@
 
 import * as THREE from './three.js';
 import * as G from './geo.js';
+
+// Kept in step with main.js. Shadow-caster policy differs by platform, and the
+// difference is worth roughly 40 draw calls a frame.
+const ON_PHONE = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
 import { CHUNK, ROAD_LIFT, NODE_LIFT, WALK_LIFT, cityStats } from './citygen.js';
 import { Builder } from './build.js';
 import { hash2, clamp, lerp, distToSeg } from './util.js';
@@ -542,7 +546,15 @@ export class World {
     const add = (bld, mat, cast, recv) => {
       if (bld.empty) return;
       const m = new THREE.Mesh(bld.build(), mat);
-      m.castShadow = cast && this.shadows;
+      // Not everything that can cast a shadow earns one.
+      //
+      // The shadow pass re-renders every caster, so each one costs a second
+      // draw call and a second pass over its geometry. Measured downtown, the
+      // props/trees/roof-kit mesh alone was 10 draws and 122k triangles of
+      // shadow -- 13 % of the frame's geometry -- for shadows that at street
+      // level fall mostly on surfaces already in shade. On a phone that is not
+      // where the budget goes; on a desktop it is worth having.
+      m.castShadow = cast && this.shadows && !(ON_PHONE && mat === this.mats.flat);
       m.receiveShadow = recv && this.shadows;
       grp.add(m);
     };

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v34';
+const CACHE = 'auto-v35';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',


### PR DESCRIPTION
Follow-up to #345, answering "did you fix any actual waste, or just turn quality
dials down?" — that one was almost entirely dials. This is waste. Build **v35**.

## Attribution first

Measured a downtown frame by toggling each scene group and re-rendering, rather
than guessing:

| group | draws | triangles |
|---|---|---|
| **full frame** | **470** | **924k** |
| streamed chunks | 188 | 627k |
| vehicles (21) | 67 | 107k |
| terrain | 52 | 119k |
| peds (21) | 42 | 55k |
| far skyline | 1 | 5k |

Two things stood out. Pedestrians cost **2 draws each**, not the 1 the docs
claim — the second is the shadow pass. And the props mesh (trees, street
clutter, roof kit) was **122k triangles of shadow casting**: 13% of the frame's
geometry, for shadows that at street level land mostly on surfaces already in
shade.

Savings, measured by turning each off and re-rendering:

| | draws | triangles |
|---|---|---|
| peds stop casting | 21 | 27k |
| parked cars stop casting | 10 | 19k |
| props/trees stop casting | 9 | 120k |

## Changes

- **Parked cars never cast.** A parked car sits against a kerb with a building
  behind it — its shadow lands on ground that is already dark, and it is three
  more meshes through the pass. All platforms.
- **Pedestrians don't cast on a phone**, except the player: your own shadow is
  how you read where you're standing.
- **Props and trees don't cast on a phone.** Kept on desktop, where it's worth
  having.

## Result

Downtown, as it ships:

| | draws | triangles |
|---|---|---|
| before #345 | 509 | 989k |
| desktop, now | 458 | 902k |
| **phone on medium, now** | **405** | **721k** |

## Ruled out, so nobody re-investigates

CPU game logic is ~0.4 ms/frame in total — `traffic.update` 0.13,
`peds.update` 0.18, `roadLift` 0.05, `traffic.updateParked` 0.012. The parked
scan does run every frame, but the `parkedSlots` set short-circuits it, so it
isn't the per-frame rescan it looks like. The far skyline mesh is 1 draw and
5,390 triangles, so its `frustumCulled = false` costs nothing worth reclaiming.

## Checks

- `node tools/verify.mjs` → `OK: 0 exceptions`
- `node tools/vehicles.mjs` → `0 figures outside their band, of 72`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B