### PR TITLE
Auto: one facade material instead of six

### DIFF
--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -551,6 +551,35 @@ Physically-shaded, image-based-lit, tone-mapped, with a hand-rolled post chain.
   and a street of five families still read as one stone -- no tint can turn
   ashlar into a running bond. `masonrySurface()` is parameterised and called
   twice, for stone and for brick.
+- **One material for every wall, and the tiling is what makes that hard.**
+  `Builder.box` emits UVs running 0..n and leans on `RepeatWrapping`, and GL
+  repeat wraps the whole texture rather than a sub-rect, so a naive atlas cannot
+  carry a tiling surface at all. `facadeAtlas()` lays the families out in a
+  HORIZONTAL strip one tile tall: V still wraps natively, so a 100 m tower's
+  seven vertical repeats cost nothing, and only U has to stay inside a cell —
+  which `box` does by cutting a face into one quad per horizontal repeat. Plain
+  textures, plain UVs, no `onBeforeCompile` and no `sampler2DArray`: the same
+  reason postfx.js is 8-bit throughout is the reason this route was taken over a
+  shader one. It costs about 41 % more facade triangles (0.2 % of the frame) and
+  saves 91 draw calls downtown.
+
+  Everything that used to differ per material is baked into the maps, because
+  one material has only one of each: `normalScale` into the normal's xy (three
+  scales the DECODED vector then normalises, so pre-scaling by `ns / nsMax`
+  reproduces the old value exactly), `roughness` and `metalness` into their own
+  channels, and `envMapIntensity` into the AO channel — three's AO term
+  attenuates the image-based light, which is the only thing env drove. Emissive
+  spans a hundredfold (a lit shop sign against a lit office window) and survives
+  anyway because the map is **sRGB-encoded**: the window lands on texel 31, not
+  on texel 2.
+
+  **Glass stays its own material.** It is the one facade whose look is mostly
+  indirect SPECULAR, which is the part of `envMapIntensity` the AO channel can
+  only approximate.
+
+  Cells carry 8 px of wrap-padding — the cell's own opposite edge — so bilinear
+  and the first three mips filter as if the tile repeated rather than pulling in
+  the neighbouring family.
 - **Adaptive quality.** The phone this ships to can't be profiled from here, so
   the game measures its own frame rate and steps `high -> medium -> low`
   (post off, then pixel ratio down). `applyQuality(q, true)` locks it manually.
@@ -872,8 +901,11 @@ counters reset on every `render()`.
 Where the budget goes, and the rules that keep it there:
 
 - chunk streaming: `CHUNK = 400`, `NEAR_R = 2` (full detail), `MID_R = 4` (roads
-  only). Up to 8 merged meshes per near chunk (road, sidewalk, flat, glow, and
-  one per facade material).
+  only). Up to 6 merged meshes per near chunk: road, sidewalk, flat, glow, glass
+  and **one for every other wall material**. Stone, brick, industrial, house and
+  signage used to be five meshes and were 115 draws downtown for 25k triangles —
+  216 triangles a draw, on a target where the draw calls are what bind. They
+  share one atlased material now; see "One material for every wall" below.
 - **vehicles are 3 draws each** — `paint` / `trim` / `matte`, sharing geometry
   and the two non-paint materials across every instance. Traffic uses the
   `…GeoW` variants with the wheels baked in; only the player's car calls

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -414,7 +414,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v35</div>
+    <div id="build">v36</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/src/build.js
+++ b/apps/auto/src/build.js
@@ -280,9 +280,13 @@ export class Builder {
   /**
    * Axis box rotated about Y. (cx,cz) is the centre, `by` the base height.
    * uScale/vScale give metres per texture tile; pass 0 for a 0..1 mapping.
+   *
+   * `opts.cell` is `[u0, du]`, a horizontal sub-rect of the facade atlas. It is
+   * how five wall materials became one: see `stripAtlas` in textures.js for why
+   * only U needs confining, and `faceU` below for what it costs.
    */
   box(cx, by, cz, w, h, d, rot, col, opts = {}) {
-    const { uScale = 0, vScale = 0, top = true, vOff = 0, sides = true, ao = 0 } = opts;
+    const { uScale = 0, vScale = 0, top = true, vOff = 0, sides = true, ao = 0, cell = null } = opts;
     const cr = Math.cos(rot), sr = Math.sin(rot);
     const hw = w / 2, hd = d / 2;
     const P = (lx, ly, lz) => [cx + lx * cr - lz * sr, by + ly, cz + lx * sr + lz * cr];
@@ -295,23 +299,50 @@ export class Builder {
     // the mass reads as sitting on the ground rather than floating over it.
     const lo = ao > 0 ? [col[0] * (1 - ao), col[1] * (1 - ao), col[2] * (1 - ao)] : col;
     const sideCols = ao > 0 ? [lo, lo, col, col] : col;
+    /**
+     * One rectangular face, `un` texture repeats wide and running v0..v1 up.
+     *
+     * With no atlas cell this is the single quad it always was. With one, the
+     * face is cut into one quad per horizontal repeat, because GL repeat wraps
+     * the whole texture and not a sub-rect -- so the UVs have to be inside the
+     * cell before the sampler ever sees them. V is left alone: the atlas is one
+     * tile tall, so vertical repeats still wrap for free and a 100 m tower
+     * costs nothing extra. Corner order is bottom-left, bottom-right,
+     * top-right, top-left, so the baked-AO colours stay on the bottom edge
+     * through the cut.
+     */
+    const faceU = (a, b, c, e, n, un, vA, vB, cols) => {
+      if (!cell) {
+        this.quad(a, b, c, e, n, [0, vA, un, vA, un, vB, 0, vB], cols);
+        return;
+      }
+      const [cu0, cdu] = cell;
+      const mix = (p, q, t) => [p[0] + (q[0] - p[0]) * t, p[1] + (q[1] - p[1]) * t, p[2] + (q[2] - p[2]) * t];
+      const steps = Math.max(1, Math.ceil(un - 1e-4));
+      for (let i = 0; i < steps; i++) {
+        const t0 = i / un, t1 = Math.min(1, (i + 1) / un);
+        const u1 = cu0 + Math.min(1, un - i) * cdu;
+        this.quad(mix(a, b, t0), mix(a, b, t1), mix(e, c, t1), mix(e, c, t0), n,
+          [cu0, vA, u1, vA, u1, vB, cu0, vB], cols);
+      }
+    };
     if (sides) {
       // +local z
-      this.quad(P(-hw, 0, hd), P(hw, 0, hd), P(hw, h, hd), P(-hw, h, hd), N(0, 1),
-        [0, v0, ru, v0, ru, v0 + rv, 0, v0 + rv], sideCols);
+      faceU(P(-hw, 0, hd), P(hw, 0, hd), P(hw, h, hd), P(-hw, h, hd), N(0, 1),
+        ru, v0, v0 + rv, sideCols);
       // -local z
-      this.quad(P(hw, 0, -hd), P(-hw, 0, -hd), P(-hw, h, -hd), P(hw, h, -hd), N(0, -1),
-        [0, v0, ru, v0, ru, v0 + rv, 0, v0 + rv], sideCols);
+      faceU(P(hw, 0, -hd), P(-hw, 0, -hd), P(-hw, h, -hd), P(hw, h, -hd), N(0, -1),
+        ru, v0, v0 + rv, sideCols);
       // +local x
-      this.quad(P(hw, 0, hd), P(hw, 0, -hd), P(hw, h, -hd), P(hw, h, hd), N(1, 0),
-        [0, v0, rd, v0, rd, v0 + rv, 0, v0 + rv], sideCols);
+      faceU(P(hw, 0, hd), P(hw, 0, -hd), P(hw, h, -hd), P(hw, h, hd), N(1, 0),
+        rd, v0, v0 + rv, sideCols);
       // -local x
-      this.quad(P(-hw, 0, -hd), P(-hw, 0, hd), P(-hw, h, hd), P(-hw, h, -hd), N(-1, 0),
-        [0, v0, rd, v0, rd, v0 + rv, 0, v0 + rv], sideCols);
+      faceU(P(-hw, 0, -hd), P(-hw, 0, hd), P(-hw, h, hd), P(-hw, h, -hd), N(-1, 0),
+        rd, v0, v0 + rv, sideCols);
     }
     if (top) {
-      this.quad(P(-hw, h, hd), P(hw, h, hd), P(hw, h, -hd), P(-hw, h, -hd), [0, 1, 0],
-        [0, 0, ru, 0, ru, rd, 0, rd], col);
+      faceU(P(-hw, h, hd), P(hw, h, hd), P(hw, h, -hd), P(-hw, h, -hd), [0, 1, 0],
+        ru, 0, rd, col);
     }
   }
 

--- a/apps/auto/src/textures.js
+++ b/apps/auto/src/textures.js
@@ -22,10 +22,10 @@ function canvas(w, h) {
 // height, and at anisotropy 8 they shimmered as you walked. Removing the albedo
 // map dropped the frame-to-frame churn from a 4 mm camera move from 6.6% of
 // pixels to 0.7%, so the flicker was all in this one map.
-function tex(c, { repeat = true, aniso = 16, srgb = true, mips = true } = {}) {
+function tex(c, { repeat = true, aniso = 16, srgb = true, mips = true, clampS = false } = {}) {
   const t = new THREE.CanvasTexture(c);
   if (repeat) {
-    t.wrapS = THREE.RepeatWrapping;
+    t.wrapS = clampS ? THREE.ClampToEdgeWrapping : THREE.RepeatWrapping;
     t.wrapT = THREE.RepeatWrapping;
   }
   t.anisotropy = aniso;
@@ -48,8 +48,8 @@ function noise(g, w, h, amount, seed) {
   g.putImageData(img, 0, 0);
 }
 
-/** Sobel a greyscale height canvas into a tangent-space normal map. */
-function normalFrom(heightCanvas, strength = 2.0) {
+/** Sobel a greyscale height canvas into a tangent-space normal map canvas. */
+function normalCanvas(heightCanvas, strength = 2.0) {
   const w = heightCanvas.width, h = heightCanvas.height;
   const src = heightCanvas.getContext('2d').getImageData(0, 0, w, h).data;
   const lum = new Float32Array(w * h);
@@ -73,7 +73,11 @@ function normalFrom(heightCanvas, strength = 2.0) {
     }
   }
   g.putImageData(img, 0, 0);
-  return tex(c, { srgb: false });
+  return c;
+}
+
+function normalFrom(heightCanvas, strength = 2.0) {
+  return tex(normalCanvas(heightCanvas, strength), { srgb: false });
 }
 
 const grey = (v) => {
@@ -326,10 +330,7 @@ function masonrySurface(opts = {}) {
   }
   noise(a.g, S, S, 16, 9);
   noise(hgt.g, S, S, 3, 12);
-  return {
-    map: tex(a.c), normalMap: normalFrom(hgt.c, 2.2),
-    roughnessMap: tex(rgh.c, { srgb: false }), emissiveMap: tex(emi.c),
-  };
+  return { albedo: a.c, height: hgt.c, rough: rgh.c, emissive: emi.c, nrm: 2.2 };
 }
 
 function industrialSurface() {
@@ -379,7 +380,7 @@ function industrialSurface() {
     a.g.fillRect(x, r() * S * 0.6, 3 + r() * 8, 40 + r() * 160);
   }
   noise(a.g, S, S, 16, 5);
-  return { map: tex(a.c), normalMap: normalFrom(hgt.c, 2.0), roughnessMap: tex(rgh.c, { srgb: false }) };
+  return { albedo: a.c, height: hgt.c, rough: rgh.c, emissive: null, nrm: 2.0 };
 }
 
 function houseSurface() {
@@ -432,10 +433,7 @@ function houseSurface() {
   a.g.fillStyle = 'rgba(255,255,255,0.22)'; a.g.fillRect(330, 316, 84, 62);
   a.g.fillStyle = '#d8c07a'; a.g.fillRect(410, 396, 12, 12);
   noise(a.g, S, S, 11, 11);
-  return {
-    map: tex(a.c), normalMap: normalFrom(hgt.c, 2.4),
-    roughnessMap: tex(rgh.c, { srgb: false }), emissiveMap: tex(emi.c),
-  };
+  return { albedo: a.c, height: hgt.c, rough: rgh.c, emissive: emi.c, nrm: 2.4 };
 }
 
 // ---------------------------------------------------------------------------
@@ -784,23 +782,191 @@ function signSurface() {
     }
   }
   noise(a.g, S, S, 7, 5);
-  return { map: tex(a.c), emissiveMap: tex(emi.c), roughnessMap: tex(rgh.c, { srgb: false }) };
+  return { albedo: a.c, height: null, rough: rgh.c, emissive: emi.c, nrm: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// Facade atlas
+// ---------------------------------------------------------------------------
+
+// Guard columns each side of a cell, filled with the cell's OWN opposite edge,
+// so bilinear and the first three mip levels filter as if the tile wrapped
+// rather than pulling in the neighbouring family. Eight is what covers mip 3;
+// past that a whole cell is a handful of texels and the wall is a few pixels
+// on screen.
+const GUARD = 8;
+const FS = 512;
+const CELL_W = FS + GUARD * 2;
+
+/**
+ * Lay a list of 512-square cells out side by side, with wrap-padding.
+ *
+ * The strip is HORIZONTAL on purpose. GL repeat wraps the whole texture rather
+ * than a sub-rect, so an atlas normally can't carry tiling surfaces at all --
+ * but a strip one tile TALL still wraps correctly in V, so vertical repeats (a
+ * 100 m tower is seven of them) cost nothing and only U has to be confined to a
+ * cell. Builder.box pre-splits a face into one quad per horizontal repeat, so
+ * every UV that reaches the sampler is already inside. That keeps this to plain
+ * textures and plain UVs -- no onBeforeCompile, no sampler2DArray, nothing this
+ * renderer has to take on trust on a phone, which is the same reason postfx.js
+ * is 8-bit throughout.
+ */
+function stripAtlas(cells) {
+  const { c, g } = canvas(CELL_W * cells.length, FS);
+  cells.forEach((src, i) => {
+    const ox = i * CELL_W;
+    g.drawImage(src, ox + GUARD, 0);
+    g.drawImage(src, FS - GUARD, 0, GUARD, FS, ox, 0, GUARD, FS);
+    g.drawImage(src, 0, 0, GUARD, FS, ox + CELL_W - GUARD, 0, GUARD, FS);
+  });
+  return c;
+}
+
+function solidCell(css) {
+  const { c, g } = canvas(FS, FS);
+  g.fillStyle = css;
+  g.fillRect(0, 0, FS, FS);
+  return c;
+}
+
+const px = (src) => src.getContext('2d').getImageData(0, 0, FS, FS).data;
+
+/**
+ * Pre-scale a normal map's xy exactly the way `normalScale` would, so one
+ * material can carry five families' relief strengths. The shader does
+ * `mapN.xy *= normalScale` on the decoded [-1,1] vector and only then
+ * normalises, so scaling by ns/nsMax here and setting normalScale to nsMax
+ * reproduces each family's old value to the byte -- and every ratio is <= 1,
+ * so nothing clips.
+ */
+function scaledNormal(heightCanvas, strength, k) {
+  if (!heightCanvas) return solidCell('rgb(128,128,255)');
+  const src = px(normalCanvas(heightCanvas, strength));
+  const { c, g } = canvas(FS, FS);
+  const img = g.createImageData(FS, FS);
+  const d = img.data;
+  for (let i = 0; i < d.length; i += 4) {
+    d[i] = Math.round(127.5 + (src[i] - 127.5) * k);
+    d[i + 1] = Math.round(127.5 + (src[i + 1] - 127.5) * k);
+    d[i + 2] = src[i + 2];
+    d[i + 3] = 255;
+  }
+  g.putImageData(img, 0, 0);
+  return c;
+}
+
+/**
+ * R = ambient occlusion, G = roughness, B = metalness -- one map read through
+ * three slots.
+ *
+ * `roughness` and `metalness` are plain multipliers on their channels, so those
+ * two bake exactly. `envMapIntensity` has no per-texel channel of its own, but
+ * three's AO term multiplies the indirect (image-based) light, which is the
+ * only thing env was ever dialling; putting each family's env ratio in R gets
+ * the diffuse IBL back exactly and the indirect specular to within the
+ * occlusion curve.
+ */
+function packedCell(roughCanvas, env, rough, metal) {
+  const src = roughCanvas ? px(roughCanvas) : null;
+  const { c, g } = canvas(FS, FS);
+  const img = g.createImageData(FS, FS);
+  const d = img.data;
+  const r = Math.round(env * 255), b = Math.round(metal * 255);
+  for (let i = 0; i < d.length; i += 4) {
+    d[i] = r;
+    d[i + 1] = Math.round((src ? src[i] : 255) * rough);
+    d[i + 2] = b;
+    d[i + 3] = 255;
+  }
+  g.putImageData(img, 0, 0);
+  return c;
+}
+
+const toLinear = (v) => (v <= 0.04045 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4));
+const toSRGB = (v) => (v <= 0.0031308 ? v * 12.92 : 1.055 * Math.pow(v, 1 / 2.4) - 0.055);
+
+/**
+ * Scale an emissive cell in LINEAR space, so one `emissiveIntensity` covers
+ * both a lit shop sign and a lit office window a hundred times fainter.
+ *
+ * The hundredfold gap is what makes this look impossible, and sRGB is what
+ * makes it fine: the map is sRGB-encoded, so a window at 1/100 of a sign still
+ * lands on texel 31 rather than on texel 2.
+ */
+function scaledEmissive(src, k) {
+  if (!src || k === 0) return solidCell('#000');
+  const s = px(src);
+  const { c, g } = canvas(FS, FS);
+  const img = g.createImageData(FS, FS);
+  const d = img.data;
+  for (let i = 0; i < d.length; i += 4) {
+    for (let ch = 0; ch < 3; ch++) {
+      d[i + ch] = Math.round(toSRGB(toLinear(s[i + ch] / 255) * k) * 255);
+    }
+    d[i + 3] = 255;
+  }
+  g.putImageData(img, 0, 0);
+  return c;
+}
+
+/**
+ * One material for every wall in the city.
+ *
+ * Six facade materials cost 139 draw calls a frame downtown to carry 34k
+ * triangles -- 247 triangles a draw, on a target where draw calls are the
+ * binding constraint and triangles are not. They are one material now, and the
+ * per-family differences that used to force them apart are all baked into the
+ * maps: relief into the normal's xy, roughness and metalness into their own
+ * channels, env into AO, emissive brightness into the emissive canvas itself.
+ * The coursing, the corrugation and the lap siding stay entirely distinct,
+ * which is the part no tint could ever have produced.
+ */
+function facadeAtlas(fams) {
+  const nsMax = Math.max(...fams.map((f) => f.ns));
+  const envMax = Math.max(...fams.map((f) => f.env));
+  const metalMax = Math.max(...fams.map((f) => f.metal));
+  const emiMax = Math.max(...fams.map((f) => f.emissive));
+  const W = CELL_W * fams.length;
+  const cells = {};
+  fams.forEach((f, i) => {
+    cells[f.name] = [(i * CELL_W + GUARD) / W, FS / W];
+  });
+  return {
+    map: tex(stripAtlas(fams.map((f) => f.s.albedo)), { clampS: true }),
+    normalMap: tex(stripAtlas(fams.map((f) => scaledNormal(f.s.height, f.s.nrm, f.ns / nsMax))),
+      { srgb: false, clampS: true }),
+    packed: tex(stripAtlas(fams.map((f) => packedCell(f.s.rough, f.env / envMax, f.rough, f.metal / metalMax))),
+      { srgb: false, clampS: true }),
+    emissiveMap: tex(stripAtlas(fams.map((f) => scaledEmissive(f.s.emissive, f.emissive / emiMax))),
+      { clampS: true }),
+    cells, envMax, nsMax, metalMax, emiMax,
+  };
 }
 
 export function buildTextures() {
   return {
     glass: glassSurface(),
-    signs: signSurface(),
-    masonry: masonrySurface(),
-    // Brick is its own texture, not a tint of the stone one. 11 px courses over
-    // a 12 m tile is a ~26 cm brick -- coarser than life, because at 512 px a
-    // true 7 cm course is sub-texel and mips straight to flat grey.
-    brick: masonrySurface({
-      base: '#a89a90', mortar: '#c9c2b4', course: 11, seedN: 47,
-      surround: '#cfc9bc', sill: '#d6d1c6',
-    }),
-    industrial: industrialSurface(),
-    house: houseSurface(),
+    // Every family's old material parameters travel with it here; `facadeAtlas`
+    // is what folds them into the one material's maps.
+    facade: facadeAtlas([
+      { name: 'masonry', s: masonrySurface(), env: 0.66, ns: 1.5, rough: 1, metal: 0, emissive: 0.015 },
+      // Brick is its own cell, not a tint of the stone one. 11 px courses over
+      // a 12 m tile is a ~26 cm brick -- coarser than life, because at 512 px a
+      // true 7 cm course is sub-texel and mips straight to flat grey. What
+      // separates brick from stone at street distance is the COURSING, and no
+      // tint and no shared cell can produce that.
+      {
+        name: 'brick',
+        s: masonrySurface({
+          base: '#a89a90', mortar: '#c9c2b4', course: 11, seedN: 47,
+          surround: '#cfc9bc', sill: '#d6d1c6',
+        }),
+        env: 0.60, ns: 1.5, rough: 1, metal: 0, emissive: 0.015,
+      },
+      { name: 'industrial', s: industrialSurface(), env: 0.5, ns: 1.7, rough: 1, metal: 0.25, emissive: 0 },
+      { name: 'house', s: houseSurface(), env: 0.45, ns: 1.8, rough: 1, metal: 0, emissive: 0.015 },
+      { name: 'signs', s: signSurface(), env: 0.5, ns: 0, rough: 0.62, metal: 0, emissive: 1.5 },
+    ]),
     road: roadSurface(),
     sidewalk: sidewalkSurface(),
     ground: groundSurface(),

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -132,6 +132,38 @@ function tint(seed, base, spread) {
   return [mute(base[0], dr), mute(base[1], 0), mute(base[2], db)];
 }
 
+/**
+ * The one wall material.
+ *
+ * Each family's old parameters are already folded into the atlas, so what is
+ * left here is the maxima they were folded against: `roughness` and `metalness`
+ * multiply their own channels, `normalScale` multiplies the pre-scaled xy, and
+ * `envMapIntensity` is recovered per-texel through the AO channel -- three's AO
+ * term attenuates the image-based light, which is the only thing env drove.
+ * `aoMap.channel` is pinned to 0 because AO is the one slot three historically
+ * read from a SECOND uv set, and there isn't one here: a wall sampling AO at a
+ * missing uv1 comes back uniformly dark over the whole city.
+ */
+function facadeMat(f) {
+  const m = new THREE.MeshStandardMaterial({
+    map: f.map,
+    normalMap: f.normalMap,
+    roughnessMap: f.packed,
+    metalnessMap: f.packed,
+    aoMap: f.packed,
+    emissiveMap: f.emissiveMap,
+    vertexColors: true,
+    roughness: 1,
+    metalness: f.metalMax,
+    envMapIntensity: f.envMax,
+  });
+  f.packed.channel = 0;
+  m.emissive = new THREE.Color(0xffffff);
+  m.emissiveIntensity = f.emiMax;
+  m.normalScale = new THREE.Vector2(f.nsMax, f.nsMax);
+  return m;
+}
+
 const DARK = [0.26, 0.27, 0.29];
 const TRIM = [0.55, 0.55, 0.56];
 // Accents stay the one place saturated colour is allowed, but pulled back:
@@ -181,14 +213,13 @@ export class World {
       // polygon faces that read as a missing texture, not as sunlight. Pulling
       // it down is what makes the exposure headroom available.
       glass: surf(tx.glass, { env: 0.9, metalness: 0.34, roughness: 0.22, ns: 1.1, emissive: 0.02 }),
-      masonry: surf(tx.masonry, { env: 0.66, ns: 1.5, emissive: 0.015 }),
-      brick: surf(tx.brick, { env: 0.60, ns: 1.5, emissive: 0.015 }),
-      // Signage. Emissive is high because a fifth of the atlas cells are lit
-      // plates and the rest have a black emissive, so the intensity only ever
-      // applies to the ones meant to glow.
-      signs: surf(tx.signs, { env: 0.5, roughness: 0.62, emissive: 1.5 }),
-      industrial: surf(tx.industrial, { env: 0.5, metalness: 0.25, ns: 1.7 }),
-      house: surf(tx.house, { env: 0.45, ns: 1.8, emissive: 0.015 }),
+      // Stone, brick, corrugated industrial, lap-sided house and shop signage,
+      // in one material. They were five, and five merged meshes per chunk was
+      // 115 draw calls downtown for 25k triangles. Everything that used to
+      // differ between them now rides in the maps -- see `facadeAtlas` in
+      // textures.js -- so the surfaces themselves are untouched: brick still
+      // has its own running bond, not a tint of the ashlar.
+      facade: facadeMat(tx.facade),
       flat: new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.82, metalness: 0.04, envMapIntensity: 0.45 }),
       glow: new THREE.MeshBasicMaterial({ vertexColors: true, toneMapped: false }),
       // The far skyline is a silhouette mesh: what matters is that a mass two
@@ -199,6 +230,8 @@ export class World {
       // not like distance.
       far: new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.9, metalness: 0.02, envMapIntensity: 0.85 }),
     };
+    // [u0, du] per wall family in the facade atlas, passed to Builder.box.
+    this.cells = tx.facade.cells;
     this.group = new THREE.Group();
     scene.add(this.group);
   }
@@ -513,11 +546,7 @@ export class World {
     const walk = new Builder(true);
     const flat = new Builder(false);
     const glow = new Builder(false);
-    const bl = {
-      glass: new Builder(true), masonry: new Builder(true), brick: new Builder(true),
-      signs: new Builder(true),
-      industrial: new Builder(true), house: new Builder(true),
-    };
+    const bl = { glass: new Builder(true), facade: new Builder(true) };
 
     const own = (x, z) => Math.floor(x / CHUNK) === cx && Math.floor(z / CHUNK) === cz;
     const nodesDone = new Set();
@@ -563,11 +592,7 @@ export class World {
     add(flat, this.mats.flat, true, true);
     add(glow, this.mats.glow, false, false);
     add(bl.glass, this.mats.glass, true, true);
-    add(bl.masonry, this.mats.masonry, true, true);
-    add(bl.brick, this.mats.brick, true, true);
-    add(bl.signs, this.mats.signs, true, false);
-    add(bl.industrial, this.mats.industrial, true, true);
-    add(bl.house, this.mats.house, true, true);
+    add(bl.facade, this.mats.facade, true, true);
     return grp.children.length ? grp : null;
   }
 
@@ -1192,12 +1217,18 @@ export class World {
 
   meshBuilding(bl, flat, glow, bd) {
     const seed = bd.seed;
-    let target, col, uS = 14, vS = 13.6;
+    const C = this.cells;
+    let target, col, cell = null, uS = 14, vS = 13.6;
     const fam = (bd.style === 'tower' || bd.style === 'midrise'
       || bd.style === 'brick' || bd.style === 'lowrise')
       ? this.buildingFamily(bd) : null;
     if (fam) {
-      target = fam.m === 'glass' ? bl.glass : fam.m === 'brick' ? bl.brick : bl.masonry;
+      // Glass keeps its own material: it is the one facade whose look is mostly
+      // indirect SPECULAR, and that is the part of envMapIntensity the AO
+      // channel can only approximate. Everything else joins the atlas.
+      const glassy = fam.m === 'glass';
+      target = glassy ? bl.glass : bl.facade;
+      if (!glassy) cell = C[fam.m];
       // Jitter stays INSIDE the family, so a brick street varies in weathering
       // rather than becoming a different material every other lot.
       col = tint(seed, fam.c, 0.26);
@@ -1207,9 +1238,11 @@ export class World {
       // sliced through by the parapet on every building in the city.
       vS = bd.h / Math.max(1, Math.round(bd.h / fam.v));
     } else if (bd.style === 'industrial') {
-      target = bl.industrial; col = tint(seed, [0.84, 0.86, 0.86], 0.3); uS = 16; vS = 16;
+      target = bl.facade; cell = C.industrial;
+      col = tint(seed, [0.84, 0.86, 0.86], 0.3); uS = 16; vS = 16;
     } else {
-      target = bl.house; col = tint(seed, [0.94, 0.92, 0.88], 0.36); uS = 0; vS = 0;
+      target = bl.facade; cell = C.house;
+      col = tint(seed, [0.94, 0.92, 0.88], 0.36); uS = 0; vS = 0;
     }
 
     if (bd.kind) return this.meshLandmarkTower(bl, flat, bd, col);
@@ -1220,13 +1253,14 @@ export class World {
 
     if (bd.style === 'house') {
       const wallH = bd.h * 0.72;
-      target.box(bd.x, base, bd.z, bd.w, wallH + 2, bd.d, bd.rot, col, { top: false, uScale: 0, vScale: 0, ao: 0.3 });
+      target.box(bd.x, base, bd.z, bd.w, wallH + 2, bd.d, bd.rot, col,
+        { top: false, uScale: 0, vScale: 0, ao: 0.3, cell });
       // Roofs were a flat near-black polygon that can fill a third of a frame
-      // with no material at all. Route them through the industrial builder so
+      // with no material at all. Route them through the industrial cell so
       // they take a texture, and lift them off black.
       const rc = tint(seed, [0.46, 0.43, 0.41], 0.16);
-      bl.industrial.box(bd.x, base + wallH + 2, bd.z, bd.w + 0.7, 0.26, bd.d + 0.7, bd.rot, rc,
-        { uScale: 5, vScale: 5 });
+      bl.facade.box(bd.x, base + wallH + 2, bd.z, bd.w + 0.7, 0.26, bd.d + 0.7, bd.rot, rc,
+        { uScale: 5, vScale: 5, cell: C.industrial });
       // A gable that fits the house it sits on.
       //
       // This used to be `cone(..., max(w, d) * 0.74, ..., 4, ...)` -- a square
@@ -1301,8 +1335,16 @@ export class World {
         [rv * 1.2, rv * 1.2, rv * 1.17]);
       // The lid itself, on a textured builder. A roof is seen from every
       // elevated view in the game and it was one flat untextured colour.
-      bl.industrial.box(bd.x, rt - 0.12, bd.z, bd.w + 0.2, 0.14, bd.d + 0.2, bd.rot,
-        [rv * 0.92, rv * 0.93, rv * 0.96], { uScale: 7, vScale: 7 });
+      // At 7 m a tile this slab is the single biggest thing splitting into
+      // per-repeat quads for the atlas -- about half the facade set's triangles
+      // across a downtown chunk, for a 12 cm band. Dropping its sides is the
+      // obvious saving and it is NOT free: the band is the only part of the lid
+      // you can see (the parapet box above covers its top face outright), and
+      // removing it visibly cleans the corrugated grain out from under every
+      // cornice in the city. That is a look change, not a perf change, so it
+      // stays.
+      bl.facade.box(bd.x, rt - 0.12, bd.z, bd.w + 0.2, 0.14, bd.d + 0.2, bd.rot,
+        [rv * 0.92, rv * 0.93, rv * 0.96], { uScale: 7, vScale: 7, cell: C.industrial });
     }
 
     const dense = bd.style !== 'industrial';
@@ -1333,7 +1375,7 @@ export class World {
         const [ax, az] = off(0, bd.d / 2 + 0.9);
         flat.box(ax, y + plinthH - 1.4, az, bd.w * 0.62, 0.22, 1.8, bd.rot, ac);
       }
-      this.meshSigns(bl.signs, flat, bd, y + plinthH, plinthH, seed, off);
+      this.meshSigns(bl.facade, flat, bd, y + plinthH, plinthH, seed, off);
       y += plinthH + 0.5;
       remaining -= plinthH + 0.5;
     }
@@ -1344,7 +1386,7 @@ export class World {
       const frac = t === tiers - 1 ? 1 : t === 0 ? 0.62 : 0.6;
       const hh = remaining * frac;
       target.box(bd.x, y, bd.z, w, hh, d, bd.rot, col,
-        { uScale: uS, vScale: vS, top: false, vOff: (y - base) / (vS || 1), ao: t === 0 ? 0.22 : 0 });
+        { uScale: uS, vScale: vS, top: false, vOff: (y - base) / (vS || 1), ao: t === 0 ? 0.22 : 0, cell });
       y += hh;
       remaining -= hh;
       if (t < tiers - 1) {
@@ -1382,6 +1424,7 @@ export class World {
 
   meshLandmarkTower(bl, flat, bd, col) {
     const base = bd.y - 2;
+    const stone = this.cells.masonry;
     if (bd.kind === 'columbia') {
       const dark = [0.24, 0.26, 0.3];
       const c = Math.cos(bd.rot), s = Math.sin(bd.rot);
@@ -1397,9 +1440,11 @@ export class World {
     }
     if (bd.kind === 'smith') {
       const white = [1.05, 1.02, 0.96];
-      bl.masonry.box(bd.x, base, bd.z, bd.w * 1.5, 22, bd.d * 1.5, bd.rot, white, { uScale: 12, vScale: 12, top: false, ao: 0.35 });
+      bl.facade.box(bd.x, base, bd.z, bd.w * 1.5, 22, bd.d * 1.5, bd.rot, white,
+        { uScale: 12, vScale: 12, top: false, ao: 0.35, cell: stone });
       flat.box(bd.x, base + 22, bd.z, bd.w * 1.5 + 1.2, 1.1, bd.d * 1.5 + 1.2, bd.rot, [0.78, 0.77, 0.73]);
-      bl.masonry.box(bd.x, base + 23.1, bd.z, bd.w, bd.h - 45, bd.d, bd.rot, white, { uScale: 11, vScale: 11, top: false });
+      bl.facade.box(bd.x, base + 23.1, bd.z, bd.w, bd.h - 45, bd.d, bd.rot, white,
+        { uScale: 11, vScale: 11, top: false, cell: stone });
       flat.box(bd.x, base + bd.h - 22, bd.z, bd.w + 1.6, 1.5, bd.d + 1.6, bd.rot, [0.78, 0.77, 0.73]);
       // cone() places its four vertices on the axes, so a 4-sided one is a
       // DIAMOND in plan -- 45 deg out from the square tower under it, and it
@@ -1414,7 +1459,8 @@ export class World {
       let y = base, w = bd.w, d = bd.d, h = bd.h + 2;
       for (let t = 0; t < 4; t++) {
         const hh = h * (t === 3 ? 1 : 0.34);
-        bl.masonry.box(bd.x, y, bd.z, w, hh, d, bd.rot, c2, { uScale: 12, vScale: 12, top: false, ao: t === 0 ? 0.28 : 0 });
+        bl.facade.box(bd.x, y, bd.z, w, hh, d, bd.rot, c2,
+          { uScale: 12, vScale: 12, top: false, ao: t === 0 ? 0.28 : 0, cell: stone });
         flat.box(bd.x, y + hh, bd.z, w + 0.8, 0.7, d + 0.8, bd.rot, TRIM);
         y += hh + 0.7; h -= hh; w *= 0.84; d *= 0.84;
         if (h < 6) break;
@@ -1422,11 +1468,13 @@ export class World {
       flat.prism(bd.x, y, bd.z, 0.35, 16, 4, [0.4, 0.4, 0.42]);
       return;
     }
-    const target = bd.kind === 'stone' ? bl.masonry : bl.glass;
+    const isStone = bd.kind === 'stone';
+    const target = isStone ? bl.facade : bl.glass;
     let y = base, h = bd.h + 2, w = bd.w, d = bd.d;
     for (let t = 0; t < 3; t++) {
       const hh = t === 2 ? h : h * 0.5;
-      target.box(bd.x, y, bd.z, w, hh, d, bd.rot, col, { uScale: 13, vScale: 13, top: false, ao: t === 0 ? 0.28 : 0 });
+      target.box(bd.x, y, bd.z, w, hh, d, bd.rot, col,
+        { uScale: 13, vScale: 13, top: false, ao: t === 0 ? 0.28 : 0, cell: isStone ? stone : null });
       flat.box(bd.x, y + hh, bd.z, w + 0.8, 0.6, d + 0.8, bd.rot, TRIM);
       y += hh + 0.6; h -= hh; w *= 0.86; d *= 0.86;
       if (h < 8) break;
@@ -1452,7 +1500,12 @@ export class World {
   meshSigns(sg, flat, bd, topY, plinthH, seed, off) {
     if (bd.w < 6 && bd.d < 6) return;
     const N = 4, C = 1 / N;
-    const cell = (k) => {
+    // The 4 x 4 plate grid now sits inside the facade atlas's signage cell, so
+    // every U goes through `su`. V is untouched -- these UVs are already inside
+    // 0..1 and the atlas is exactly one tile tall.
+    const [su0, sdu] = this.cells.signs;
+    const su = (u) => su0 + u * sdu;
+    const plate = (k) => {
       const i = Math.floor(hash2(seed, k) * 16);
       return [(i % N) * C, Math.floor(i / N) * C];
     };
@@ -1477,7 +1530,7 @@ export class World {
       // Signing every face of every building makes the city a retail park.
       if (f === 1 && hash2(seed, 200) > 0.55) continue;
       if (fc.span < 5) continue;
-      const [u0, v0] = cell(201 + f * 7);
+      const [u0, v0] = plate(201 + f * 7);
       const nrm = dirOf(fc.out[0], fc.out[1]);
       const halfW = fc.span * 0.38;
       // Stand a little proud of the plinth, which is itself 0.15 m wider than
@@ -1489,12 +1542,12 @@ export class World {
       };
       const yTop = topY - 0.18, yBot = yTop - fh;
       sg.quad(pt(-halfW, yBot), pt(halfW, yBot), pt(halfW, yTop), pt(-halfW, yTop),
-        nrm, [u0, v0, u0 + C, v0, u0 + C, v0 + C, u0, v0 + C], [1, 1, 1]);
+        nrm, [su(u0), v0, su(u0 + C), v0, su(u0 + C), v0 + C, su(u0), v0 + C], [1, 1, 1]);
 
       // Projecting blade sign: hung near one end and read from ALONG the
       // street rather than across it, which is the whole point of a blade.
       if (hash2(seed, 210 + f) > 0.62) {
-        const [bu, bv] = cell(220 + f * 3);
+        const [bu, bv] = plate(220 + f * 3);
         const bt = halfW * (hash2(seed, 230 + f) > 0.5 ? 0.72 : -0.72);
         const bladeN = dirOf(fc.along[0], fc.along[1]);
         const byTop = yTop + 0.4, byBot = byTop - 1.5;
@@ -1504,21 +1557,21 @@ export class World {
           return [wx, yy, wz];
         };
         sg.quad(q(0.05, byBot), q(1.0, byBot), q(1.0, byTop), q(0.05, byTop),
-          bladeN, [bu, bv, bu + C, bv, bu + C, bv + C, bu, bv + C], [1, 1, 1]);
+          bladeN, [su(bu), bv, su(bu + C), bv, su(bu + C), bv + C, su(bu), bv + C], [1, 1, 1]);
       }
     }
 
     // Rooftop billboard, on low and mid buildings only: on a tower it sits
     // 150 m up where nobody reads it, and on a house it is absurd.
     if (bd.h > 10 && bd.h < 42 && bd.w > 14 && hash2(seed, 240) > 0.72) {
-      const [bu, bv] = cell(241);
+      const [bu, bv] = plate(241);
       const bw = Math.min(bd.w * 0.7, 16), bh = bw * 0.42;
       const yb = bd.y - 2 + bd.h + 3.4;
       const p0 = off(-bw / 2, bd.d * 0.2), p1 = off(bw / 2, bd.d * 0.2);
       const nrm = dirOf(0, 1);
       sg.quad([p0[0], yb, p0[1]], [p1[0], yb, p1[1]],
         [p1[0], yb + bh, p1[1]], [p0[0], yb + bh, p0[1]],
-        nrm, [bu, bv, bu + C, bv, bu + C, bv + C, bu, bv + C], [1, 1, 1]);
+        nrm, [su(bu), bv, su(bu + C), bv, su(bu + C), bv + C, su(bu), bv + C], [1, 1, 1]);
       // Legs, so it stands on the roof instead of floating over it.
       for (const lt of [-bw * 0.34, bw * 0.34]) {
         const [lx, lz] = off(lt, bd.d * 0.2);

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v35';
+const CACHE = 'auto-v36';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',


### PR DESCRIPTION
Follow-up to #346, going after the largest remaining waste. Build **v36**.

## The problem

Measured downtown across 24 near chunks, the six facade materials cost **139
draw calls to carry 34,442 triangles — 247 triangles per draw call.** `house`
managed 52.

| material | meshes | triangles | tris/draw |
|---|---|---|---|
| glass | 24 | 9,136 | 380 |
| masonry | 24 | 3,768 | 157 |
| brick | 24 | 4,424 | 184 |
| signs | 24 | 4,672 | 194 |
| industrial | 24 | 11,442 | 476 |
| house | 19 | 1,000 | **52** |

Draw calls are the binding constraint on a phone and triangles are not, so
roughly a quarter of the frame was going on almost no geometry.

## Why it isn't just "make an atlas"

You cannot naively atlas a *tiling* texture — GL repeat wraps the whole image,
not a sub-rect. Three routes were on the table: a WebGL2 texture array, an atlas
with `fract()` in the shader, or an atlas with UVs pre-wrapped at build time.

The first two both need `onBeforeCompile` surgery across albedo, normal,
roughness *and* emissive. `apps/auto/CLAUDE.md` records that this pipeline
deliberately avoids clever GPU features because the target device can't be
profiled from here — half-float render targets silently black-screen iOS. So:
route three, no shader work at all.

**The refinement that made it cheap: the atlas is a horizontal strip exactly one
tile tall.** `wrapT` then still repeats natively, so vertical repeats stay free —
a 100 m tower is seven of them — and only U has to be confined to its cell.
`Builder.box` cuts a face into one quad per *horizontal* repeat. Splitting both
axes would have cost roughly 4× the triangles; this cost 41% on the facade set.

Five of six merged. Glass stays separate: its look is mostly indirect
*specular*, which is the part of `envMapIntensity` the AO trick below can only
approximate.

Everything that used to force the five apart is baked into the maps, since one
material has only one of each:

- **`normalScale`** pre-scaled into the normal map's xy. Three scales the
  decoded vector and only then normalises, so `ns / nsMax` reproduces each
  family's old value exactly, and every ratio is ≤ 1 so nothing clips.
- **`roughness` / `metalness`** become channels of one packed map.
- **`envMapIntensity`** becomes the AO channel — three's AO term attenuates the
  image-based light, which is the only thing env was ever dialling.
- **`emissiveIntensity`** spans 100× between a lit shop sign and a lit office
  window, and survives because the emissive map is sRGB-encoded: the window
  lands on texel 31, not texel 2.

Cells carry 8 px of wrap-padding taken from the cell's own opposite edge, so
bilinear and the first three mips filter as though the tile repeated.

## Result

| | before | after |
|---|---|---|
| facade draw calls | 139 | **48** |
| facade triangles | 34,442 | 85,018 |
| frame draw calls | 589 | **497** |
| frame triangles | — | +4.2% |
| `verify` scene pass | 326 draws | **278 draws** |

## Checks

- `node tools/verify.mjs` → `OK: 0 exceptions`
- `node tools/vehicles.mjs` → `0 figures outside their band, of 72`
- `tools/values.py`: every shot within 0.001 of baseline — `street`
  lit-to-shadow **2.4**, clipping **0.00%**, saturation unchanged.
- Visual: `street`, `shopfront`, `residential`, `downtown` compared before and
  after. Brick keeps its running bond distinct from the ashlar, shopfront fascia
  and blade signs stay legible and emissive, lit windows still glow. Pixel diff
  0.50–0.86/255 against a measured harness noise floor of 0.40 (screen-space
  dither), with no cell seams and no atlas bleed.

## Deliberately not shipped

`sides: false` on the industrial roof lid takes the facade set from 75,882 to
**39,626** triangles and the frame cost from +4.2% to +0.2%. But the lid's 12 cm
side band is the only part of it you can see — the parapet box covers its top
face outright — and removing it visibly cleans a speckled corrugated grain out
from under every cornice in the city. That's an art call, not a perf one, so
it's left as a one-word edit with the saving recorded beside it. Say the word if
you want the triangles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B