### PR TITLE
Auto: steer within grip, fix shadow acne, rewrite SSAO

### DIFF
--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -382,7 +382,7 @@
       <div class="row"><span>Post effects</span><div class="toggle" id="setPost"></div></div>
       <div class="dbgrid">
         <button class="dbg on" data-fx="bloom">Bloom</button>
-        <button class="dbg on" data-fx="ssao">SSAO</button>
+        <button class="dbg" data-fx="ssao">SSAO</button>
         <button class="dbg on" data-fx="grade">Grade</button>
         <button class="dbg on" data-fx="vignette">Vignette</button>
         <button class="dbg on" data-fx="grain">Grain</button>
@@ -414,7 +414,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v36</div>
+    <div id="build">v37</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/src/main.js
+++ b/apps/auto/src/main.js
@@ -393,11 +393,20 @@ function installHeightFog() {
   sun.shadow.camera.right = S;
   sun.shadow.camera.top = S;
   sun.shadow.camera.bottom = -S;
-  // The texel is now ~0.25 m and the old bias no longer spans one: acne comes
-  // back as dark blotches across sunlit facades. normalBias scales with texel
-  // size, so it goes up whenever S does.
+  // Bias is DERIVED from texel size, not written down.
+  //
+  // The rule is that normalBias has to span a shadow texel, and the texel is
+  // 2*S/mapSize -- so it changes whenever either the box or the map does. That
+  // coupling was noted in the docs and then promptly broken: dropping the phone
+  // to a 1024 map made its texel 0.37 m against the desktop's 0.25, and the
+  // bias was moved DOWN at the same time, from 0.12 to 0.09. The result is
+  // classic acne, dark cloudy blotches over flat sunlit ground, and it was
+  // mistaken for an SSAO artefact because it looks like one.
+  //
+  // Computing it removes the chance of getting it wrong again.
+  const shadowTexel = (S * 2) / sun.shadow.mapSize.x;
   sun.shadow.bias = -0.0006;
-  sun.shadow.normalBias = ON_PHONE ? 0.09 : 0.12;
+  sun.shadow.normalBias = shadowTexel * 0.48;
   scene.add(sun);
   scene.add(sun.target);
 

--- a/apps/auto/src/postfx.js
+++ b/apps/auto/src/postfx.js
@@ -277,8 +277,8 @@ export class PostFX {
     this.scenePass = new THREE.Scene();
     this.quadScene = new THREE.Scene();
 
-    this.fx = { bloom: true, ssao: true, grain: true, vignette: true, fxaa: true, grade: true, dither: true };
-    this.base = { bloom: 0.34, grain: 0.0025, vignette: 0.10, fxaa: 1, ao: 1.0 };
+    this.fx = { bloom: true, ssao: false, grain: true, vignette: true, fxaa: true, grade: true, dither: true };
+    this.base = { bloom: 0.34, grain: 0.0025, vignette: 0.10, fxaa: 1, ao: 0.55 };
     this.bloomPasses = 2;
     // Set by the pause-menu switch; kept apart from the tier so a debug session
     // survives an automatic quality change.
@@ -430,6 +430,23 @@ export class PostFX {
     for (const m of [this.bright, this.blur, this.aoBlur, this.composite, this.ssao]) m.material.dispose();
     QUAD.dispose();
   }
+
+  /**
+   * SSAO is OFF by default, and that is not a performance decision.
+   *
+   * It reconstructs its normal from `dFdx/dFdy` of view-space position, which
+   * on a road running away from the camera means neighbouring samples differ
+   * mostly in depth -- so the range check reads occlusion across open tarmac
+   * and lays down large soft dark clouds. On a phone at half resolution,
+   * upscaled through the bilateral blur, they read as smears of dirt on the
+   * screen that follow the camera. It has looked like this since it was added
+   * and it went unnoticed because the beauty harness frames buildings.
+   *
+   * It is also the most expensive pass in the chain, so leaving it off costs
+   * nothing to reclaim. Bringing it back needs the occlusion test to reject by
+   * SURFACE ORIENTATION rather than by depth alone; the switch is there to
+   * check that work against what it does now.
+   */
 
   /**
    * Individual effect switches, for finding out which pass is responsible for

--- a/apps/auto/src/postfx.js
+++ b/apps/auto/src/postfx.js
@@ -204,8 +204,34 @@ vec3 viewPos(vec2 uv) {
   return v.xyz / v.w;
 }
 
-// 12 points on a hemisphere, weighted toward the centre so near-contact
-// darkening reads without the far samples turning into banding.
+/**
+ * Normal from depth, rejecting silhouettes.
+ *
+ * The obvious cross(dFdx(P), dFdy(P)) is computed across a 2x2 quad, so at
+ * any edge in the scene -- a roofline, a kerb, the side of a car -- one pixel of
+ * that quad is on a near surface and one is on a far one, and the normal comes
+ * out as nonsense. That was a band of garbage normals along every edge in the
+ * frame, one quad wide at half resolution and then smeared wider by the blur.
+ *
+ * Taking four neighbours and keeping whichever of each pair is closer in depth
+ * picks the one that is on the SAME surface, so an edge no longer contaminates
+ * the normal on the side of it that is being shaded.
+ */
+vec3 viewNormal(vec2 uv, vec3 P) {
+  vec3 l = viewPos(uv - vec2(texel.x, 0.0));
+  vec3 r = viewPos(uv + vec2(texel.x, 0.0));
+  vec3 d = viewPos(uv - vec2(0.0, texel.y));
+  vec3 u = viewPos(uv + vec2(0.0, texel.y));
+  vec3 dx = abs(l.z - P.z) < abs(r.z - P.z) ? P - l : r - P;
+  vec3 dy = abs(d.z - P.z) < abs(u.z - P.z) ? P - d : u - P;
+  vec3 n = normalize(cross(dx, dy));
+  // View space looks down -Z, so a visible surface faces the camera.
+  return n.z < 0.0 ? -n : n;
+}
+
+// A hemisphere, weighted toward the centre so near-contact darkening reads
+// without the far samples banding. z is kept positive: these are oriented
+// along the surface normal below, not flipped into a half-space.
 const vec3 K[12] = vec3[12](
   vec3( 0.5381, 0.1856, 0.4319), vec3( 0.1379, 0.2486, 0.4430),
   vec3( 0.3371, 0.5679, 0.0057), vec3(-0.6999,-0.0451, 0.0019),
@@ -220,25 +246,56 @@ void main() {
   // Sky: depth 1.0. Occluding it produces a dark halo along every roofline.
   if (z >= 0.9999) { gl_FragColor = vec4(1.0); return; }
   vec3 P = viewPos(vUv);
-  vec3 N = normalize(cross(dFdx(P), dFdy(P)));
+  vec3 N = viewNormal(vUv, P);
+  float dist = -P.z;
+
+  /**
+   * Orient the kernel to the SURFACE, which is the whole ball game.
+   *
+   * The previous version rotated a fixed kernel about the view axis and then
+   * flipped each sample with dot(k, N) < 0. Flipping only guarantees a
+   * sample is on the correct side of the surface -- it does not build a
+   * hemisphere around the normal. On a road raking away from the camera most
+   * samples therefore ended up nearly TANGENT to the tarmac, skimming along it
+   * at essentially the surface's own depth, where whether they counted as
+   * occluders came down entirely to the bias. That is what laid soft dark
+   * clouds over open ground, worse with distance and worse at grazing angles.
+   */
   float rnd = fract(sin(dot(vUv, vec2(12.9898, 78.233))) * 43758.5453);
-  float ca = cos(rnd * 6.2831), sa = sin(rnd * 6.2831);
+  vec3 rvec = vec3(cos(rnd * 6.2831), sin(rnd * 6.2831), 0.0);
+  vec3 T = normalize(rvec - N * dot(rvec, N));
+  mat3 TBN = mat3(T, cross(N, T), N);
+
+  // Bias has to scale with distance. A constant 3.5 cm is fine at 2 m and
+  // meaningless at 40 m, where the depth difference across one sample step on a
+  // receding surface is far larger -- so open road self-occluded.
+  float bi = bias * (1.0 + dist * 0.35);
+
   float occ = 0.0;
   for (int i = 0; i < 12; i++) {
     vec3 k = K[i];
-    k.xy = vec2(k.x * ca - k.y * sa, k.x * sa + k.y * ca);
-    if (dot(k, N) < 0.0) k = -k;
-    vec3 sp = P + k * radius;
+    k.z = abs(k.z);
+    vec3 sp = P + (TBN * k) * radius;
     vec4 cp = proj * vec4(sp, 1.0);
     vec2 suv = (cp.xy / cp.w) * 0.5 + 0.5;
     if (suv.x < 0.0 || suv.x > 1.0 || suv.y < 0.0 || suv.y > 1.0) continue;
     float sz = viewPos(suv).z;
-    // Range check: a foreground object must not occlude the distant ground
-    // behind it, which is what produces black outlines around everything.
-    float rc = smoothstep(0.0, 1.0, radius / abs(P.z - sz));
-    occ += (sz >= sp.z + bias ? 1.0 : 0.0) * rc;
+    // Occluded when the surface actually drawn at that pixel sits nearer the
+    // camera than the sample point does -- i.e. the sample is buried.
+    if (sz >= sp.z + bi) {
+      // Reject occluders that are simply a long way in front: a foreground
+      // object must not darken the distant ground behind it, which is what
+      // draws black outlines around everything.
+      occ += smoothstep(0.0, 1.0, radius / max(abs(P.z - sz), 1e-4));
+    }
   }
-  float ao = clamp(1.0 - (occ / 12.0) * strength, 0.0, 1.0);
+
+  // Fade out with distance. The kernel is a fixed size in metres, so past a few
+  // tens of metres it projects into a pixel or two and all twelve samples read
+  // the same texel -- correlated noise, which the blur turns into a blob rather
+  // than removing.
+  float fade = 1.0 - smoothstep(30.0, 65.0, dist);
+  float ao = clamp(1.0 - (occ / 12.0) * strength * fade, 0.0, 1.0);
   gl_FragColor = vec4(vec3(ao), 1.0);
 }`;
 
@@ -328,9 +385,12 @@ export class PostFX {
       projInv: { value: new THREE.Matrix4() },
       proj: { value: new THREE.Matrix4() },
       texel: { value: new THREE.Vector2() },
-      radius: { value: 0.85 },
-      strength: { value: 2.1 },
-      bias: { value: 0.035 },
+      radius: { value: 0.7 },
+      // Strength was 2.1 to make a broken effect visible. With the kernel
+      // oriented to the surface the occlusion it reports is real, so it needs
+      // far less pushing.
+      strength: { value: 1.1 },
+      bias: { value: 0.02 },
     });
     this.composite = pass(COMPOSITE, {
       tScene: { value: null }, tBloom: { value: null },

--- a/apps/auto/src/vehicles.js
+++ b/apps/auto/src/vehicles.js
@@ -58,6 +58,12 @@ const V0_100 = 100 / 3.6;
 // corner dangerous, and they are not what makes a car feel slow.
 const ARCADE_PUNCH = 2.4;
 
+// And how much more grip than real. Same bargain as ARCADE_PUNCH: the ratios
+// between classes stay honest, the whole scale moves. At true road-tyre grip a
+// sedan's cornering radius at 72 km/h is 46 m, which in a city built from real
+// street widths means you cannot make a junction at any speed worth driving.
+const ARCADE_GRIP = 2.2;
+
 export const TYPES = {
   sedan: deriveSpec({ wheelbase: 2.98,len: 5.06, wid: 1.90, wheelR: 0.34, sill: 0.30, belt: 1.06, roof: 1.50, cab: [-0.26, 0.10], hand: 'sedan', mass: 1.0, acc: 4.1, topKph: 205, brakeM: 40, latG: 0.88 }),
   hatch: deriveSpec({ wheelbase: 2.6,len: 4.10, wid: 1.76, wheelR: 0.31, sill: 0.29, belt: 0.96, roof: 1.50, cab: [-0.30, 0.16], mass: 0.9, acc: 3.6, topKph: 185, brakeM: 41, latG: 0.85 }),
@@ -2935,7 +2941,7 @@ export class Vehicle {
     this.pitch = 0; this.roll = 0;
     this.health = 100;
     this.dead = false;
-    this.understeer = 0;   // how far past the grip limit the front tyres are
+    this.latAcc = 0;       // lateral acceleration, which is what a bike leans to
     // Seconds before this vehicle can take collision damage again. One crash
     // spans many frames -- see damage().
     this.hitCd = 0;
@@ -3024,8 +3030,29 @@ export class Vehicle {
     this.lift = this.city.roadLift(this.x, this.z);
     const sp = Math.abs(this.vLong);
     // Steering authority falls off with speed so the car stays controllable.
+    // Steer within grip, rather than demanding more than the tyres have and
+    // clawing it back afterwards.
+    //
+    // The bicycle model turns steering angle straight into yaw, so at 72 km/h
+    // full lock asks for FIVE g. The friction circle then removed 82 % of it
+    // again, every frame, at every speed above walking pace -- so the limiter
+    // was permanently engaged, the car never went where it was pointed, and the
+    // leftover lateral velocity read as a permanent drift. It felt broken
+    // because functionally it was: the input was being thrown away.
+    //
+    // Solving for the angle the tyres can actually hold means the wheel always
+    // does something, and the car turns as hard as it is able to. Below about
+    // 45 km/h the mechanical lock is the smaller of the two and nothing
+    // changes; above it, grip takes over smoothly.
+    //
+    //   lat = v^2 / L * tan(steer)  <=  latA   ->   steer <= atan(latA * L / v^2)
+    const wheelbase = spec.wheelbase || spec.len * 0.62;
+    const latA = spec.latA * ARCADE_GRIP * (hand > 0.5 ? 0.45 : 1)
+      * (brake > 0 && this.vLong > 0.4 ? 0.8 : 1);
     const maxSteer = lerp(0.62, 0.16, clamp(sp / 34, 0, 1));
-    this.steer = lerp(this.steer, steerIn * maxSteer, 1 - Math.exp(-11 * dt));
+    const gripSteer = sp > 3 ? Math.atan((latA * wheelbase) / (sp * sp)) : maxSteer;
+    const lock = Math.min(maxSteer, gripSteer);
+    this.steer = lerp(this.steer, steerIn * lock, 1 - Math.exp(-11 * dt));
 
     const top = spec.fadeTop;
     let acc = 0;
@@ -3062,14 +3089,10 @@ export class Vehicle {
     this.vLong += acc * dt;
     if (Math.abs(this.vLong) < 0.12 && throttle === 0) this.vLong *= 0.82;
 
-    // Bicycle-model yaw plus lateral slip for arcade drift.
-    // The authored builders each declare their real axle centres, so use them.
-    // `len * 0.62` was a guess made before any vehicle had a wheelbase to read:
-    // it happens to land within 2 cm on the sports car and puts the bus's axles
-    // 7.4 m apart, against a real 6. The handling and the model disagreeing
-    // about where the wheels are is the kind of thing nobody notices directly
-    // and everybody feels.
-    const wheelbase = spec.wheelbase || spec.len * 0.62;
+    // Bicycle-model yaw plus lateral slip for arcade drift. `wheelbase` comes
+    // from the authored builders' real axle centres -- `len * 0.62` was a guess
+    // made before any vehicle had a wheelbase to read, and it put the bus's
+    // axles 7.4 m apart against a real 6.
     const yawRate = (this.vLong / wheelbase) * Math.tan(this.steer);
     this.heading += yawRate * dt;
 
@@ -3081,31 +3104,16 @@ export class Vehicle {
     const before = this.vLat;
     this.vLat *= Math.exp(-grip * dt);
 
-    // The friction circle. There was no lateral limit at ALL: yaw came
-    // straight from the steering angle, so a bus cornered at 1.1 g and a sedan
-    // at 4.4 g, and no amount of speed could ever push a car wide. Nothing in
-    // the game could be taken too fast, which removes most of what driving is.
-    //
-    // Beyond the limit the front tyres stop turning the car and it runs wide,
-    // which is understeer -- the failure a road car actually has. Braking eats
-    // into the same budget, so trail-braking into a corner lets go.
-    const latDemand = Math.abs(yawRate * this.vLong);
-    const braking = brake > 0 && this.vLong > 0.4 ? 0.75 : 1;
-    const latMax = spec.latA * braking * (hand > 0.5 ? 0.45 : 1);
-    // Signed lateral acceleration the tyres are actually delivering, which is
-    // what a bike leans against -- the demand before the limiter would lay one
-    // flat on the road at a cornering speed it cannot hold anyway.
-    let latAcc = yawRate * this.vLong;
-    if (latDemand > latMax && Math.abs(this.vLong) > 1) {
-      const excess = latMax / latDemand;
-      // Give back the yaw the tyres cannot support.
-      this.heading -= yawRate * dt * (1 - excess);
-      this.understeer = clamp((latDemand / latMax - 1) * 1.6, 0, 1);
-      latAcc *= excess;
-    } else {
-      this.understeer = 0;
-    }
-    this.skid = clamp(Math.max(Math.abs(before) * 0.35, this.understeer * 0.8), 0, 1);
+    // Grip is spent in the steering limit above, so there is nothing left to
+    // claw back here. What remains is the slide itself: lateral velocity that
+    // the tyres are scrubbing off, which is what the handbrake unleashes and
+    // what the skid sound and marks read from.
+    // What the bike is actually pulling laterally. This used to come out of the
+    // friction-circle block that the steering clamp replaced; with steering
+    // limited to what grip supports, the yaw the car achieves IS the lateral
+    // acceleration, so there is nothing to correct for.
+    this.latAcc = yawRate * this.vLong;
+    this.skid = clamp(Math.abs(before) * 0.35, 0, 1);
 
     const f = this.forward;
     const rx = f.z, rz = -f.x;
@@ -3163,7 +3171,7 @@ export class Vehicle {
     // backwards here, and a bike leaning out of its corners is unmissable.
     // Faded out below walking pace so a parked bike stands up straight.
     const tgtRoll = two
-      ? -Math.atan2(latAcc, 9.81) * clamp((sp - 0.8) / 2.5, 0, 1)
+      ? -Math.atan2(this.latAcc, 9.81) * clamp((sp - 0.8) / 2.5, 0, 1)
       : Math.atan2(lh - rh, this.halfWid * 2) + clamp(this.vLat, -9, 9) * 0.016;
     this.pitch = lerp(this.pitch, tgtPitch, 1 - Math.exp(-10 * dt));
     this.roll = lerp(this.roll, tgtRoll, 1 - Math.exp(-10 * dt));

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v36';
+const CACHE = 'auto-v37';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',

--- a/tools/beauty.mjs
+++ b/tools/beauty.mjs
@@ -157,6 +157,10 @@ async function main() {
     await evaluate(`(() => {
       const d = window.__dbg;
       d.applyQuality('high', true);
+      // SSAO ships off, so the harness needs a way to photograph it -- the only
+      // reason it stayed broken for so long is that nothing ever framed a road
+      // with it enabled.
+      if (${JSON.stringify(!!process.env.AUTO_SSAO)}) d.postfx.setFx('ssao', true);
       for (const id of ['hud','pad','stickZone','lookZone','objective','toast','rotate'])
         { const e = document.getElementById(id); if (e) e.style.display = 'none'; }
       d.game.paused = true;

--- a/tools/vehicles.mjs
+++ b/tools/vehicles.mjs
@@ -24,8 +24,9 @@ const PORT = 9231;
 const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 const HTTP_PORT = process.env.AUTO_HTTP_PORT || 8000;
 const JSON_OUT = process.argv.includes('--json');
-// Keep in step with ARCADE_PUNCH in apps/auto/src/vehicles.js.
+// Keep in step with apps/auto/src/vehicles.js.
 const ARCADE_PUNCH = 2.4;
+const ARCADE_GRIP = 2.2;
 
 // Real-world bands per class, for the types we ship. 0-100 km/h in seconds,
 // top speed in km/h, 100-0 braking in metres, lateral grip in g.
@@ -40,6 +41,11 @@ const ARCADE_PUNCH = 2.4;
 // the accel band is divided by the same constant here and the check still
 // catches a van out-dragging a sports car. Top speed, braking and grip are
 // compared against the real figures unchanged.
+//
+// GRIP is the same bargain and has one extra caveat worth stating: steering is
+// now CLAMPED to the angle grip supports, so a steady-state corner returns the
+// limit by construction. That makes this column a check that the clamp is wired
+// up and scaled per class, not evidence that the cornering model is right.
 const BANDS = {
   sedan: { name: 'mid-size sedan', accel: [7.5, 11], top: [190, 235], brake: [36, 44], lat: [0.82, 0.92] },
   hatch: { name: 'small hatchback', accel: [9, 13], top: [170, 200], brake: [36, 45], lat: [0.80, 0.90] },
@@ -206,7 +212,7 @@ async function main() {
       if (!b) { console.log(`${name}: no band`); continue; }
       const marks = [
         band(r.accel, b.accel.map((v) => v / ARCADE_PUNCH)), band(r.top, b.top),
-        band(r.brake, b.brake), band(r.lat, b.lat),
+        band(r.brake, b.brake), band(r.lat, b.lat.map((v) => v * ARCADE_GRIP)),
       ];
       bad += marks.filter((m) => m !== 'ok').length;
       const f = (v, m) => `${v === null ? '  --' : v.toFixed(v < 100 ? 1 : 0).padStart(6)}${m === 'ok' ? ' ' : '!'}`;


### PR DESCRIPTION
Two regressions I introduced, both found on the device. Build **v37**.

## "Constantly drifting and doesn't steer properly"

The bicycle model turns steering angle straight into yaw, so at 72 km/h full
lock asks for **five g**. The friction circle I added last week then removed 82%
of it again — every frame, at every speed above walking pace.

So the limiter was permanently engaged. The car never went where it was pointed
and the leftover lateral velocity read as a constant drift. It felt broken
because functionally it was: the steering input was being thrown away.

Steering is now clamped to the angle the tyres can actually hold, instead of
demanding the impossible and clawing it back:

```
lat = v² / L · tan(steer) ≤ latA   →   steer ≤ atan(latA · L / v²)
```

The wheel always does something, and the car turns as hard as it's able to.
Below ~45 km/h the mechanical lock is the smaller of the two and nothing
changes. Braking and the handbrake eat the same budget, so trail-braking still
runs wide and the handbrake still breaks it loose.

`ARCADE_GRIP = 2.2` is the same bargain as `ARCADE_PUNCH` — class ratios stay
honest, the whole scale moves. At true road-tyre grip a sedan corners at 46 m
radius at 72 km/h, and in a city built from real street widths that means you
can't make a junction at any speed worth driving.

**Measured turn radius**, speed held constant (holding *throttle* instead
measures the accelerator — a sports car and a bus end up at different speeds):

| km/h | 30 | 50 | 80 | 110 |
|---|---|---|---|---|
| sports | 4.9 | 8.8 | 22.4 | 42.4 |
| sedan | 5.4 | 10.2 | 26.0 | 49.2 |
| bus | 10.8 | 14.4 | 36.9 | 69.8 |

Correctly ordered, and the sedan's 5.4 m at 30 km/h is its real lock.

## The dark blotches were shadow acne, not SSAO

Reported with SSAO already off, which is what ruled it out.

Dropping the phone to a 1024 map with a 190 m box made its texel 0.37 m against
the desktop's 0.25 — and the *same commit* moved `normalBias` **down**, 0.12 →
0.09. `CLAUDE.md` says plainly that normalBias has to scale *with* texel size. I
moved it the wrong way.

It's derived now rather than written down: `normalBias = texel × 0.48`, where
texel is `2·S / mapSize`. Desktop reproduces its old 0.12 exactly; the phone gets
the 0.18 it needed. Getting this wrong again would mean editing the formula
rather than forgetting a coupling.

## SSAO rewritten — still off by default

Four compounding faults, all of which hit hardest on flat ground receding from
the camera, which is most of what a driving game shows you.

**The kernel wasn't oriented to the surface.** A fixed hemisphere was rotated
about the *view* axis and each sample flipped with `dot(k, N) < 0`. Flipping only
puts a sample on the correct *side* of the surface — it does not build a
hemisphere around the normal. On a road raking away from the camera, most samples
ended up nearly **tangent** to the tarmac, skimming along it at essentially the
surface's own depth. There's a real tangent basis now.

**The bias was a constant in metres.** 3.5 cm is fine at 2 m and meaningless at
40 m, where the depth difference across one sample step on a receding surface is
far larger — so open road self-occluded. It scales with view depth now.

**The range check did the opposite of what was needed.** `radius / abs(P.z - sz)`
*explodes* when a sample sits on the same surface, so `smoothstep` saturated at 1
and handed full weight to exactly the self-occlusion case it should reject. With
the kernel oriented correctly, a same-surface sample now fails the occlusion test
outright and the range check goes back to its real job.

**`cross(dFdx(P), dFdy(P))` is garbage at silhouettes.** Derivatives come from a
2×2 quad, so at any edge one pixel is on a near surface and one on a far one —
a band of nonsense normals along every edge in the frame, smeared wider by the
blur. Four neighbours are sampled instead, keeping the closer of each pair.

Plus a distance fade: the kernel is a fixed size in metres, so past a few tens of
metres it projects into a pixel or two, all twelve samples read the same texel,
and the blur turns correlated noise into a blob.

Strength 2.1 → 1.1 and radius 0.85 → 0.7 — those were high to make a broken
effect visible.

`AUTO_SSAO=1 node tools/beauty.mjs <tag>` turns it on for a capture. The only
reason this survived is that nothing ever framed a road with it enabled —
facades face the camera, so not one of the four failure modes shows up in a shot
of a building.

Measured on `street`, off → on: shadowed quartile 0.0711 → 0.0451, lit 0.2186 →
0.1659. Contact and creases darken, open tarmac doesn't, clipping stays 0.00%.

## Also

Motorcycle lean read `latAcc` from the friction-circle block the steering clamp
replaced. It's computed from the achieved yaw now — which, with grip-limited
steering, is the same quantity.

## Checks

- `node tools/verify.mjs` → `OK: 0 exceptions`
- `node tools/vehicles.mjs` → `0 figures outside their band, of 72`

The bench's grip column divides by `ARCADE_GRIP`, and is now flagged as a check
that the clamp is wired up and scaled per class — **not** evidence the cornering
model is right. Steering is clamped to the limit, so a steady-state corner
returns it by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B
