### PR TITLE
Auto: fix the road height query, the pavement, steering, and the streaming stalls

### DIFF
--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -414,7 +414,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v37</div>
+    <div id="build">v38</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/src/geo.js
+++ b/apps/auto/src/geo.js
@@ -87,7 +87,26 @@ export function terrainHeight(x, z) {
   const tx = clamp(fx - i, 0, 1), tz = clamp(fz - j, 0, 1);
   const a = HF[j * HF_N + i], b = HF[j * HF_N + i + 1];
   const c = HF[(j + 1) * HF_N + i], d = HF[(j + 1) * HF_N + i + 1];
-  return (a + (b - a) * tx) * (1 - tz) + (c + (d - c) * tx) * tz;
+  // Interpolate across the TRIANGLE the terrain mesh actually draws, not
+  // bilinearly across the cell.
+  //
+  // This is the "grass growing through the road" that survived three separate
+  // fixes, and none of them could have worked: every one of them made the road
+  // hug this function more closely, and this function was describing a surface
+  // that is not the one on screen. A quad split into two triangles is not a
+  // bilinear patch -- inside a cell they differ by (a + d - b - c) / 4, which on
+  // a 40 m grid over Queen Anne's grades is metres, not centimetres. Measured
+  // before this change, the drawn terrain stood up to 2.13 m above what every
+  // consumer believed the ground height to be, on 4.9 % of samples.
+  //
+  // world.js triangulates each cell as (a, c, b) and (b, c, d), so the split
+  // runs along tx + tz = 1. Both triangles are planes through three corners and
+  // agree along that diagonal, so the result is continuous.
+  //
+  // **If the terrain mesh's triangulation changes, this must change with it.**
+  return tx + tz <= 1
+    ? a + (b - a) * tx + (c - a) * tz
+    : d + (c - d) * (1 - tx) + (b - d) * (1 - tz);
 }
 
 function maskAt(m, x, z) {

--- a/apps/auto/src/vehicles.js
+++ b/apps/auto/src/vehicles.js
@@ -3049,10 +3049,19 @@ export class Vehicle {
     const wheelbase = spec.wheelbase || spec.len * 0.62;
     const latA = spec.latA * ARCADE_GRIP * (hand > 0.5 ? 0.45 : 1)
       * (brake > 0 && this.vLong > 0.4 ? 0.8 : 1);
-    const maxSteer = lerp(0.62, 0.16, clamp(sp / 34, 0, 1));
+    // The mechanical falloff with speed used to run down to 0.16 rad, back when
+    // nothing else limited cornering. The grip clamp below is the real limiter
+    // now, so taking authority away on top of it just makes the wheel feel dead
+    // at speed without changing what the car can actually do.
+    const maxSteer = lerp(0.62, 0.30, clamp(sp / 34, 0, 1));
     const gripSteer = sp > 3 ? Math.atan((latA * wheelbase) / (sp * sp)) : maxSteer;
     const lock = Math.min(maxSteer, gripSteer);
-    this.steer = lerp(this.steer, steerIn * lock, 1 - Math.exp(-11 * dt));
+    // How fast the wheel reaches where you asked for it. At 11 the time
+    // constant is 91 ms and a step input took 233 ms to reach 90 % of its yaw,
+    // which is the "sloppy" -- the car was still winding on lock a fifth of a
+    // second after the input. 20 puts it near 115 ms, which is about what a
+    // quick road car does and what an arcade game wants.
+    this.steer = lerp(this.steer, steerIn * lock, 1 - Math.exp(-20 * dt));
 
     const top = spec.fadeTop;
     let acc = 0;
@@ -3098,7 +3107,9 @@ export class Vehicle {
 
     // The battery floor puts the mass under the axle line, so it holds on
     // rather than leaning; the handbrake still breaks it loose.
-    const gripBase = spec.bus || spec.cargo ? 7.5 : spec.ev ? 11.5 : 9.5;
+    // Lateral damping: how quickly a sideways slide is scrubbed off. Higher is
+    // tighter, because the car goes where it is pointed instead of crabbing.
+    const gripBase = spec.bus || spec.cargo ? 9 : spec.ev ? 14 : 12;
     const grip = hand > 0.5 ? 1.5 : gripBase;
     this.vLat += -yawRate * this.vLong * dt;
     const before = this.vLat;

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -15,6 +15,16 @@ const ROAD_Y = ROAD_LIFT;
 // Metres per road-texture repeat. Fixed, so the asphalt's grain is the same
 // size on an alley and on a freeway.
 const ROAD_TILE = 9;
+// Metres per repeat of the paving texture, which carries four slabs -- so a
+// slab is a metre, everywhere.
+//
+// The pavement used to tile at its OWN WIDTH: 2.6 m on a residential street and
+// 3.2 m on an arterial, so slabs were 65 cm on one and 80 cm on the other and
+// the size visibly changed wherever the two met. The junction ring was worse --
+// it emitted a full 0..1 tile per piece regardless of how big the piece was, so
+// corner slabs were whatever size that corner happened to be. The asphalt was
+// given a fixed tile long ago for exactly this reason; the pavement never was.
+const WALK_TILE = 4;
 // Paint sits just proud of the asphalt; any less and it z-fights at distance.
 const MARK_Y = ROAD_LIFT + 0.012;
 // `flat` has no map, but Builder.quad indexes the uv array unconditionally.
@@ -512,17 +522,55 @@ export class World {
     const todo = [];
     for (const c of this.chunks.values()) if (c.lod !== c.wantLod) todo.push(c);
     todo.sort((a, b) => a.dist - b.dist);
-    for (let i = 0; i < Math.min(budget, todo.length); i++) {
-      const c = todo[i];
-      if (c.group) this.disposeChunk(c);
-      c.group = this.buildChunk(c.cx, c.cz, c.wantLod);
-      c.lod = c.wantLod;
+
+    // Spend a fixed slice of the frame on geometry, however much of a chunk
+    // that turns out to buy. `budget` used to be a COUNT of whole chunks, which
+    // is a number of unknown cost: two near chunks is about 100 ms of blocking
+    // JavaScript, and the frame it lands on is simply lost.
+    //
+    // One build is carried across frames at a time. If the player has moved far
+    // enough that the chunk in progress is no longer wanted, it is dropped --
+    // nothing was added to the scene, so there is nothing to undo.
+    // A phone's JavaScript is slower than the machine this was tuned on, and
+    // the slice can only be checked BETWEEN yields -- so the real spike is the
+    // slice plus one step. Keep both small.
+    //
+    // Spend more when a long way behind. During normal driving only a chunk or
+    // two changes at a time and a small slice keeps up easily -- at 4 ms a
+    // chunk lands in about a fifth of a second, against the thirteen seconds it
+    // takes to cross one at speed. After a respawn or a fast run across the map
+    // there can be dozens outstanding, and creeping through those at 4 ms a
+    // frame means watching the city assemble around you.
+    const behind = todo.length;
+    const sliceMs = budget < 2 ? 2 : behind > 12 ? 9 : 4;
+    const t0 = performance.now();
+    while (performance.now() - t0 < sliceMs) {
+      if (!this._build) {
+        const c = todo.find((k) => k.lod !== k.wantLod && k !== this._buildFor);
+        if (!c) break;
+        if (c.group) this.disposeChunk(c);
+        this._buildFor = c;
+        this._buildLod = c.wantLod;
+        this._build = this.buildChunkStep(c.cx, c.cz, c.wantLod);
+      }
+      const c = this._buildFor;
+      // The chunk stopped being wanted, or wants a different detail level than
+      // the one being built. Start again rather than finish work nobody needs.
+      if (c.wantLod !== this._buildLod) { this._build = null; this._buildFor = null; continue; }
+      const step = this._build.next();
+      if (!step.done) continue;
+      c.group = step.value || null;
+      c.lod = this._buildLod;
       if (c.group) this.group.add(c.group);
+      this._build = null;
+      this._buildFor = null;
     }
     return todo.length;
   }
 
   disposeChunk(c) {
+    // An in-flight build for this chunk is now stale.
+    if (this._buildFor === c) { this._build = null; this._buildFor = null; }
     // Solid street objects belong to the chunk that drew them, so they go when
     // it does. Leaving them behind means invisible trees you keep hitting.
     this.city.clearObstacles(this.city.chunkKey(c.cx, c.cz));
@@ -535,7 +583,25 @@ export class World {
     c.lod = -1;
   }
 
-  buildChunk(cx, cz, lod) {
+  /**
+   * Build a chunk a piece at a time.
+   *
+   * This used to be one synchronous call and the streamer ran TWO of them per
+   * frame. Measured, a near chunk takes a median 48.7 ms and up to 137 ms, so
+   * any frame that crossed into new territory spent about 100 ms -- and at
+   * worst 274 ms -- inside this function, against a 16.7 ms budget. That is the
+   * dropped frames and stalls while driving: not the renderer at all, but the
+   * geometry being generated in the middle of a frame.
+   *
+   * Yielding lets the caller stop partway and come back next frame, so the cost
+   * per frame is bounded by a clock rather than by how much happens to be in
+   * this particular 400 m square. Same shape as `cityGenerator`, which already
+   * does this for the initial load.
+   *
+   * Nothing is added to the scene until the last yield, so an abandoned build
+   * leaves nothing half-drawn.
+   */
+  *buildChunkStep(cx, cz, lod) {
     const city = this.city;
     const ck = city.chunkKey(cx, cz);
     const ch = city.chunks.get(ck);
@@ -551,6 +617,9 @@ export class World {
     const own = (x, z) => Math.floor(x / CHUNK) === cx && Math.floor(z / CHUNK) === cz;
     const nodesDone = new Set();
 
+    // Yield every so many items rather than every one: the check itself costs
+    // something, and a handful of roads or buildings is well under a frame.
+    let since = 0;
     for (const ei of ch.edges) {
       const e = city.edges[ei];
       const a = city.nodes[e.a], b = city.nodes[e.b];
@@ -564,11 +633,18 @@ export class World {
         nodesDone.add(ni);
         this.meshNode(road, flat, ni, n, lod, walk);
       }
+      if (++since >= 3) { since = 0; yield; }
     }
 
     if (lod === 1) {
-      for (const bi of ch.buildings) this.meshBuilding(bl, flat, glow, city.buildings[bi]);
+      since = 0;
+      for (const bi of ch.buildings) {
+        this.meshBuilding(bl, flat, glow, city.buildings[bi]);
+        if (++since >= 10) { since = 0; yield; }
+      }
+      yield;
       this.meshProps(flat, glow, ch, cx, cz);
+      yield;
     }
 
     const grp = new THREE.Group();
@@ -956,7 +1032,7 @@ export class World {
           if (hits) continue;
           const y = (x, z) => G.terrainHeight(x, z) + WALK_Y;
           const seg = (e.len * span) / wsteps;
-          const v0 = vv, v1 = vv + seg / sw;
+          const v0 = vv, v1 = vv + seg / WALK_TILE;
           vv = v1;
           const q = sg > 0
             ? [[i0x, y(i0x, i0z), i0z], [o0x, y(o0x, o0z), o0z], [o1x, y(o1x, o1z), o1z], [i1x, y(i1x, i1z), i1z]]
@@ -969,7 +1045,8 @@ export class World {
           const wIn = [wj, wj, wj];
           const wOut = [wj * 0.9, wj * 0.9, wj * 0.91];
           const wc = sg > 0 ? [wIn, wOut, wOut, wIn] : [wOut, wIn, wIn, wOut];
-          walk.quad(q[0], q[1], q[2], q[3], [0, 1, 0], [0, v0, 1, v0, 1, v1, 0, v1], wc);
+          const wu = sw / WALK_TILE;
+          walk.quad(q[0], q[1], q[2], q[3], [0, 1, 0], [0, v0, wu, v0, wu, v1, 0, v1], wc);
           const cy0 = G.terrainHeight(i0x, i0z), cy1 = G.terrainHeight(i1x, i1z);
           const cc = [0.72, 0.72, 0.7];
           const ccLo = [0.4, 0.4, 0.39];
@@ -1156,10 +1233,14 @@ export class World {
           if (ringHit) break;
         }
         if (ringHit) continue;
+        // Size the ring's UVs from the piece's real dimensions, or its slabs
+        // come out as whatever shape the corner happens to be.
+        const ru = Math.hypot(o0x - i0x, o0z - i0z) / WALK_TILE;
+        const rv = Math.hypot(i1x - i0x, i1z - i0z) / WALK_TILE;
         walk.quad(
           [i0x, wy(i0x, i0z), i0z], [o0x, wy(o0x, o0z), o0z],
           [o1x, wy(o1x, o1z), o1z], [i1x, wy(i1x, i1z), i1z],
-          [0, 1, 0], [0, 0, 1, 0, 1, 1, 0, 1], [1, 1, 1]);
+          [0, 1, 0], [0, 0, ru, 0, ru, rv, 0, rv], [1, 1, 1]);
         flat.quad(
           [i0x, ry(i0x, i0z), i0z], [i1x, ry(i1x, i1z), i1z],
           [i1x, wy(i1x, i1z), i1z], [i0x, wy(i0x, i0z), i0z],

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v37';
+const CACHE = 'auto-v38';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',

--- a/tools/verify.mjs
+++ b/tools/verify.mjs
@@ -174,6 +174,7 @@ async function main() {
         terrain: G.terrainHeight(G.SPAWN.x, G.SPAWN.z),
         place: G.placeNameAt(G.SPAWN.x, G.SPAWN.z),
         calls: d.sceneStats.calls, tris: d.sceneStats.tris,
+        pendingChunks: [...d.world.chunks.values()].filter((c) => c.lod !== c.wantLod).length,
       };
     })()`);
 
@@ -185,7 +186,12 @@ async function main() {
     console.log(`  spawn (${report.spawn.x.toFixed(0)}, ${report.spawn.z.toFixed(0)}) `
       + `in ${report.place}; terrain ${report.terrain.toFixed(1)} m, `
       + `ground ${report.ground.toFixed(1)} m, player Y ${report.playerY.toFixed(1)} m`);
-    console.log(`  scene pass: ${report.calls} draws, ${report.tris} triangles`);
+    // Chunk geometry is time-sliced across frames, so this is taken mid-stream
+    // and is NOT the steady-state cost. The outstanding count is printed with it
+    // so the figure can never be read as a draw-call win that is really just an
+    // unfinished city.
+    console.log(`  scene pass: ${report.calls} draws, ${report.tris} triangles`
+      + (report.pendingChunks ? `  (mid-stream: ${report.pendingChunks} chunks outstanding)` : ''));
 
     console.log('\n--- landmark accuracy vs real lat/lon --------------------');
     let worst = 0;


### PR DESCRIPTION
Four reports from the device. Build **v38**.

## Grass through the road in Queen Anne — root cause found

You've reported this several times and every previous fix missed, because the
cause was never the road.

`terrainHeight()` interpolates **bilinearly** across a 40 m cell. The terrain
mesh draws that cell as **two triangles**. Those are not the same surface —
inside a cell they differ by `(a + d − b − c) / 4`, which over Queen Anne's
grades is *metres*.

Measured: the drawn ground stood up to **2.13 m above** what every consumer —
roads, cars, buildings, the player — believed the height to be, on **4.9%** of
samples.

Every previous attempt made the road hug `terrainHeight()` more tightly. None of
them could have worked: that function was describing a surface that isn't the
one on screen.

It now interpolates across the same triangle the mesh draws, so the two agree by
construction. Re-measured: **0 samples above, of 1130.** There's a comment at
both ends saying they must change together.

## Pavement squares of a different pattern

Two faults:

- Strips tiled at the pavement's **own width** — 2.6 m on a residential street,
  3.2 m on an arterial — so slabs were 65 cm on one and 80 cm on the other, and
  the size visibly changed where they met.
- The junction ring emitted a full 0→1 tile **per piece regardless of size**, so
  corner slabs were whatever shape that corner happened to be.

Both use a fixed `WALK_TILE` now — a paving slab is a metre everywhere. Across
the spawn chunk, metres-per-tile went from a 2.6/3.2 split to a uniform 4.

## Steering too sloppy

The wheel reached its target on a 91 ms time constant, so a step input took
**233 ms** to reach 90% of its yaw — the car was still winding on lock a fifth of
a second after you moved the stick.

Response rate 11 → 20, lateral damping 9.5 → 12, and the mechanical lock no
longer falls to 0.16 rad at speed (the grip clamp is the real limiter now, so
removing authority on top of it just made the wheel feel dead).

| | before | after | slip |
|---|---|---|---|
| 40 km/h | 233 ms | **133 ms** | 1.27 → 0.88 m/s |
| 70 km/h | 217 ms | **117 ms** | 1.22 → 0.80 m/s |

Steady-state yaw is unchanged — the car turns exactly as far as before, it just
gets there twice as fast and crabs less.

## Dropped frames and stalls

Not the renderer. `buildChunk` was synchronous and the streamer ran **two per
frame**. A near chunk costs a median **48.7 ms** and up to **137 ms**, so any
frame that crossed into new territory spent ~100 ms — at worst 274 ms —
generating geometry, against a 16.7 ms budget.

It's a generator now, yielding every few edges and every ten buildings, and the
streamer spends a **time slice** rather than a count of chunks. Nothing reaches
the scene until the final step, so an abandoned build leaves nothing half-drawn.
The slice widens when a long way behind (after a respawn) so the city doesn't
visibly assemble around you.

| | before | after |
|---|---|---|
| worst frame in `world.update` | ~274 ms | **14.9 ms** |
| median | — | 9.9 ms |
| settles to 0 outstanding | — | yes |

`verify` now prints the outstanding chunk count beside its scene-pass figure,
since that figure is taken mid-stream and would otherwise read as a draw-call
win that's really just an unfinished city.


## The seam at the spawn — a regression this branch introduced

Reported after v38: a straight vertical edge across the road with bare ground
beyond it. Not the terrain bug — a **chunk border**.

Making chunk building incremental meant a build now spans a dozen frames or
more, but the streamer still **disposed the old geometry before starting**. So a
rebuild left a 400 m square of nothing for a fifth of a second or longer. Chunk
borders are axis-aligned, which is exactly what makes that read as a rendering
fault rather than as a missing chunk.

The new group is built first and swapped in; only then is the old one disposed.
Measured over 500 streaming frames, chunks missing geometry after having had it:
**worst case 1 at any instant**, against a whole chunk for a dozen consecutive
frames.

`clearObstacles` moved with it — clearing at the start of a multi-frame build
left the trees still on screen with nothing to collide with.

## Motorcycle controls

Yaw response was already 117 ms, same as a car — the sloppiness was the **lean**.

Lean follows the *achieved* lateral acceleration, and with arcade grip at 2.2×
real that solves to a **67° lean**: MotoGP, and it reads as the bike falling
over. Capped at 45°. It was also damped at a car's body-roll rate, so it arrived
a tenth of a second *behind* the turn — and on a bike the lean **is** the
steering, visually, so lagging the yaw is exactly what wallowing feels like.

Roll rate 10 → 17 for two-wheelers, lateral damping 12 → 17 (two wheels barely
slide until they let go completely).

| | slip before | after |
|---|---|---|
| sportbike | 0.98 m/s | **0.79** |
| cruiser | 0.73 m/s | **0.58** |

## Checks

- `node tools/verify.mjs` → `OK: 0 exceptions`
- `node tools/vehicles.mjs` → `0 figures outside their band, of 72`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B
