### PR TITLE
Auto: swap chunk geometry instead of disposing it first (v39)

### DIFF
--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -414,7 +414,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v38</div>
+    <div id="build">v39</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/src/vehicles.js
+++ b/apps/auto/src/vehicles.js
@@ -3109,7 +3109,9 @@ export class Vehicle {
     // rather than leaning; the handbrake still breaks it loose.
     // Lateral damping: how quickly a sideways slide is scrubbed off. Higher is
     // tighter, because the car goes where it is pointed instead of crabbing.
-    const gripBase = spec.bus || spec.cargo ? 9 : spec.ev ? 14 : 12;
+    // Two wheels barely slide until they let go completely, so a bike that
+    // crabs like a car reads as vague.
+    const gripBase = spec.moto ? 17 : spec.bus || spec.cargo ? 9 : spec.ev ? 14 : 12;
     const grip = hand > 0.5 ? 1.5 : gripBase;
     this.vLat += -yawRate * this.vLong * dt;
     const before = this.vLat;
@@ -3182,10 +3184,16 @@ export class Vehicle {
     // backwards here, and a bike leaning out of its corners is unmissable.
     // Faded out below walking pace so a parked bike stands up straight.
     const tgtRoll = two
-      ? -Math.atan2(this.latAcc, 9.81) * clamp((sp - 0.8) / 2.5, 0, 1)
+      // Capped, because the lean follows the ACHIEVED lateral acceleration and
+      // arcade grip is 2.2x real -- solved honestly that is a 67 deg lean, which
+      // is MotoGP and reads as the bike falling over. 45 deg is hard riding.
+      ? -clamp(Math.atan2(this.latAcc, 9.81), -0.78, 0.78) * clamp((sp - 0.8) / 2.5, 0, 1)
       : Math.atan2(lh - rh, this.halfWid * 2) + clamp(this.vLat, -9, 9) * 0.016;
     this.pitch = lerp(this.pitch, tgtPitch, 1 - Math.exp(-10 * dt));
-    this.roll = lerp(this.roll, tgtRoll, 1 - Math.exp(-10 * dt));
+    // A bike's lean IS its steering, visually, so it has to arrive with the
+    // turn rather than a tenth of a second behind it -- lagging the yaw is what
+    // makes the controls feel like they are wallowing.
+    this.roll = lerp(this.roll, tgtRoll, 1 - Math.exp(-(two ? 17 : 10) * dt));
 
     this.wheelSpin += (this.vLong / (this.assets.wheelR || 0.34)) * dt;
     this.sync();

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -548,7 +548,6 @@ export class World {
       if (!this._build) {
         const c = todo.find((k) => k.lod !== k.wantLod && k !== this._buildFor);
         if (!c) break;
-        if (c.group) this.disposeChunk(c);
         this._buildFor = c;
         this._buildLod = c.wantLod;
         this._build = this.buildChunkStep(c.cx, c.cz, c.wantLod);
@@ -559,9 +558,23 @@ export class World {
       if (c.wantLod !== this._buildLod) { this._build = null; this._buildFor = null; continue; }
       const step = this._build.next();
       if (!step.done) continue;
+      // **Swap, never dispose-then-build.**
+      //
+      // The old geometry has to stay on screen until its replacement is ready.
+      // Disposing first was fine when a build finished inside the same frame;
+      // now that it is spread over a dozen or more, it leaves a 400 m square of
+      // bare terrain where the chunk used to be -- a hard straight edge across
+      // the road, with the ground showing through beyond it, for a fifth of a
+      // second or longer. Chunk borders are axis-aligned, which is exactly what
+      // makes the seam look like a rendering fault rather than a missing chunk.
+      const old = c.group;
       c.group = step.value || null;
       c.lod = this._buildLod;
       if (c.group) this.group.add(c.group);
+      if (old) {
+        old.traverse((o) => { if (o.geometry) o.geometry.dispose(); });
+        this.group.remove(old);
+      }
       this._build = null;
       this._buildFor = null;
     }
@@ -606,7 +619,6 @@ export class World {
     const ck = city.chunkKey(cx, cz);
     const ch = city.chunks.get(ck);
     if (!ch) return null;
-    city.clearObstacles(ck);
     this._ck = ck;
     const road = new Builder(true);
     const walk = new Builder(true);
@@ -616,6 +628,11 @@ export class World {
 
     const own = (x, z) => Math.floor(x / CHUNK) === cx && Math.floor(z / CHUNK) === cz;
     const nodesDone = new Set();
+    // Solid objects are registered as the geometry is generated, so the old
+    // set is dropped here rather than at the top: a build now spans many frames,
+    // and clearing first would leave the trees still on screen with no collision
+    // until it finished.
+    city.clearObstacles(ck);
 
     // Yield every so many items rather than every one: the check itself costs
     // something, and a handful of roads or buildings is well under a frame.

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v38';
+const CACHE = 'auto-v39';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',


### PR DESCRIPTION
**This is the commit that missed #349.** That PR was merged while the branch head
was still the v38 commit; this landed on the branch afterwards, so it never
reached master. Build **v39**.

## The seam at the spawn — a regression #349 introduced

A straight vertical edge across the road with bare ground beyond it. Not the
terrain bug — a **chunk border**.

Making chunk building incremental meant a build now spans a dozen frames or
more, but the streamer still **disposed the old geometry before starting**. A
rebuild therefore left a 400 m square of nothing for a fifth of a second or
longer. Chunk borders are axis-aligned, which is exactly what makes that read as
a rendering fault rather than as a missing chunk.

The new group is built first and swapped in; only then is the old one disposed.
Measured over 500 streaming frames, chunks missing geometry after having had it:
**worst case 1 at any instant**, against a whole chunk for a dozen consecutive
frames.

`clearObstacles` moved with it — clearing at the start of a multi-frame build
left the trees still on screen with nothing to collide with until it finished.

## Motorcycle controls

Yaw response was already 117 ms, the same as a car — the sloppiness was the
**lean**.

Lean follows the *achieved* lateral acceleration, and with arcade grip at 2.2×
real that solves to a **67° lean**: MotoGP, and it reads as the bike falling
over. Capped at 45°. It was also damped at a car's body-roll rate, so it arrived
a tenth of a second *behind* the turn — and on a bike the lean **is** the
steering, visually, so lagging the yaw is exactly what wallowing feels like.

Roll rate 10 → 17 for two-wheelers, lateral damping 12 → 17, since two wheels
barely slide until they let go completely.

| | slip before | after |
|---|---|---|
| sportbike | 0.98 m/s | **0.79** |
| cruiser | 0.73 m/s | **0.58** |

## Checks

- `node tools/verify.mjs` → `OK: 0 exceptions`
- `node tools/vehicles.mjs` → `0 figures outside their band, of 72`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B