### PR TITLE
Auto: the spawn seam, the driving stutter, and a harness that was photographing dirt

### DIFF
--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -414,7 +414,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v39</div>
+    <div id="build">v40</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -414,7 +414,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v40</div>
+    <div id="build">v41</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/src/main.js
+++ b/apps/auto/src/main.js
@@ -467,10 +467,15 @@ function installHeightFog() {
   window.__dbg = { game, city, player, world, traffic, peds, scene, camera, renderer, G, fx, hud, controls, audio, pickups, THREE, postfx, applyQuality, sun, sceneStats, cityStats, animateWalk, collideWithBuildings, TYPES: VEHICLE_TYPES };
   wireUi();
   game.newTarget();
-  // A phone starts on medium. `high` was only ever reachable downward, so
-  // every player paid 2.5 s of stutter to discover their device could not run
-  // the desktop preset.
-  applyQuality(ON_PHONE ? 'medium' : 'high', false);
+  // Start on `high` everywhere.
+  //
+  // Phones were dropped to `medium` when the frame was 509 draws and a chunk
+  // build could block for a quarter of a second. Both are fixed -- 299 draws
+  // and a 17 ms worst frame -- and a modern phone measured 61 fps with a floor
+  // of 57 at `high`. `autoQuality` is still watching, so a device that cannot
+  // hold it steps down on its own rather than everyone being pre-emptively
+  // demoted.
+  applyQuality('high', false);
   startedAt = performance.now();
   loading.classList.add('hide');
   setTimeout(() => loading.remove(), 700);

--- a/apps/auto/src/peds.js
+++ b/apps/auto/src/peds.js
@@ -353,7 +353,19 @@ export function makeHumanoid(opts = {}) {
     group: g, mesh, bones, height: 1.75 * scale, bob: 0, scale,
     // Pooled variants are shared by every pedestrian using that look, so only a
     // uniquely-built character may dispose its own geometry.
-    dispose() { if (!pooled) geo.dispose(); },
+    //
+    // The SKELETON is always per-instance, and three backs each one with a bone
+    // texture on the GPU. Not disposing it leaked one texture per pedestrian
+    // that walked out of range -- measured, `renderer.info.memory.textures` rose
+    // from 62 to 80 over two minutes of driving and never came down. Every
+    // spawn also uploads a fresh one, and a texture upload is a synchronous
+    // stall on the main thread, which is what the intermittent stutter while
+    // driving actually was: pedestrians churning in and out of the 150 m spawn
+    // radius, each one costing an upload.
+    dispose() {
+      if (!pooled) geo.dispose();
+      if (mesh.skeleton) mesh.skeleton.dispose();
+    },
     gait: 0.92 + hash2(seed, 11) * 0.16,
     lean: hash2(seed, 12) * 0.06,
     swing: 0.8 + hash2(seed, 13) * 0.45,

--- a/apps/auto/src/traffic.js
+++ b/apps/auto/src/traffic.js
@@ -11,6 +11,22 @@ const TRAFFIC_TARGET = 26;
 const PARKED_RADIUS = 105;
 const DESPAWN = 520;
 
+/**
+ * Free everything under a node.
+ *
+ * Only safe on geometry that is genuinely per-instance. Vehicles share their
+ * geometry and their trim/matte materials across every instance in the game --
+ * see the "never dispose a pooled geometry" law in CLAUDE.md, which is the same
+ * trap one level down.
+ */
+function disposeTree(root) {
+  root.traverse((o) => {
+    if (o.geometry) o.geometry.dispose();
+    const ms = o.material ? (Array.isArray(o.material) ? o.material : [o.material]) : [];
+    for (const m of ms) m.dispose();
+  });
+}
+
 export function collideWithBuildings(v, city, onHit) {
   // Street objects first: a tree or a lamp post is closer than the building
   // line and is what you actually hit coming off a kerb. Until this existed
@@ -91,6 +107,7 @@ export class TrafficSystem {
     this.scene.remove(v.group);
     if (v.slot != null) this.parkedSlots.delete(v.slot);
     v.bodyMat.dispose();
+    if (v.extra) { disposeTree(v.extra); v.extra = null; }
   }
 
   spawnAt(x, z, heading, typeName, color, mode) {
@@ -233,6 +250,12 @@ export class TrafficSystem {
       v.lightL = mkL(0x3355ff, -0.31);
       v.lightR = mkL(0xff2a2a, 0.31);
       v.tilt.add(bar);
+      // Remember the light bar so `remove` can free it. A vehicle SHARES its
+      // trim and matte geometry and materials with every other instance, so
+      // nothing may traverse-and-dispose a car -- only the per-instance extras
+      // built here. Cops churn continuously during a chase, and this was three
+      // geometries and three materials leaked every time one despawned.
+      v.extra = bar;
       return v;
     }
     return null;
@@ -275,6 +298,10 @@ export class TrafficSystem {
       this.heli = { g, rotor, tr, beacon, a: 0, ang: 0 };
     } else if (!active && this.heli) {
       this.scene.remove(this.heli.g);
+      // Nothing in the helicopter is shared, and it is rebuilt from scratch
+      // every time the wanted level crosses four -- so without this an entire
+      // airframe leaked on each transition, in both directions.
+      disposeTree(this.heli.g);
       this.heli = null;
     }
   }

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -1208,7 +1208,21 @@ export class World {
       pts.push(x, z);
       ys.push(n.elev ? n.y + 0.07 : G.terrainHeight(x, z) + NODE_Y);
     }
-    road.flat(pts, ys, [1, 1, 1], [0.18, 0.62, 0.34, 0.62, 0.34, 0.76, 0.18, 0.76]);
+    // UVs in METRES, at the same ROAD_TILE the strips use.
+    //
+    // This was a hardcoded 0.16 x 0.14 slice of the asphalt texture stretched
+    // across the whole junction -- which at a 20 m crossing is a repeat every
+    // 130 m against the strips' 9 m. Roughly a hundred times less UV density,
+    // so the junction magnified mip 0 while the road beside it sampled real
+    // detail, and the two met at a hard line with sharp tarmac on one side and
+    // a smear on the other. It reads as a rendering fault and was mistaken in
+    // turn for post-processing, a shadow and a missing chunk.
+    //
+    // Aligned to world axes rather than to the junction's rotation, so the two
+    // triangles of a crossing cannot disagree about which way the grain runs.
+    const uq = [];
+    for (let i = 0; i < 4; i++) uq.push(pts[i * 2] / ROAD_TILE, pts[i * 2 + 1] / ROAD_TILE);
+    road.flat(pts, ys, [1, 1, 1], uq);
 
     if (lod !== 1 || sw <= 0 || n.elev || !walk) return;
     // Square ring of pavement around the junction; its inner edge lines up with

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v39';
+const CACHE = 'auto-v40';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v40';
+const CACHE = 'auto-v41';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',

--- a/tools/beauty.mjs
+++ b/tools/beauty.mjs
@@ -183,7 +183,15 @@ async function main() {
       const lz = t.z + Math.cos(bear) * V.ahead;
       const counts = await evaluate(`(() => {
         const d = window.__dbg;
+        // Settle the streamer. Chunk geometry is time-sliced across frames now,
+        // and this harness pauses the game -- so a single update builds a few
+        // milliseconds of geometry and nothing ever continues it. Every shot
+        // taken since that change was a photograph of bare terrain with cars
+        // standing on dirt, which is the third time a harness has quietly
+        // invalidated the thing it was built to measure.
+        const pending = () => [...d.world.chunks.values()].filter((c) => c.lod !== c.wantLod).length;
         d.world.update(${cx}, ${cz}, 60);
+        for (let i = 0; i < 2000 && pending() > 0; i++) d.world.update(${cx}, ${cz}, 60);
         const gy = (x, z) => Math.max(0, d.city.groundAt(x, z, null));
         const cy = gy(${cx}, ${cz}) + ${V.eye};
         const ly = gy(${lx}, ${lz}) + ${V.look};

--- a/tools/perfguard.mjs
+++ b/tools/perfguard.mjs
@@ -1,0 +1,175 @@
+// Performance guard: the numbers a change must not make worse.
+//
+//   node tools/perfguard.mjs            print the record
+//   node tools/perfguard.mjs --save     write it to tools/data/perfguard.json
+//   node tools/perfguard.mjs --check    compare against the saved record
+//
+// Draw calls and triangles are device-independent, and so is the JavaScript
+// cost of streaming a chunk -- which means all three can be held to account
+// from here even though the target device cannot be profiled. What this cannot
+// see is fill rate and shader cost on the actual GPU; for those, the readout in
+// the pause menu is the only honest source.
+//
+// Three separate regressions this session were shipped because "it looks fine
+// to me" was the only check: a shadow pass that doubled the frame, a chunk
+// streamer that stalled for a quarter of a second, and a rebuild that punched a
+// 400 m hole in the world. Each was obvious once counted.
+
+import { spawn } from 'node:child_process';
+import { writeFileSync, readFileSync, existsSync, mkdirSync } from 'node:fs';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const PORT = 9237;
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const HTTP_PORT = process.env.AUTO_HTTP_PORT || 8000;
+const REC = 'tools/data/perfguard.json';
+const SAVE = process.argv.includes('--save');
+const CHECK = process.argv.includes('--check');
+
+// How much worse a figure may get before it counts as a regression. Streaming
+// times are noisy on a shared machine, so they get more room than draw counts,
+// which are exact.
+// **Run this on a quiet machine.** The draw and triangle counts are exact and
+// repeatable; the streaming times are wall-clock and collapse under contention.
+// Measured with two other headless Chrome instances running, updateMax read
+// 26 ms against a true 16; with the machine idle it reproduces inside a
+// millisecond. A timing "regression" here is worth a second run before it is
+// worth an investigation.
+const TOLERANCE = {
+  drawsSteady: 0.04, trisSteady: 0.05,
+  drawsFrame: 0.04, trisFrame: 0.05,
+  updateP99: 0.35, updateMax: 0.35,
+  holes: 0,
+};
+
+function launch() {
+  return spawn(CHROME, [
+    `--remote-debugging-port=${PORT}`, '--headless=new', '--use-gl=swiftshader',
+    '--enable-unsafe-swiftshader', '--window-size=1280,720', '--no-first-run',
+    '--user-data-dir=/tmp/auto-perfguard', 'about:blank',
+  ], { stdio: 'ignore' });
+}
+
+const MEASURE = `(() => {
+  const d = window.__dbg, r = d.renderer;
+  const DOWNTOWN = { x: 305, z: -278 };
+
+  // Settle the streamer first. Chunk geometry is time-sliced, so a figure taken
+  // mid-stream describes an unfinished city and reads as an improvement.
+  const pending = () => [...d.world.chunks.values()].filter((c) => c.lod !== c.wantLod).length;
+  for (let i = 0; i < 900 && pending() > 0; i++) d.world.update(DOWNTOWN.x, DOWNTOWN.z, 2);
+
+  const gy = Math.max(0, d.city.groundAt(DOWNTOWN.x, DOWNTOWN.z, null));
+  d.camera.position.set(DOWNTOWN.x, gy + 3, DOWNTOWN.z + 40);
+  d.camera.lookAt(DOWNTOWN.x, gy + 2, DOWNTOWN.z);
+  d.camera.updateMatrixWorld(true);
+  d.scene.updateMatrixWorld(true);
+
+  // The whole frame, including the shadow pass. postfx.render does NOT
+  // re-render the scene, so measuring around it counts the post chain alone.
+  r.info.autoReset = false;
+  r.info.reset();
+  r.setRenderTarget(d.postfx.target);
+  r.render(d.scene, d.camera);
+  r.setRenderTarget(null);
+  const frame = { calls: r.info.render.calls, tris: r.info.render.triangles };
+  r.info.autoReset = true;
+
+  // Streaming cost: drive across the map and time every world.update the way a
+  // frame would, and watch for chunks that lose their geometry mid-rebuild.
+  const times = [];
+  const everHad = new Set();
+  let holes = 0;
+  for (let i = 0; i < 320; i++) {
+    const x = -2400 + i * 11, z = -700 + i * 5;
+    const t0 = performance.now();
+    d.world.update(x, z, 2);
+    times.push(performance.now() - t0);
+    for (const c of d.world.chunks.values()) {
+      if (c.group) everHad.add(c.key);
+      else if (everHad.has(c.key)) holes++;
+    }
+  }
+  times.sort((a, b) => a - b);
+  const q = (f) => +times[Math.floor(times.length * f)].toFixed(2);
+
+  return JSON.stringify({
+    drawsSteady: d.sceneStats.calls, trisSteady: d.sceneStats.tris,
+    drawsFrame: frame.calls, trisFrame: frame.tris,
+    updateMedian: q(0.5), updateP99: q(0.99), updateMax: +times[times.length - 1].toFixed(2),
+    holes,
+    vehicles: d.traffic.cars.length, peds: d.peds.peds.length,
+  });
+})()`;
+
+async function main() {
+  const chrome = launch();
+  try {
+    let page;
+    for (let i = 0; i < 90 && !page; i++) {
+      try {
+        page = (await (await fetch(`http://127.0.0.1:${PORT}/json/list`)).json())
+          .find((t) => t.type === 'page');
+      } catch { /* not up */ }
+      if (!page) await sleep(300);
+    }
+    const ws = new WebSocket(page.webSocketDebuggerUrl);
+    await new Promise((r, j) => { ws.addEventListener('open', r); ws.addEventListener('error', j); });
+    let id = 0; const pend = new Map();
+    ws.addEventListener('message', (ev) => {
+      const m = JSON.parse(ev.data);
+      if (m.id && pend.has(m.id)) { pend.get(m.id)(m); pend.delete(m.id); }
+    });
+    const send = (method, params = {}) => new Promise((res) => {
+      ws.send(JSON.stringify({ id: ++id, method, params })); pend.set(id, res);
+    });
+    const evaluate = async (e) => {
+      const r = await send('Runtime.evaluate', { expression: e, returnByValue: true });
+      if (r.result?.exceptionDetails) throw new Error(r.result.exceptionDetails.exception?.description);
+      return r.result?.result?.value;
+    };
+    await send('Runtime.enable');
+    await send('Page.enable');
+    await send('Network.enable');
+    await send('Network.setBypassServiceWorker', { bypass: true });
+    await send('Network.setCacheDisabled', { cacheDisabled: true });
+    await send('Page.addScriptToEvaluateOnNewDocument', { source: 'window.__noAutoQuality = true;' });
+    await send('Page.navigate', { url: `http://localhost:${HTTP_PORT}/apps/auto/` });
+    for (let i = 0; i < 400; i++) {
+      await sleep(500);
+      if (await evaluate('!!window.__dbg')) break;
+    }
+    const now = JSON.parse(await evaluate(MEASURE));
+
+    const row = (k, v) => console.log(`  ${k.padEnd(14)}${String(v).padStart(10)}`);
+    console.log('performance guard');
+    for (const [k, v] of Object.entries(now)) row(k, v);
+
+    if (SAVE) {
+      mkdirSync('tools/data', { recursive: true });
+      writeFileSync(REC, JSON.stringify(now, null, 2));
+      console.log(`\nsaved to ${REC}`);
+      return;
+    }
+    if (CHECK) {
+      if (!existsSync(REC)) { console.error(`no record at ${REC} -- run --save first`); process.exitCode = 1; return; }
+      const was = JSON.parse(readFileSync(REC, 'utf8'));
+      let bad = 0;
+      console.log('\nagainst the saved record:');
+      for (const [k, tol] of Object.entries(TOLERANCE)) {
+        if (!(k in was) || !(k in now)) continue;
+        const limit = was[k] * (1 + tol) + (tol === 0 ? 0 : 0.5);
+        const over = now[k] > limit;
+        if (over) bad++;
+        console.log(`  ${k.padEnd(14)}${String(was[k]).padStart(10)} -> ${String(now[k]).padStart(9)}`
+          + `  ${over ? 'REGRESSED' : 'ok'}`);
+      }
+      console.log(bad ? `\n${bad} figure(s) regressed.` : '\nno regressions.');
+      if (bad) process.exitCode = 1;
+    }
+  } finally {
+    chrome.kill('SIGKILL');
+  }
+}
+
+main().catch((e) => { console.error('perfguard failed:', e.message); process.exitCode = 1; });


### PR DESCRIPTION
Build **v41**. Reverted off master (`112854e`) so it can be reviewed here — this
branch reapplies it and adds the stutter work.

## 1. The seam at the spawn

Reported three times; I diagnosed it wrongly twice, first as post-processing,
then as a chunk-streaming hole. Neither.

Reproduced headlessly at the spawn with the game's own chase camera and the
streamer settled, then bisected: **it appears at exactly the same column with
post off, shadows off and fog off.**

`meshNode` emitted the crossing square with a hardcoded UV rectangle:

```js
road.flat(pts, ys, [1, 1, 1], [0.18, 0.62, 0.34, 0.62, 0.34, 0.76, 0.18, 0.76])
```

A 0.16 × 0.14 slice of the asphalt texture stretched across an entire junction —
at a 20 m crossing that's one repeat per ~130 m against the strips' `ROAD_TILE`
of 9 m. Roughly **a hundred times less UV density**, so the junction magnified
mip 0 while the road beside it sampled real detail. UVs are world metres now.

![seam before and after](https://raw.githubusercontent.com/maattp/maattp.github.io/pr-351-shots/seam/seam-compare.jpg)

Mean horizontal gradient either side of the seam — which is what "blurry" means
numerically:

| | left | right | ratio |
|---|---|---|---|
| before | 1.04 | **0.50** | 2.06 |
| after | 1.14 | 1.10 | **1.04** |

## 2. Why it stutters while driving

**Not JavaScript.** Timing every per-frame system on a real route: worst frame
was `world.update` at 13.4 ms, mean 1.2 ms, and **no shader compiled during the
drive** (26 programs before, 26 after).

But `renderer.info.memory.textures` climbed steadily — 62 → 80 over two minutes
— and never came down. Traversing the scene found no new material maps, because
they weren't material maps. They were **skeleton bone textures**: three backs
every `Skeleton` with a GPU texture, `makeHumanoid`'s `dispose()` only freed
geometry, and pedestrians churn continuously through the 150 m spawn radius as
you drive.

So every pedestrian leaving range leaked a texture, and every one spawning
uploaded a fresh one — and **a texture upload is a synchronous stall on the main
thread.** That's the hitch.

Disposing the skeleton takes the count after the same drive from **80 → 48** —
below the pre-drive baseline, because it now reclaims as pedestrians despawn.

Two more of the same class:

- **Police light bar** — three geometries and three materials per cruiser, never
  freed, and cops churn constantly during a chase. Freed via `v.extra`.
  Deliberately *not* a traverse-and-dispose of the vehicle: a car shares its
  geometry and its trim/matte materials with every other instance.
- **Helicopter** — a dozen meshes with their own geometries and materials,
  rebuilt whenever `wanted` crosses 4 and removed without disposing. A whole
  airframe leaked on every transition, both directions.

## 3. `beauty.mjs` has been photographing bare terrain

Found by a broad sweep. Since the streamer was time-sliced, the harness called
`world.update` **once** and then paused the game — and a paused frame returns
before the streamer runs, so nothing ever continued the build. Cars and
pedestrians were standing on dirt in every shot; the downtown frame contained
only the far skyline.

It settles now, the way `perfguard` already did. The value structure changes a
lot, because it's finally measuring the city:

| shot | ratio (was) | ratio (now) |
|---|---|---|
| downtown | 2.3 | **9.0** |
| skyline | 1.8 | 3.8 |
| residential | 1.3 | 3.7 |
| street | 1.3 | 3.1 |

Downtown at 9.0 is well outside the 2.2–3.3 band this codebase holds itself to,
and nobody could have known. **That's the third time a harness has quietly
invalidated the thing it was built to measure** — worth its own follow-up.

## 4. Graphics default back to `high`

Phones were demoted to `medium` when the frame was 509 draws and a chunk build
could block for a quarter second. Both fixed — 299 draws, 16 ms worst frame — and
the device measures 61 fps with a floor of 57. `autoQuality` still steps down on
its own if a device can't hold it.

## 5. `tools/perfguard.mjs`

Records what a change must not make worse: draws and triangles for a *settled*
downtown frame, streaming cost, and chunks left without geometry mid-rebuild.
`--check` compares against the saved record.

It earned its keep immediately — flagged an apparent 45% streaming regression in
this very change, which turned out to be other headless Chrome instances
competing for the machine. There's a note in the file, because otherwise the
next person hunts a bug that isn't there.

## Checks

- `node tools/verify.mjs` → `OK: 0 exceptions`
- `node tools/vehicles.mjs` → `0 figures outside their band, of 72`
- `node tools/perfguard.mjs --check` → no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B