### PR TITLE
Auto: you can fall, you can drown in a lake, and the guns are on land

### DIFF
--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -414,7 +414,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v41</div>
+    <div id="build">v42</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/src/main.js
+++ b/apps/auto/src/main.js
@@ -436,7 +436,7 @@ function installHeightFog() {
   // KEXP's now-playing feed drives a toast, so the radio names its own tracks.
   audio.onTrack = (label) => { if (hud) hud.showToast(`♪ ${label}`); };
   controls = new Controls(document.getElementById('app'));
-  player = new Player(scene, city, game);
+  player = new Player(scene, city, game, world);
   traffic = new TrafficSystem(scene, city, game);
   peds = new PedSystem(scene, city, game);
   fx = new Effects(scene, tx);
@@ -486,23 +486,47 @@ function installHeightFog() {
 // ---------------------------------------------------------------------------
 
 function buildPickups(scene, city) {
-  const spots = [
-    { x: -1150, z: -900, kind: 'gun' },
-    { x: 240, z: 1400, kind: 'gun' },
-    { x: -300, z: -1300, kind: 'health' },
-    { x: 900, z: -1400, kind: 'gun' },
-    { x: 1050, z: 240, kind: 'health' },
-    { x: -960, z: -3760, kind: 'gun' },
-    { x: 1400, z: -3900, kind: 'health' },
-    { x: -2900, z: 2400, kind: 'health' },
-    { x: -3400, z: -4000, kind: 'gun' },
-    { x: 300, z: 1900, kind: 'health' },
-    { x: 2000, z: 600, kind: 'gun' },
-    { x: -1300, z: -1500, kind: 'health' },
-    { x: 1250, z: 2500, kind: 'gun' },
-    { x: -2600, z: 3600, kind: 'health' },
-    { x: 620, z: -4200, kind: 'gun' },
+  // Pickup sites are found in the map, not written down.
+  //
+  // These were fifteen hardcoded coordinates from the hand-drawn city. Against
+  // real OSM data four of them had gone wrong: a health pack under Puget Sound
+  // at y = -2.1, a pistol floating on the water at (620, -4200), and two more
+  // sitting in a live carriageway. That is one of eight guns unobtainable, and
+  // it is the same failure the beauty harness had -- coordinates outlive the
+  // world they were measured in.
+  //
+  // Anchored to real places so they stay spread across the map and stay put
+  // between sessions, then nudged to the nearest spot that is dry land, off the
+  // carriageway and not inside a building.
+  const anchors = [
+    [-1150, -900], [240, 1400], [-2200, 1100], [900, -1400], [1500, -2400],
+    [-960, -3760], [-300, 700], [-3400, -4000], [300, 1900], [2000, 600],
+    [-1300, -1500], [1250, 2500], [-2600, 3600], [620, -4200], [-1800, -2600],
   ];
+  const usable = (x, z) => !G.isWater(x, z) && G.terrainHeight(x, z) > 1.2
+    && !city.onRoad(x, z, 1.5, false) && !world.inBuilding(x, z, 1.5);
+  // Snap each anchor to the nearest street, then step off the carriageway onto
+  // the verge. Spiralling out from the raw anchor is not enough on its own --
+  // one of these sits well out in Puget Sound, and no search radius that stays
+  // in the right neighbourhood will ever find land. A road node is guaranteed
+  // to be somewhere you could stand.
+  const spots = anchors.map(([ax, az], i) => {
+    let nd = null, bestD = Infinity;
+    for (const n of city.nodes) {
+      if (n.elev) continue;
+      const d2 = (n.x - ax) ** 2 + (n.z - az) ** 2;
+      if (d2 < bestD) { bestD = d2; nd = n; }
+    }
+    const cx0 = nd ? nd.x : ax, cz0 = nd ? nd.z : az;
+    for (let r = 6; r <= 60; r += 6) {
+      for (let a = 0; a < 16; a++) {
+        const th = (a / 16) * Math.PI * 2 + i;
+        const x = cx0 + Math.cos(th) * r, z = cz0 + Math.sin(th) * r;
+        if (usable(x, z)) return { x, z, kind: i % 2 ? 'health' : 'gun' };
+      }
+    }
+    return { x: cx0, z: cz0, kind: i % 2 ? 'health' : 'gun' };
+  });
   for (const s of spots) {
     const y = city.groundAt(s.x, s.z, null) + 1.1;
     const g = new THREE.Group();

--- a/apps/auto/src/player.js
+++ b/apps/auto/src/player.js
@@ -7,10 +7,13 @@ import { clamp, lerp, angleWrap, damp, dist2 } from './util.js';
 import * as G from './geo.js';
 
 export class Player {
-  constructor(scene, city, game) {
+  constructor(scene, city, game, world) {
     this.scene = scene;
     this.city = city;
     this.game = game;
+    // Needed for `waterLevelAt`: drowning is against the local surface, and
+    // the lakes are not at sea level.
+    this.world = world;
     this.h = makeHumanoid({ seed: 1, unique: true, shirt: [0.16, 0.2, 0.3], pants: [0.12, 0.13, 0.17], hair: [0.1, 0.08, 0.07], scale: 1.03 });
     scene.add(this.h.group);
     this.x = G.SPAWN.x;
@@ -30,6 +33,7 @@ export class Player {
     this.lift = 0;
     this.dead = false;
     this.crashCd = 0; // see updateDrive: one wall scrape is one crash
+    this.fellFrom = 0; // height a fall started at, for landing damage
 
     this.camYaw = this.heading + Math.PI;
     this.camPitch = 0.1;
@@ -46,6 +50,11 @@ export class Player {
   enterVehicle(v) {
     if (!v || v.dead) return false;
     this.vehicle = v;
+    // Remember it was parked BEFORE the mode is overwritten. `game.onEnterVehicle`
+    // tests `v.mode === 'parked' || v.wasParked` to decide whether this is theft
+    // -- but mode is set to 'free' on the line below, and nothing in the repo
+    // ever wrote `wasParked`, so taking a parked car has never added heat.
+    v.wasParked = v.mode === 'parked';
     v.mode = 'free';
     v.setDetailed(true);
     this.onFoot = false;
@@ -67,6 +76,13 @@ export class Player {
     this.heading = v.heading;
     this.onFoot = true;
     this.h.group.visible = true;
+    // Step out with the vertical state the car had, not whatever was left over
+    // from before you got in -- jumping, entering and exiting used to launch you
+    // upward on the stale `vy`.
+    this.vy = 0;
+    this.speed = 0;
+    this.grounded = true;
+    this.fellFrom = 0;
     v.mode = 'free';
     v.setDetailed(false);
     this.vehicle = null;
@@ -135,16 +151,45 @@ export class Player {
       this.vy = 6.2;
       this.grounded = false;
     }
+    // Walk off an edge and you FALL.
+    //
+    // `grounded` was only ever cleared by jumping, so stepping off a viaduct or
+    // a sea wall eased you down on the same exponential the camera uses for
+    // kerbs -- measured, dropped 25 m the player descended smoothly with
+    // `grounded` still true the whole way. No arc, no fall, and nothing that
+    // could ever cost you health. Anything more than a kerb below your feet is
+    // air, and air is not something you stand on.
+    const KERB = 0.45;
+    if (this.grounded && this.y - ground > KERB) {
+      this.grounded = false;
+      this.vy = 0;
+      this.fellFrom = this.y;
+    }
     if (!this.grounded) {
       this.vy -= 20 * dt;
       this.y += this.vy * dt;
-      if (this.y <= ground) { this.y = ground; this.vy = 0; this.grounded = true; }
+      if (this.y <= ground) {
+        // Landing. Below about four metres a person absorbs it; past that it
+        // hurts, and it scales with the square of the drop the way the energy
+        // does.
+        const drop = (this.fellFrom || this.y) - ground;
+        this.y = ground;
+        this.vy = 0;
+        this.grounded = true;
+        this.fellFrom = 0;
+        if (drop > 4.5) this.game.damagePlayer(Math.min(100, (drop - 4.5) ** 1.6 * 1.6), 'fall');
+      }
     } else {
       this.y = lerp(this.y, ground, 1 - Math.exp(-16 * dt));
     }
 
-    // drowning
-    if (this.y < -0.6 && G.isWater(this.x, this.z)) this.game.onDrown();
+    // Drowning is against the LOCAL water surface, not sea level.
+    //
+    // `y < -0.6` only ever describes the sea. Green Lake sits at 50 m and Lake
+    // Union at 5, so you could stand on a lake bed indefinitely -- and
+    // `world.waterLevelAt()`, written for exactly this, had no callers at all.
+    const wl = this.world.waterLevelAt(this.x, this.z);
+    if (wl !== null && this.y < wl - 0.6) this.game.onDrown();
 
     animateWalk(this.h, clamp(this.speed * 0.16, 0, 0.85), dt, this.speed);
     this.h.group.position.set(this.x, this.y, this.z);

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v41';
+const CACHE = 'auto-v42';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',


### PR DESCRIPTION
Four correctness bugs found by a broad sweep of the game. Each one verified by
probe **before and after**, not by reading the code. Build **v42**.

## The player never fell

`grounded` was only ever cleared by jumping, so stepping off a viaduct or a sea
wall eased you down on the same exponential the camera uses to smooth kerbs.

Measured: dropped 25 m, the player descended smoothly with `grounded` **still
true the whole way**. No arc, and nothing that could ever cost health.

Anything more than a kerb below your feet is air now, and landing past ~4.5 m
hurts, scaling with the drop the way the energy does. Re-measured: **10.1 m in
the first second**, which is `½·20·t²` exactly.

## You could not drown in a lake

The test was `y < -0.6` — which only ever describes the sea. Lake Union sits at
5 m and Green Lake at 50, so you could stand on a lake bed indefinitely.

`world.waterLevelAt()` was written for exactly this problem and had **no callers
at all**. It does now. Verified by standing the player 3 m under Lake Union:
drowns.

## Four of fifteen pickups were unreachable or in the road

Hardcoded coordinates from the hand-drawn city. Against real OSM data:

| | |
|---|---|
| health at (-2900, 2400) | under Puget Sound, y = **-2.1** |
| gun at (620, -4200) | floating on the water |
| gun at (900, -1400) | in a live carriageway |
| health at (-2600, 3600) | in a live carriageway |

That's **one gun in eight simply unobtainable** — and it's the same failure the
beauty harness had, which `CLAUDE.md` already documents: coordinates outlive the
world they were measured in.

Sites are found in the map now. Each anchor snaps to the nearest street node —
guaranteed to be somewhere you could stand — then steps off the carriageway onto
the verge, skipping water, buildings and tarmac. Spiralling out from the raw
anchor isn't enough on its own: one anchor is well out in Puget Sound, and no
radius that stays in the right neighbourhood will ever find land.

**0 of 15 bad.**

## Stealing a parked car never added heat

`game.onEnterVehicle` tests `v.mode === 'parked' || v.wasParked`. But
`enterVehicle` sets the mode to `'free'` *before* calling it, and **nothing in
the repo ever wrote `wasParked`** — so the condition was dead both ways round and
car theft was free. Flagged before the mode is overwritten.

## Also

`exitVehicle` resets `vy`, `speed`, `grounded` and the fall height. Jumping,
entering a car and getting out used to launch you upward on the stale `vy`.

## Checks

- `node tools/verify.mjs` → `OK: 0 exceptions`
- `node tools/vehicles.mjs` → `0 figures outside their band, of 72`
- `node tools/perfguard.mjs --check` → no regressions

## Still open, from the same sweep

Not in this PR, roughly in order of value:

- **Navigation.** Delivery targets are picked 420–2400 m away but the minimap
  only shows ~388 m, with no rim clamp and no off-screen arrow — so most
  deliveries have no on-screen guidance at all, despite the help text saying to
  follow the minimap.
- **Police can't be shaken.** A cruiser inside 140 m keeps driving at you
  regardless of wanted level, so it never qualifies for despawn and the siren
  wails permanently at zero stars.
- **Downtown measures 9.0:1 lit-to-shadow**, against the 2.2–3.3 band this
  codebase holds itself to. Only visible since the beauty harness was fixed.
- **The far skyline is 223 untextured white boxes** past 800 m — a texture there
  costs 0 draws and 0 triangles.
- **Cops wear civilian clothes** — `makeHumanoid` only consumes the uniform
  colours in its `unique` branch, which cops don't take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B