### PR TITLE
Auto: zero-cost graphics — skyline, sky chroma, roof lids, and a harness lighting bug

### DIFF
--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -414,7 +414,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v44</div>
+    <div id="build">v45</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -414,7 +414,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v45</div>
+    <div id="build">v46</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/src/main.js
+++ b/apps/auto/src/main.js
@@ -265,7 +265,7 @@ async function boot() {
   // before it reached the framebuffer: hemisphere and ambient were pushed 2.6x
   // and bought 1.6x on screen. Exposure slides the whole scene up the curve
   // instead of pushing harder into the compressed region.
-  renderer.toneMappingExposure = 0.46;
+  renderer.toneMappingExposure = 0.53;
   const viewW = () => canvas.clientWidth || window.innerWidth;
   const viewH = () => canvas.clientHeight || window.innerHeight;
   renderer.setSize(viewW(), viewH(), false);

--- a/apps/auto/src/textures.js
+++ b/apps/auto/src/textures.js
@@ -614,13 +614,22 @@ function skyEquirect() {
   const W = 2048, H = 1024;
   const { c, g } = canvas(W, H);
   const grad = g.createLinearGradient(0, 0, 0, H);
-  grad.addColorStop(0.00, '#2f5680');
-  grad.addColorStop(0.22, '#4a749a');
-  grad.addColorStop(0.42, '#88a8c2');
-  grad.addColorStop(0.50, '#c2ced6');
-  grad.addColorStop(0.54, '#cdd6db');
-  grad.addColorStop(0.70, '#8e969b');
-  grad.addColorStop(1.00, '#5d6469');
+  // Chroma, at the luminance the sky already had.
+  //
+  // The stops were never the problem -- #88a8c2 is saturation 0.227. Measured
+  // off the rendered frames, the sky arrives on screen at **0.010 to 0.020**:
+  // achromatic grey across a third to a half of most frames, and it is also
+  // 100 % of the image-based light, so every shaded facade and the whole surface
+  // of Puget Sound were being lit by grey. The bleaching happens below, in the
+  // cloud pass and the haze band. These stops keep their luminance and take
+  // their hue back.
+  grad.addColorStop(0.00, '#1f4f8c');
+  grad.addColorStop(0.22, '#3f74ab');
+  grad.addColorStop(0.42, '#7ba7cd');
+  grad.addColorStop(0.50, '#b6cbdb');
+  grad.addColorStop(0.54, '#c6d4dd');
+  grad.addColorStop(0.70, '#8b979f');
+  grad.addColorStop(1.00, '#5a6469');
   g.fillStyle = grad;
   g.fillRect(0, 0, W, H);
   // Sun: placed to match the key light direction so speculars line up.
@@ -649,22 +658,30 @@ function skyEquirect() {
   // gaps between them, and enough alpha each to be a cloud rather than a wash.
   const r = mulberry32(83);
   for (let layer = 0; layer < 3; layer++) {
-    const count = 46 + layer * 30;
+    const count = 14 + layer * 9;
     for (let i = 0; i < count; i++) {
       // Keep out of the zenith. Equirect x spans a full 360 deg at every
       // latitude, so a bank drawn near y=0 is stretched across an enormous arc
       // and renders as a grey swirl rather than a cloud. From about 25 deg
       // down to the horizon is the band a player actually looks at anyway.
-      const y = H * 0.17 + Math.pow(r(), 0.75) * (H * 0.30);
+      const y = H * 0.26 + Math.pow(r(), 0.8) * (H * 0.21);
       const x = r() * W;
       // Perspective still flattens a bank toward the horizon, but the floor is
       // high enough that the shape stays a cloud and not a line.
       const squash = 0.46 + (y / H) * 0.5;
-      const w = (110 + r() * 260) * (1 + layer * 0.35);
+      // Clamp the width. At 630 px this reached 110 degrees of azimuth, and a
+      // bank that wide sitting 59 degrees up wraps the zenith region and reads
+      // as one grey smear across the top of the frame -- visible in five of the
+      // seven beauty shots. The comment below always said to keep out of the
+      // zenith; nothing enforced it.
+      const w = Math.min(W * 0.11, (110 + r() * 200) * (1 + layer * 0.3));
       const h = w * squash * (0.34 + r() * 0.3);
       const near = 1 - Math.abs(y - sy) / 900;
       const bright = 0.88 + Math.max(0, near) * 0.12;
-      const alpha = 0.07 + r() * 0.11;
+      // Higher per-cloud, far fewer clouds. 228 banks over a 2048x307 band was
+      // roughly thirty times overdraw at 0.12 alpha -- about an 80 % white wash
+      // over the entire sky, which is what took the chroma out.
+      const alpha = 0.16 + r() * 0.16;
       const cg = g.createRadialGradient(x, y, 0, x, y, w);
       const t = Math.round(255 * bright);
       cg.addColorStop(0, `rgba(${t},${t},${Math.round(t * 0.99)},${alpha})`);
@@ -682,10 +699,14 @@ function skyEquirect() {
     }
   }
   // horizon haze band
-  const haze = g.createLinearGradient(0, H * 0.44, 0, H * 0.56);
-  haze.addColorStop(0, 'rgba(206,216,222,0)');
-  haze.addColorStop(0.5, 'rgba(206,216,222,0.85)');
-  haze.addColorStop(1, 'rgba(206,216,222,0)');
+  // Narrower and much weaker, and tinted to scene.fog's own colour so the
+  // horizon and the fog agree instead of meeting at a seam. At 0.85 alpha across
+  // v 0.44-0.56 this was a near-opaque grey wash over the horizon plus or minus
+  // 22 degrees -- which is exactly where every street-level shot points.
+  const haze = g.createLinearGradient(0, H * 0.47, 0, H * 0.53);
+  haze.addColorStop(0, 'rgba(185,195,207,0)');
+  haze.addColorStop(0.5, 'rgba(185,195,207,0.35)');
+  haze.addColorStop(1, 'rgba(185,195,207,0)');
   g.fillStyle = haze;
   g.fillRect(0, 0, W, H);
 

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -1461,21 +1461,22 @@ export class World {
         flat.prism(tx2, rt + 1.8, tz2, 1.5, 2.4, 8, [0.42, 0.34, 0.27]);
         flat.cone(tx2, rt + 4.2, tz2, 1.55, 0.7, 8, [0.36, 0.29, 0.23]);
       }
-      // parapet lip, so the roof edge has a silhouette rather than a clean cut
+      // The parapet does not get a top face, because the lid goes on top of it.
+      //
+      // It used to: `box` defaults to `top: true`, so the surface you actually
+      // saw when you looked at a roof was the parapet's lid at rt + 0.85, on
+      // `flat` -- which has no map and no normal map. The textured lid was
+      // underneath it at rt - 0.12, contributing a 12 cm band nobody could see.
+      // Roofs are roughly 40 % of the pixels in the skyline shot and every one
+      // of them was a flat colour.
       flat.box(bd.x, rt, bd.z, bd.w + 0.5, 0.85, bd.d + 0.5, bd.rot,
-        [rv * 1.2, rv * 1.2, rv * 1.17]);
-      // The lid itself, on a textured builder. A roof is seen from every
-      // elevated view in the game and it was one flat untextured colour.
-      // At 7 m a tile this slab is the single biggest thing splitting into
-      // per-repeat quads for the atlas -- about half the facade set's triangles
-      // across a downtown chunk, for a 12 cm band. Dropping its sides is the
-      // obvious saving and it is NOT free: the band is the only part of the lid
-      // you can see (the parapet box above covers its top face outright), and
-      // removing it visibly cleans the corrugated grain out from under every
-      // cornice in the city. That is a look change, not a perf change, so it
-      // stays.
-      bl.facade.box(bd.x, rt - 0.12, bd.z, bd.w + 0.2, 0.14, bd.d + 0.2, bd.rot,
-        [rv * 0.92, rv * 0.93, rv * 0.96], { uScale: 7, vScale: 7, cell: C.industrial });
+        [rv * 1.2, rv * 1.2, rv * 1.17], { top: false });
+      // The lid, capping the parapet flush. `box` draws no bottom face, so
+      // there is nothing to see through where the two meet. 4 m a tile rather
+      // than 7 so the industrial cell's corrugation reads as roof seams instead
+      // of grain.
+      bl.facade.box(bd.x, rt + 0.71, bd.z, bd.w + 0.5, 0.14, bd.d + 0.5, bd.rot,
+        [rv * 0.92, rv * 0.93, rv * 0.96], { uScale: 4, vScale: 4, cell: C.industrial });
     }
 
     const dense = bd.style !== 'industrial';

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -14,6 +14,33 @@ import { hash2, clamp, lerp, distToSeg } from './util.js';
 const ROAD_Y = ROAD_LIFT;
 // Metres per road-texture repeat. Fixed, so the asphalt's grain is the same
 // size on an alley and on a freeway.
+/**
+ * The tiers a tall building steps back through.
+ *
+ * Shared by the near chunk mesh and the far skyline mesh, because they were
+ * modelling the same building differently and each poked through the other. The
+ * near mesh stepped back at 62 % of the height; the far mesh at 80-90 %. Between
+ * those the far version was WIDER, so it stood proud of the textured geometry
+ * all the way round -- and the far mesh has no map, so every tall building in
+ * downtown wore a blank pale slab across its upper third. Measured by raycast,
+ * the far mesh was the frontmost surface at 235-353 m, well inside the 800 m
+ * near radius where it has no business being visible at all.
+ *
+ * One profile, two consumers. They cannot drift again.
+ */
+function* buildingTiers(bd, baseY, totalH) {
+  const n = bd.h > 100 ? 3 : bd.h > 55 ? 2 : 1;
+  let y = baseY, remaining = totalH, w = bd.w, d = bd.d;
+  for (let t = 0; t < n; t++) {
+    const frac = t === n - 1 ? 1 : t === 0 ? 0.62 : 0.6;
+    const h = remaining * frac;
+    yield { t, last: t === n - 1, y, h, w, d };
+    y += h;
+    remaining -= h;
+    if (t < n - 1) { y += 0.55; w *= 0.78; d *= 0.78; }
+  }
+}
+
 const ROAD_TILE = 9;
 // Metres per repeat of the paving texture, which carries four slabs -- so a
 // slab is a metre, everywhere.
@@ -443,36 +470,28 @@ export class World {
       //
       // This is the far mesh, so it is silhouette only -- four boxes at most,
       // and only for the few hundred buildings over 45 m.
-      const crown = bd.h > 45;
-      const shaftH = crown ? bd.h * (0.80 + hash2(bd.seed, 23) * 0.10) : bd.h;
-      b.box(bd.x, bd.y - 2, bd.z, bd.w * s, shaftH + 2, bd.d * s, bd.rot, col, { top: true, ao: 0.3 });
-      if (!crown) continue;
+      // Same tiers the near mesh draws, inset and stopped 2 m short, so the far
+      // version is strictly INSIDE the textured geometry wherever both exist.
+      const plant = bd.h > 45 ? Math.min(4.5, bd.h * 0.05) : 0;
+      const totalH = bd.h + 2 - plant;
       const dk = [col[0] * 0.86, col[1] * 0.88, col[2] * 0.92];
-      let cy = bd.y - 2 + shaftH + 2;
-      let cw = bd.w * s, cd = bd.d * s;
-      const style = hash2(bd.seed, 29);
-      const setbacks = style < 0.4 ? 1 : style < 0.8 ? 2 : 3;
-      // The crown has to fit INSIDE the building's own height. Built on top of
-      // it, the penthouse and mast stood proud of the real roofline drawn by
-      // the near-chunk mesh -- so every tall building in the city wore an
-      // untextured pale box floating above its actual roof, which clipped to
-      // white slabs across downtown.
-      const rest = bd.h - shaftH;
-      const plant = Math.min(4.5, rest * 0.35);
-      const stepped = rest - plant;
-      for (let t = 0; t < setbacks; t++) {
-        const th = stepped / setbacks;
-        cw *= 0.78; cd *= 0.78;
-        b.box(bd.x, cy, bd.z, cw, th, cd, bd.rot, t % 2 ? col : dk, { top: true, ao: 0 });
-        cy += th;
+      let topY = bd.y - 2, topW = bd.w * s, topD = bd.d * s;
+      for (const tier of buildingTiers(bd, bd.y - 2, totalH)) {
+        b.box(bd.x, tier.y, bd.z, tier.w * s, tier.h, tier.d * s, bd.rot,
+          tier.t % 2 ? dk : col, { top: true, ao: tier.t === 0 ? 0.3 : 0 });
+        topY = tier.y + tier.h; topW = tier.w * s; topD = tier.d * s;
       }
-      // Mechanical penthouse: the boxy plant room every real tower carries.
-      b.box(bd.x, cy, bd.z, cw * 0.62, plant, cd * 0.62, bd.rot, dk, { top: true });
-      // A mast is the one thing that legitimately stands above the parapet, and
-      // it is thin enough not to read as a slab.
+      // Mechanical penthouse, within the top tier's footprint and within the
+      // building's own height -- so it cannot stand proud of the near mesh.
+      if (plant > 0) {
+        b.box(bd.x, topY, bd.z, topW * 0.6, plant, topD * 0.6, bd.rot, dk, { top: true });
+        topY += plant;
+      }
+      // A mast is the one thing that legitimately rises above a parapet, and it
+      // is thin enough to read as an antenna rather than as a slab.
       if (bd.h > 80 && hash2(bd.seed, 37) > 0.45) {
         const mh = 8 + hash2(bd.seed, 41) * 22;
-        b.box(bd.x, cy + plant, bd.z, 0.9, mh, 0.9, bd.rot, dk, { top: true });
+        b.box(bd.x, topY, bd.z, 0.9, mh, 0.9, bd.rot, dk, { top: true });
       }
     }
     const m = new THREE.Mesh(b.build(), this.mats.far);
@@ -1493,19 +1512,13 @@ export class World {
     }
 
     let w = bd.w, d = bd.d;
-    const tiers = bd.h > 100 ? 3 : bd.h > 55 ? 2 : 1;
-    for (let t = 0; t < tiers; t++) {
-      const frac = t === tiers - 1 ? 1 : t === 0 ? 0.62 : 0.6;
-      const hh = remaining * frac;
-      target.box(bd.x, y, bd.z, w, hh, d, bd.rot, col,
-        { uScale: uS, vScale: vS, top: false, vOff: (y - base) / (vS || 1), ao: t === 0 ? 0.22 : 0, cell });
-      y += hh;
-      remaining -= hh;
-      if (t < tiers - 1) {
-        flat.box(bd.x, y, bd.z, w + 0.8, 0.55, d + 0.8, bd.rot, TRIM);
-        y += 0.55;
-        w *= 0.78; d *= 0.78;
-      }
+    for (const tier of buildingTiers(bd, y, remaining)) {
+      target.box(bd.x, tier.y, bd.z, tier.w, tier.h, tier.d, bd.rot, col,
+        { uScale: uS, vScale: vS, top: false, vOff: (tier.y - base) / (vS || 1),
+          ao: tier.t === 0 ? 0.22 : 0, cell });
+      y = tier.y + tier.h;
+      w = tier.w; d = tier.d;
+      if (!tier.last) flat.box(bd.x, y, bd.z, tier.w + 0.8, 0.55, tier.d + 0.8, bd.rot, TRIM);
     }
 
     // cornice, roof deck, then a parapet wall standing above it

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v44';
+const CACHE = 'auto-v45';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v45';
+const CACHE = 'auto-v46';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',

--- a/tools/beauty.mjs
+++ b/tools/beauty.mjs
@@ -213,7 +213,21 @@ async function main() {
         // the shot so the shadow box covers what is in frame.
         const ax = ${cx} + (${lx} - ${cx}) * 0.25, az = ${cz} + (${lz} - ${cz}) * 0.25;
         const ay = gy(ax, az);
-        d.sun.position.set(ax - 215, ay + 200, az - 150);
+        // Put the sun ACROSS the view, not behind it.
+        //
+        // main.js's fixed (-215, 200, -150) offset throws shadows toward xz
+        // (0.82, 0.57). Every view here is framed on a bearing of 0.9, which
+        // looks toward (0.78, 0.62) -- 4.5 degrees apart. So in every shot the
+        // sun was almost directly behind the camera and every shadow fell away
+        // from it, hidden behind its own caster. That is why the park shot measured a
+        // 1.3:1 lit-to-shadow ratio and looked unlit: the numbers were reading
+        // bounce and baked AO, not the key light at all.
+        //
+        // Same elevation (38 deg) and the same distance, rotated 100 degrees off
+        // the view bearing so shadows cross the frame and can be seen.
+        const SUN_AZ = 0.9 + 1.75;
+        const sr = Math.hypot(215, 150);
+        d.sun.position.set(ax - Math.sin(SUN_AZ) * sr, ay + 200, az - Math.cos(SUN_AZ) * sr);
         d.sun.target.position.set(ax, ay, az);
         d.sun.target.updateMatrixWorld();
         // Populate the shot. The game is paused so the camera can be flown, and


### PR DESCRIPTION
A graphics pass constrained to things that cost nothing. Build **v45**.

The beauty harness only stopped photographing bare terrain a few commits ago, so
this is the first honest look at downtown in several passes — and it made the
biggest defect obvious immediately.

## Blank pale slabs across every tall building

![downtown before and after](https://raw.githubusercontent.com/maattp/maattp.github.io/pr-354-shots/gfx/skyline-compare.jpg)

They were the **far skyline mesh** — which has `vertexColors` and **no map at
all** — poking through the textured near geometry. Raycast at four points on the
slabs returned `mat: "far", hasMap: false` at **235, 253, 328 and 353 m**: well
inside the 800 m radius where near chunks draw the same buildings in full
detail, and where the far mesh has no business being visible.

The two were modelling the same building differently:

| | steps back at |
|---|---|
| near chunk mesh | **62%** of height |
| far skyline mesh | **80–90%** of height |

Between those the far version is *wider*, so it stood proud of the textured
geometry all the way round — and being untextured, it read as a blank slab.

`buildingTiers()` is now the one profile both consume. The far mesh draws the
same tiers inset 1.5% and stopped 2 m short, so it's strictly inside the textured
geometry wherever both exist. The mechanical penthouse sits within the top tier's
footprint and within the building's own height, and only a 0.9 m mast rises above
a parapet — which reads as an antenna rather than a slab.

Re-raycast at the same four points: `glass` and `facade`, `hasMap: true`, same
distances.


## 2. The beauty harness lit every shot from behind the camera

Found by the judge. The sun offset throws shadows toward xz `(0.82, 0.57)`; every
view is framed on a bearing looking toward `(0.78, 0.62)`. **4.5° apart** — so the
sun sat almost directly behind the camera and every shadow fell away from it,
hidden behind its own caster.

That's why the park shot measured a 1.3:1 lit-to-shadow ratio and looked unlit:
the numbers were reading bounce and baked AO, not the key light. Rotated 100° off
the view bearing at the same elevation. **Every ratio in the previous record was
measuring something other than what it claimed** — including the "downtown is
8.7:1" finding I flagged in this PR's first draft.

## 3. The sky was grey — and it's 100% of the ambient light

![sky and roof before/after](https://raw.githubusercontent.com/maattp/maattp.github.io/pr-354-shots/gfx/sky-compare.jpg)

Measured off the rendered frames, the sky arrived at **saturation 0.010–0.020**.
Achromatic, across a third to a half of most frames — and since it *is* the
image-based light, every shaded facade and the whole surface of Puget Sound were
being lit by grey.

The gradient stops were never the problem (`#88a8c2` is saturation 0.227). Two
things downstream bleached them:

- **228 cloud banks, each drawn twice**, inside a 2048×307 band — roughly **30×
  overdraw** at 0.12 alpha, about an 80% white wash over the entire sky. Now 41
  banks with real gaps and enough alpha each to be a cloud.
- **A 0.85-alpha grey wash across the horizon ±22°** — exactly where every
  street-level shot points. Now 0.35 over a third of the width, tinted to
  `scene.fog`'s own colour so the horizon and the fog agree instead of meeting at
  a seam.
- **Bank width clamped** to 11% of the equirect. At 630 px a bank spanned 110° of
  azimuth, and one sitting 59° up wraps the zenith and reads as a single grey
  smear — visible in five of seven shots. The comment always said to keep out of
  the zenith; nothing enforced it.

Stops keep their luminance and take their hue back. Deeper blues emit less as
IBL, so exposure pays it back (0.46 → 0.53): medians land within a few percent of
where they were, clipping stays 0.00%, and saturation rises where it matters —
**downtown 0.259 → 0.312, waterfront 0.440 → 0.478**. The water gets its blue
back for free, because it's deliberately a Fresnel mirror of the sky.

## 4. The roof you could see was the untextured one

`box` defaults to `top: true`, so the surface you actually looked at on any roof
was the **parapet's** lid — on `flat`, which has no map and no normal map. The
textured lid sat *underneath* it, contributing a 12 cm band nobody could see.
Roofs are ~40% of the pixels in the skyline shot and every one was a flat colour.

The parapet loses its top face; the lid caps it flush at 4 m a tile so the
corrugation reads as roof seams.

## Cost: nothing

| | before | after |
|---|---|---|
| draws, steady | 213 | 215 |
| draws, frame | 299 | 301 |
| triangles, steady | 409,954 | **409,026** |
| triangles, frame | 765,048 | **764,120** |

Draw counts move inside noise; triangles went **down**, because the shared
profile emits one fewer box on some buildings. `perfguard --check` reports no
regressions.

## Why this kept happening

This is the same class of bug as the greenhouse roof cap: two places computing
what should be one thing, drifting until the difference became visible. Deriving
it once is the only version that stays fixed — which is why this is a shared
generator rather than two sets of matching numbers.

## Checks

- `node tools/verify.mjs` → `OK: 0 exceptions`
- `node tools/vehicles.mjs` → `0 of 54 out of band`, class order holds
- `node tools/perfguard.mjs --check` → no regressions

## Noted, not done

Downtown still measures **8.7:1** lit-to-shadow against the 2.2–3.3 band this
codebase holds itself to. That's a real finding, only visible since the harness
was fixed, and it wants its own pass rather than being bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B
