### PR TITLE
Auto: trees out of the water, and you no longer sink into your own junctions

### DIFF
--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -241,6 +241,18 @@ centres sit inside the green mask. `inPark()` knows about grass, not about
 tarmac, so the scatter asks `city.onRoad(x, z, pad)` as well. Anything else
 scattered on the ground needs the same call.
 
+**And they plant themselves in the sea.** The green mask and the water mask are
+separate rasters whose shorelines do not agree to the metre, so `inPark()` says
+yes on cells that are under Puget Sound. **63 trunks** stood in the water. The
+scatter tests `G.isWater()` plus a 0.35 m floor for the shoreline band where the
+40 m DEM blends land into sea.
+
+**Do not reach for `waterLevelAt()` to do it.** It answers over a lake's
+axis-aligned BOUNDING BOX, so it reports Green Lake's 50.3 m for the whole park
+ringing it — testing terrain against that level deleted 105 of Green Lake's 717
+trees and 251 around Lake Union. The water mask is the authority on what is wet;
+a lake's level is a reference height, not a region test.
+
 **Ground tint: tarmac is built-up too, and `SUBURB` has to look different from
 `GRASS`.** Two separate bugs made the I-5 trench through Chinatown render as a
 lawn. `builtAt()` counted building footprints only, and a freeway corridor has no
@@ -393,6 +405,47 @@ ground on a Queen Anne cross-slope, against +/-7 cm before.
 taken at `halfWid` either side, which for a bike is the gutter and the crown of
 a road it is nowhere near, so averaging them sinks or floats it by half the
 camber. It also takes two `groundAt` calls a frame instead of four.
+
+**A junction square is a chord too, and it was the last big one.** `meshNode`
+drew the crossing as ONE quad up to ~9 m across, sampling terrain at its four
+corners; `groundAt` samples the heightfield at the exact point. Those are
+different surfaces the moment the ground is not planar, and at a residential
+crossing whose corners spread 2.4 m the drawn square stood **0.67 m** above the
+height you were standing at — you sank into your own junction. The corner
+samples were never wrong; the middle was. It subdivides into ~4 m cells now,
+exactly as `meshRoad` does. Measured on a 5x5 grid across that crossing:
+
+| gap between drawn surface and standing height | one quad | ~4 m cells |
+|---|---|---|
+| worst | 74.2 cm | **31.3 cm** |
+| mean | 31.1 cm | **9.8 cm** |
+| samples over 10 cm (of 25) | 22 | **7** |
+
+Going finer does not pay: at 2.5 m cells the mean improves to 5.6 cm but the
+worst does not move at all (31.3 cm), so the residual there is not the square —
+and the extra triangles regress `trisFrame` past the guard. **Don't screenshot
+this one.** The tarmac is continuous either way and before/after renders are
+indistinguishable; the defect is where you *stand* relative to what is drawn, so
+the raycast is the evidence and a picture is not.
+
+**Gate that subdivision on BOW, not on spread.** A junction on a uniform grade
+has a large corner spread and is still exactly representable by one quad,
+because a plane is a plane. What one quad cannot follow is curvature — the
+centre's deviation from the plane of the corners. Gating on spread subdivided
+nearly every junction downtown (Seattle is hilly) and saved almost nothing:
+432814 triangles against 432214. Gating on bow costs +2.7 % steady triangles and
+passes `tools/perfguard.mjs --check`.
+
+**The junction ring may not override the strip scan, however wrong the scan
+looks.** `roadLift` ramps a strip's lift to zero across the last `RAMP` metres,
+so a point under the ring can pick up a small tail — 0.06 m — and the ring's
+0.52 m used to be discarded, leaving you 0.46 m inside visible pavement. Taking
+the ring wherever it is higher is the obvious fix and it is **wrong**:
+`nodeSurface` reports the ring as a plain box, but `meshNode` cuts the ring up
+and drops the pieces covering each approach, so over an approach the ring is
+reported and not drawn. Measured, that override moved `sink` 11.8 % -> 12.44 %.
+Fixing it properly means teaching `nodeSurface` the approach-dropping that
+`meshNode` does.
 
 ## What the map looks like from above
 
@@ -591,6 +644,32 @@ Physically-shaded, image-based-lit, tone-mapped, with a hand-rolled post chain.
 Four separate visual bugs were each diagnosed two or three times as something
 else, because the thing doing the judging was wrong. The rule that came out of
 it: **measure the composited frame, and check the harness before the renderer.**
+
+**A check that re-derives its own answer measures the map, not the game.**
+`tools/jank.mjs` had two of these. `tree-in-water` re-implemented the scatter's
+filters and counted the points that passed — which is a property of the rasters
+and never changes, so it reported an unchanged 16 before and after the scatter
+was fixed and could not have detected its own fix in either direction. Against
+the trees that actually get planted the real figure was **63**. `roof` had the
+same shape. Both now read the built result: `city.obstacles` is the record
+`buildChunk` writes as it plants each trunk, and `World.gables()` is the one
+decision the mesher and the check both ask. **If a check and the code under test
+each hold their own copy of a threshold, the check is decorative.**
+
+**Settle the streamer before raycasting anything.** Chunk geometry is
+time-sliced, so one `world.update` builds a few milliseconds of it and returns.
+Querying straight after measures a half-built city: every worst-point diagnosis
+came back `drawn: null` because the road mesh did not exist yet. Note
+`world.update`'s `budget` argument is **not** a millisecond budget — it is read
+only as a `< 2` flag and the function then picks its own 2/4/9 ms slice — so
+settling means calling until nothing is pending (~243 calls cold, ~126 for a
+neighbouring site). Settling is far too expensive to do per sample: work
+site-by-site, settle once, then take every sample inside the built area.
+
+**`city.obstacles` is a flat stride-3 array** (`x, z, r, x, z, r, …`), one per
+chunk — not a list of objects. Iterating it as objects matched nothing and
+reported a clean `0 of 0`, which is the most dangerous possible result: a green
+number that means "measured nothing at all". Always check the denominator.
 
 `tools/beauty.mjs` captures a fixed set of framed views; `tools/values.py`
 reports the linear value structure of the resulting PNGs -- percentiles, the
@@ -842,7 +921,27 @@ The heightfield is now **imported** rather than baked from polygon distance
 tests, but the law is unchanged and is still the one that bites:
 
 > After boot, every consumer -- terrain mesh, road quads, buildings, cars,
-> pedestrians -- reads the same bilinear `terrainHeight()`.
+> pedestrians -- reads the same `terrainHeight()`.
+
+**It is not bilinear any more, and the importer never got the message.**
+`terrainHeight()` interpolates the way the terrain MESH is triangulated, because
+a bilinear query over a triangulated mesh disagrees by `(a + d - b - c) / 4` and
+that is what grass growing through the road was. `tools/build_roads.py` still
+bakes node heights with a bilinear sample, and its `terrain_at()` docstring
+still claims *"Bilinear, matching geo.terrainHeight() exactly."* — which is now
+false. Measured: **55,282 of 64,170 nodes (86 %) carried a wrong height, worst
+by 6.63 m.**
+
+Ground nodes therefore re-read their height from `terrainHeight()` at load, in
+`cityGenerator`. Elevated nodes keep their baked value — that is a deck, not the
+ground under it. Done at load rather than in the importer for the same reason
+`roadFit()` is: the correction travels with the geometry and cannot go stale
+against a re-import. `cityStats.nodesReheighted` / `worstReheight` report it.
+
+Note this did **not** move `sink` (11.8 % -> 11.82 %): `meshRoad` draws strips
+from `terrainHeight` directly and only uses node `y` for its bow/grade
+subdivision heuristics. It is a correctness fix for the invariant above, not a
+fix for anything visible, and shipping it as the latter would have been a lie.
 
 `height.png` is 401x401 at 40 m. **That spacing is not free to change**: it is
 also the terrain mesh's vertex spacing, and the two have to agree. A finer query

--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -651,10 +651,24 @@ filters and counted the points that passed — which is a property of the raster
 and never changes, so it reported an unchanged 16 before and after the scatter
 was fixed and could not have detected its own fix in either direction. Against
 the trees that actually get planted the real figure was **63**. `roof` had the
-same shape. Both now read the built result: `city.obstacles` is the record
-`buildChunk` writes as it plants each trunk, and `World.gables()` is the one
-decision the mesher and the check both ask. **If a check and the code under test
-each hold their own copy of a threshold, the check is decorative.**
+same shape, and a first attempt at fixing it made things worse rather than
+better: the check was changed to ask the mesher's own `World.gables()` guard,
+which made the condition `aspect > 4.5 && aspect < 4.5` — a tautology that
+reports 0 however the mesher behaves. **If a check and the code under test each
+hold their own copy of a threshold, the check is decorative; if the check asks
+the code under test whether the code under test did its job, it is worse than
+decorative.** `tree-in-water` now reads `city.obstacles`, the record
+`buildChunk` writes as it plants each trunk.
+
+**The `roof` check was deleted, because its defect did not exist.** It counted
+footprints more elongated than 4.5:1 — a threshold invented in the check and
+never checked against `meshGable`, which sizes eaves from the actual `w` and `d`
+(a fixed 0.45 m overhang) and runs the ridge along the longer side. Measured on
+the three footprints it named, contiguous roof past the narrow wall was 0.4 /
+6.0 / 5.8 m with the gable built and 0 / 6.0 / 5.8 m with it **suppressed** —
+the metres are neighbouring terrace roofs, which touch and cannot be separated
+by contiguity. A guard was briefly added to skip gables on elongated houses;
+that was a regression on three correct terraces, and is reverted.
 
 **Settle the streamer before raycasting anything.** Chunk geometry is
 time-sliced, so one `world.update` builds a few milliseconds of it and returns.

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -414,7 +414,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v46</div>
+    <div id="build">v47</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -515,6 +515,7 @@ export function* cityGenerator(md) {
       // sink 11.8% -> 12.44%. Fixing this properly means teaching nodeSurface
       // the approach-dropping that meshNode does; until then the empty-scan test
       // is the conservative approximation.
+      if (ns && lift <= 0) return ns.lift;
       return lift;
     },
 

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -65,7 +65,10 @@ function styleFor(cls, h, w, d) {
 
 // Counters the verify harness asserts on, so a regression in the clearing
 // passes shows up as a number rather than as a screenshot nobody looks at.
-export const cityStats = { buildingsShrunk: 0, buildingsDropped: 0, treesSkipped: 0, landmarkCleared: 0, propsSkipped: 0 };
+export const cityStats = {
+  buildingsShrunk: 0, buildingsDropped: 0, treesSkipped: 0, landmarkCleared: 0,
+  propsSkipped: 0, nodesReheighted: 0, worstReheight: 0,
+};
 
 const skey = (cx, cz) => cx * 100003 + cz;
 

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -75,9 +75,34 @@ export function* cityGenerator(md) {
   // --- 1. Road graph ------------------------------------------------------
   const R = md.roads;
   const nodes = new Array(R.nodeCount);
+  let reheighted = 0, worstReheight = 0;
   for (let i = 0; i < R.nodeCount; i++) {
-    nodes[i] = { x: R.nx[i], z: R.nz[i], y: R.ny[i], elev: R.nElev[i] !== 0, e: [] };
+    const elev = R.nElev[i] !== 0;
+    let y = R.ny[i];
+    // Re-read a ground node's height from the ONE height surface.
+    //
+    // build_roads.py bakes node heights with a bilinear sample, and its comment
+    // still claims that matches geo.terrainHeight() -- which it did until
+    // terrainHeight was changed to interpolate the way the terrain MESH is
+    // triangulated, to stop grass showing through the road. The two differ by
+    // (a + d - b - c) / 4 on a 40 m cell, which on Seattle's grades reaches
+    // 1.18 m: junction squares are drawn at n.y while groundAt stands you at
+    // terrainHeight, so you sank into your own crossroads by over a metre.
+    //
+    // Done here rather than in the importer for the same reason roadFit() is:
+    // the correction travels with the geometry and cannot go stale against a
+    // re-import. Elevated nodes keep their baked height -- that is a deck, not
+    // the ground under it.
+    if (!elev) {
+      const t = G.terrainHeight(R.nx[i], R.nz[i]);
+      const d = Math.abs(t - y);
+      if (d > 0.01) { reheighted++; if (d > worstReheight) worstReheight = d; }
+      y = t;
+    }
+    nodes[i] = { x: R.nx[i], z: R.nz[i], y, elev, e: [] };
   }
+  cityStats.nodesReheighted = reheighted;
+  cityStats.worstReheight = +worstReheight.toFixed(2);
   const edges = new Array(R.edgeCount);
   for (let i = 0; i < R.edgeCount; i++) {
     const a = R.ea[i], b = R.eb[i];
@@ -481,7 +506,15 @@ export function* cityGenerator(md) {
       }
       // The pavement ring around a junction reaches past the end of every strip
       // -- its diagonal corners especially, which no radiating edge comes near.
-      if (ns && lift <= 0) return ns.lift;
+      //
+      // Only where the scan found NOTHING. Taking the ring wherever it is
+      // higher was tried and is wrong: nodeSurface reports the ring as a plain
+      // box, but meshNode cuts the ring into pieces and DROPS the ones covering
+      // each approach road, so over an approach the ring is reported and not
+      // drawn -- the override floated you above the carriageway there and moved
+      // sink 11.8% -> 12.44%. Fixing this properly means teaching nodeSurface
+      // the approach-dropping that meshNode does; until then the empty-scan test
+      // is the conservative approximation.
       return lift;
     },
 

--- a/apps/auto/src/main.js
+++ b/apps/auto/src/main.js
@@ -5,7 +5,7 @@ import * as G from './geo.js';
 import { cityGenerator, cityStats } from './citygen.js';
 import { loadMapData } from './mapdata.js';
 import { buildTextures } from './textures.js';
-import { World } from './world.js';
+import { World, WET_FLOOR } from './world.js';
 import { buildLandmarks } from './landmarks.js';
 import { TrafficSystem, collideWithBuildings } from './traffic.js';
 import { TYPES as VEHICLE_TYPES } from './vehicles.js';
@@ -464,7 +464,7 @@ function installHeightFog() {
   }
 
   await step(1, 'Welcome to Seattle');
-  window.__dbg = { game, city, player, world, traffic, peds, scene, camera, renderer, G, fx, hud, controls, audio, pickups, THREE, postfx, applyQuality, sun, sceneStats, cityStats, animateWalk, collideWithBuildings, TYPES: VEHICLE_TYPES };
+  window.__dbg = { game, city, player, world, traffic, peds, scene, camera, renderer, G, fx, hud, controls, audio, pickups, THREE, postfx, applyQuality, sun, sceneStats, cityStats, WET_FLOOR, animateWalk, collideWithBuildings, TYPES: VEHICLE_TYPES };
   wireUi();
   game.newTarget();
   // Start on `high` everywhere.

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -1138,22 +1138,6 @@ export class World {
    * side, which is what a house does -- run it the short way and a long terrace
    * ends up with an absurdly tall roof and gable ends the width of the street.
    */
-  /**
-   * Does this footprint get a pitched roof?
-   *
-   * A gable needs a ridge to run along, and it is sized off the longer side, so
-   * on a very elongated box it hangs metres past the walls on the narrow axis.
-   * The worst in the map is 24:1 -- a min-area rectangle fitted to a terrace.
-   * Those take the flat cap the roof lid already gives them.
-   *
-   * This is a static method so tools/jank.mjs can ask the same question the
-   * mesher asks. A check carrying its OWN copy of the threshold measures the
-   * data, not the geometry, and cannot notice this guard being deleted.
-   */
-  static gables(bd) {
-    return Math.max(bd.w, bd.d) / Math.min(bd.w, bd.d) < 4.5;
-  }
-
   meshGable(flat, bd, y0, col, seed) {
     const cs = Math.cos(bd.rot), sn = Math.sin(bd.rot);
     const OVER = 0.45;                       // eaves overhang, all four sides
@@ -1452,7 +1436,7 @@ export class World {
       // -- a pitched roof sized off the longer side hangs metres past the walls
       // on the narrow axis. Three of these exist; they take the flat cap the
       // lid already gives them.
-      if (World.gables(bd)) this.meshGable(flat, bd, base + wallH + 2.26, rc, seed);
+      this.meshGable(flat, bd, base + wallH + 2.26, rc, seed);
       const [sx, sz] = off(0, bd.d / 2 + 0.5);
       flat.box(sx, base + 1.6, sz, 2.0, 0.22, 1.2, bd.rot, [0.62, 0.6, 0.57]);
       return;

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -212,6 +212,13 @@ const AWNING = [
 
 // ---------------------------------------------------------------------------
 
+// Ground at or below this reads as wet even where the water mask says dry:
+// the 40 m DEM blends land into sea at the shoreline, so the two rasters
+// disagree by about a metre there. Exported so tools/jank.mjs can select the
+// same candidate set -- the constant is shared, the VERDICT is not, which is
+// what keeps the check from being a tautology.
+export const WET_FLOOR = 0.35;
+
 export class World {
   constructor(scene, city, tx, opts = {}) {
     this.scene = scene;
@@ -1431,11 +1438,14 @@ export class World {
       // Gable stays on `flat`: Builder.tri takes no UVs, so a textured builder
       // would sample one texel across the whole slope. Its believability comes
       // from the two slopes shading differently against the key light instead.
-      // A gable needs a ridge to run along. On a footprint this elongated -- the
-      // worst in the map is 24:1, from a min-area rectangle fitted to a terrace
-      // -- a pitched roof sized off the longer side hangs metres past the walls
-      // on the narrow axis. Three of these exist; they take the flat cap the
-      // lid already gives them.
+      // Every house, however elongated. A guard was once added here to skip the
+      // gable above 4.5:1, on the theory that a roof sized off the longer side
+      // hangs past the walls on the narrow axis. It does not: meshGable sizes
+      // its eaves from the actual w and d with a fixed 0.45 m overhang, so a
+      // terrace gets a long ridge and a low pitch, which is what a terrace has.
+      // Measured, the drawn roof reached 0.4 m past the narrow wall; the metres
+      // that looked like overhang were the NEIGHBOURING terrace's roof, which
+      // touches this one. The guard was suppressing three correct roofs.
       this.meshGable(flat, bd, base + wallH + 2.26, rc, seed);
       const [sx, sz] = off(0, bd.d / 2 + 0.5);
       flat.box(sx, base + 1.6, sz, 2.0, 0.22, 1.2, bd.rot, [0.62, 0.6, 0.57]);
@@ -1966,16 +1976,15 @@ export class World {
       // that actually get planted, not off the raster candidates, which is a
       // number that cannot move and reported 16 either way.
       //
-      // The water mask is the authority on what is wet; the 0.35 m floor only
-      // catches the shoreline band where the 40 m DEM blends land into sea and
-      // the two rasters disagree by a metre or so.
+      // The water mask is the authority on what is wet; WET_FLOOR only catches
+      // the shoreline band where the two rasters disagree.
       //
       // Do NOT reach for waterLevelAt here. It answers over a lake's
       // axis-aligned BOUNDING BOX, so it reports "Green Lake, 50.3 m" for the
       // whole park ringing it -- and testing terrain against that level deleted
       // 105 of Green Lake's 717 trees and 251 around Lake Union. Measured, both
       // times, which is the only reason it did not ship.
-      if (G.isWater(x, z) || G.terrainHeight(x, z) < 0.35) { treeSkip++; continue; }
+      if (G.isWater(x, z) || G.terrainHeight(x, z) < WET_FLOOR) { treeSkip++; continue; }
       const h = hash2(Math.round(x), Math.round(z));
       const gy = G.terrainHeight(x, z);
       // Foliage that isn't one emerald cone.

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -1138,6 +1138,22 @@ export class World {
    * side, which is what a house does -- run it the short way and a long terrace
    * ends up with an absurdly tall roof and gable ends the width of the street.
    */
+  /**
+   * Does this footprint get a pitched roof?
+   *
+   * A gable needs a ridge to run along, and it is sized off the longer side, so
+   * on a very elongated box it hangs metres past the walls on the narrow axis.
+   * The worst in the map is 24:1 -- a min-area rectangle fitted to a terrace.
+   * Those take the flat cap the roof lid already gives them.
+   *
+   * This is a static method so tools/jank.mjs can ask the same question the
+   * mesher asks. A check carrying its OWN copy of the threshold measures the
+   * data, not the geometry, and cannot notice this guard being deleted.
+   */
+  static gables(bd) {
+    return Math.max(bd.w, bd.d) / Math.min(bd.w, bd.d) < 4.5;
+  }
+
   meshGable(flat, bd, y0, col, seed) {
     const cs = Math.cos(bd.rot), sn = Math.sin(bd.rot);
     const OVER = 0.45;                       // eaves overhang, all four sides
@@ -1403,7 +1419,12 @@ export class World {
       // Gable stays on `flat`: Builder.tri takes no UVs, so a textured builder
       // would sample one texel across the whole slope. Its believability comes
       // from the two slopes shading differently against the key light instead.
-      this.meshGable(flat, bd, base + wallH + 2.26, rc, seed);
+      // A gable needs a ridge to run along. On a footprint this elongated -- the
+      // worst in the map is 24:1, from a min-area rectangle fitted to a terrace
+      // -- a pitched roof sized off the longer side hangs metres past the walls
+      // on the narrow axis. Three of these exist; they take the flat cap the
+      // lid already gives them.
+      if (World.gables(bd)) this.meshGable(flat, bd, base + wallH + 2.26, rc, seed);
       const [sx, sz] = off(0, bd.d / 2 + 0.5);
       flat.box(sx, base + 1.6, sz, 2.0, 0.22, 1.2, bd.rot, [0.62, 0.6, 0.57]);
       return;
@@ -1926,6 +1947,21 @@ export class World {
       // yes in the middle of a building. Measured, 9.3 % of surviving park
       // candidates stood inside a footprint -- trees growing through roofs.
       if (this.inBuilding(x, z, 0.8)) { treeSkip++; continue; }
+      // ...nor in the water. The green mask and the water mask are separate
+      // rasters and their shorelines do not agree to the metre, so `inPark` says
+      // yes on cells that are under Puget Sound or below the tide line. Sixteen
+      // trees across the map were standing in the sea. `waterLevelAt` is the
+      // local surface, because the lakes are not at sea level.
+      // The water mask is the authority on what is wet; the 0.35 m floor only
+      // catches the shoreline band where the 40 m DEM blends land into sea and
+      // the two rasters disagree by a metre or so.
+      //
+      // Do NOT reach for waterLevelAt here. It answers over a lake's
+      // axis-aligned BOUNDING BOX, so it reports "Green Lake, 50.3 m" for the
+      // whole park ringing it -- and testing terrain against that level deleted
+      // 105 of Green Lake's 717 trees and 251 around Lake Union. Measured, both
+      // times, which is the only reason it did not ship.
+      if (G.isWater(x, z) || G.terrainHeight(x, z) < 0.35) { treeSkip++; continue; }
       const h = hash2(Math.round(x), Math.round(z));
       const gy = G.terrainHeight(x, z);
       // Foliage that isn't one emerald cone.

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -1234,15 +1234,6 @@ export class World {
     }
     if (hw <= 0) return;
     const c = Math.cos(rot), s = Math.sin(rot);
-    const pts = [];
-    const ys = [];
-    const corners = [[-hw, -hw], [hw, -hw], [hw, hw], [-hw, hw]];
-    for (const [lx, lz] of corners) {
-      const x = n.x + lx * c - lz * s;
-      const z = n.z + lx * s + lz * c;
-      pts.push(x, z);
-      ys.push(n.elev ? n.y + 0.07 : G.terrainHeight(x, z) + NODE_Y);
-    }
     // UVs in METRES, at the same ROAD_TILE the strips use.
     //
     // This was a hardcoded 0.16 x 0.14 slice of the asphalt texture stretched
@@ -1255,9 +1246,46 @@ export class World {
     //
     // Aligned to world axes rather than to the junction's rotation, so the two
     // triangles of a crossing cannot disagree about which way the grain runs.
-    const uq = [];
-    for (let i = 0; i < 4; i++) uq.push(pts[i * 2] / ROAD_TILE, pts[i * 2 + 1] / ROAD_TILE);
-    road.flat(pts, ys, [1, 1, 1], uq);
+    // Subdivide the square, for the same reason meshRoad subdivides a strip.
+    //
+    // Drawn as ONE quad it interpolates linearly between its four corners,
+    // while groundAt samples the heightfield at the exact point -- and those
+    // are different surfaces as soon as the ground is not planar. Measured at a
+    // 9.2 m residential crossing whose corners spread 2.4 m, the drawn square
+    // stood 0.67 m above the height you were standing at: you sank into your
+    // own junction. The corner samples were never the problem; the middle was.
+    //
+    // ~4 m cells, and only where the ground actually moves. The heightfield is
+    // 40 m, so finer buys nothing, and subdividing every junction cost 5.6 % of
+    // the scene's triangles to fix a defect most of them do not have.
+    //
+    // Gate on BOW, not on spread. A junction on a uniform grade has a large
+    // corner spread and is still exactly representable by one quad -- a plane
+    // is a plane. What one quad cannot follow is curvature, which is the
+    // centre's deviation from the plane of the corners. Gating on spread
+    // subdivided nearly every junction downtown, Seattle being hilly, and saved
+    // almost nothing: 432814 triangles against 432214. Bow costs +2.7 % and
+    // passes tools/perfguard.mjs --check.
+    const cy = (x, z) => (n.elev ? n.y + 0.07 : G.terrainHeight(x, z) + NODE_Y);
+    const at = (lx, lz) => cy(n.x + lx * c - lz * s, n.z + lx * s + lz * c);
+    const bow = Math.abs(
+      at(0, 0) - (at(-hw, -hw) + at(hw, -hw) + at(hw, hw) + at(-hw, hw)) / 4
+    );
+    const sub = bow < 0.08 ? 1 : Math.max(2, Math.min(6, Math.round((hw * 2) / 4)));
+    for (let iz = 0; iz < sub; iz++) {
+      for (let ix = 0; ix < sub; ix++) {
+        const qp = [], qy = [], qu = [];
+        for (const [fx, fz] of [[ix, iz], [ix + 1, iz], [ix + 1, iz + 1], [ix, iz + 1]]) {
+          const lx = -hw + (fx / sub) * hw * 2, lz = -hw + (fz / sub) * hw * 2;
+          const x = n.x + lx * c - lz * s;
+          const z = n.z + lx * s + lz * c;
+          qp.push(x, z);
+          qy.push(cy(x, z));
+          qu.push(x / ROAD_TILE, z / ROAD_TILE);
+        }
+        road.flat(qp, qy, [1, 1, 1], qu);
+      }
+    }
 
     if (lod !== 1 || sw <= 0 || n.elev || !walk) return;
     // Square ring of pavement around the junction; its inner edge lines up with

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -1960,10 +1960,12 @@ export class World {
       // candidates stood inside a footprint -- trees growing through roofs.
       if (this.inBuilding(x, z, 0.8)) { treeSkip++; continue; }
       // ...nor in the water. The green mask and the water mask are separate
-      // rasters and their shorelines do not agree to the metre, so `inPark` says
-      // yes on cells that are under Puget Sound or below the tide line. Sixteen
-      // trees across the map were standing in the sea. `waterLevelAt` is the
-      // local surface, because the lakes are not at sea level.
+      // rasters and their shorelines do not agree to the metre, so inPark says
+      // yes on cells that are under Puget Sound or below the tide line. 63
+      // trunks across the map were standing in the sea -- counted off the trees
+      // that actually get planted, not off the raster candidates, which is a
+      // number that cannot move and reported 16 either way.
+      //
       // The water mask is the authority on what is wet; the 0.35 m floor only
       // catches the shoreline band where the 40 m DEM blends land into sea and
       // the two rasters disagree by a metre or so.

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v46';
+const CACHE = 'auto-v47';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',

--- a/tools/build_roads.py
+++ b/tools/build_roads.py
@@ -66,7 +66,18 @@ def load_rasters():
 
 
 def terrain_at(height, x, z):
-    """Bilinear, matching geo.terrainHeight() exactly."""
+    """Bilinear. This NO LONGER matches geo.terrainHeight().
+
+    terrainHeight() now interpolates the way the terrain mesh is triangulated,
+    which was the fix for grass showing through the road; bilinear differs from
+    it by (a + d - b - c) / 4, up to 6.63 m on Seattle's grades. Node heights
+    baked here are therefore corrected at load time in cityGenerator, which is
+    where the runtime and the drawn geometry can be guaranteed to agree.
+
+    Only the node heights are affected -- anything using this for a coarse
+    land/water or grade decision is fine. If you make this triangulated to match,
+    the load-time correction becomes a no-op rather than a conflict.
+    """
     fx = min(max((x + MAP_HALF) / HF_STEP, 0), HF_N - 1.001)
     fz = min(max((z + MAP_HALF) / HF_STEP, 0), HF_N - 1.001)
     i, j = int(fx), int(fz)

--- a/tools/jank.mjs
+++ b/tools/jank.mjs
@@ -65,6 +65,49 @@ const CHECKS = `(() => {
     return pts;
   };
 
+  // Chunk geometry is time-sliced across frames, so ONE world.update builds a
+  // few milliseconds of it and returns. Raycasting straight after leaves you
+  // measuring a half-built chunk -- which is how the beauty harness spent
+  // several passes photographing bare terrain, and it is why sink read 11.7 %:
+  // most of those samples found no road mesh at all because it had not been
+  // generated yet.
+  // A settle rebuilds up to a 9x9 grid of chunks, so it is far too expensive to
+  // do per sample. The raycast checks therefore work SITE BY SITE: settle once,
+  // then take every sample that falls inside the built area before moving on.
+  // Sampling in node-index order instead walks the whole 16 km map at random
+  // and settles thousands of times, which does not finish.
+  //
+  // The budget is a per-call millisecond slice; a large one builds a whole
+  // chunk per call, so a site settles in a handful of calls rather than
+  // hundreds.
+  const settle = (x, z) => {
+    const pending = () => [...world.chunks.values()].filter((c) => c.lod !== c.wantLod).length;
+    // Measured: a cold site converges in ~243 calls, a neighbouring one in
+    // ~126. The budget arg is NOT milliseconds -- world.update only reads it
+    // as a less-than-2 flag and then picks its own 2/4/9 ms slice, so the
+    // only way to finish is to keep calling until nothing is pending.
+    for (let i = 0; i < 20000 && (i === 0 || pending() > 0); i++) world.update(x, z, 9);
+    d.scene.updateMatrixWorld(true);
+  };
+
+  // NEAR_R = 2 at CHUNK = 400, so full-detail geometry exists within 800 m of
+  // the site centre. Stay well inside that.
+  const SITE_R = 600;
+  const nearSite = (x, z, sx, sz) => Math.abs(x - sx) < SITE_R && Math.abs(z - sz) < SITE_R;
+
+  // Deterministic spread of road-bearing sites across the map.
+  const roadSites = (n, seed) => {
+    const r = R(seed), out = [];
+    const nodes = city.nodes;
+    for (let i = 0; i < n * 40 && out.length < n; i++) {
+      const nd = nodes[Math.floor(r() * nodes.length)];
+      if (!nd || nd.elev) continue;
+      if (out.some(([x, z]) => Math.abs(x - nd.x) < SITE_R && Math.abs(z - nd.z) < SITE_R)) continue;
+      out.push([nd.x, nd.z]);
+    }
+    return out;
+  };
+
   const add = (name, n, of, worst, note) =>
     out.push({ name, n, of, rate: of ? +(100 * n / of).toFixed(2) : 0, worst: worst.slice(0, 6), note });
 
@@ -75,7 +118,8 @@ const CHECKS = `(() => {
   // between them to the metre, so a tree can be planted in Puget Sound.
   if (want('tree-in-water')) {
     const CHUNK = 400;
-    let cand = 0, wet = 0;
+    let cand = 0, wet = 0, planted = 0;
+    const wetCand = [], sites = [], seen = new Set();
     const worst = [];
     const h2 = (a, b) => { const t = Math.sin(a * 127.1 + b * 311.7) * 43758.5453; return t - Math.floor(t); };
     for (let cx = -18; cx <= 18; cx++) {
@@ -88,14 +132,49 @@ const CHECKS = `(() => {
           if (city.onRoad(x, z, 2.5)) continue;
           if (world.inBuilding && world.inBuilding(x, z, 0.8)) continue;
           cand++;
-          if (G.isWater(x, z) || G.terrainHeight(x, z) < 0.35) {
+          if (G.isWater(x, z) || G.terrainHeight(x, z) < 0.35) wetCand.push([x, z]);
+        }
+      }
+    }
+    // Those are CANDIDATES -- points the scatter considers. Counting them
+    // measures the raster disagreement, which is a fixed property of the map:
+    // this check reported an unchanged 16 before and after the scatter learned
+    // to reject them, because it never looked at a tree that got built.
+    //
+    // world.buildChunk registers each trunk into city.obstacles, so the
+    // obstacle list IS the drawn record. Settle over each wet candidate and
+    // count the trunks that actually stand in water.
+    for (const [wx, wz] of wetCand) {
+      if (sites.some(([x, z]) => Math.abs(x - wx) < SITE_R && Math.abs(z - wz) < SITE_R)) continue;
+      sites.push([wx, wz]);
+    }
+    for (const [sx, sz] of sites) {
+      settle(sx, sz);
+      // addObstacle pushes x, z, r onto ONE flat array per chunk -- these are
+      // not objects, and iterating them as if they were silently matched
+      // nothing and reported a clean 0 of 0.
+      for (const list of city.obstacles.values()) {
+        for (let i = 0; i < list.length; i += 3) {
+          const ox = list[i], oz = list[i + 1];
+          if (!nearSite(ox, oz, sx, sz)) continue;
+          // Trunks and lamp posts share this list. Street furniture offsets
+          // from its own road, and a road over water here is a PIER -- Alaskan
+          // Way and Colman Dock are supposed to be out there -- so a pole above
+          // the tide line is correct and only a tree is a bug.
+          if (city.onRoad(ox, oz, 4.0)) continue;
+          const key = Math.round(ox) + ',' + Math.round(oz);
+          if (seen.has(key)) continue;
+          seen.add(key);
+          planted++;
+          if (G.isWater(ox, oz) || G.terrainHeight(ox, oz) < 0.35) {
             wet++;
-            if (worst.length < 6) worst.push({ x: Math.round(x), z: Math.round(z), y: +G.terrainHeight(x, z).toFixed(2) });
+            if (worst.length < 6) worst.push({ x: Math.round(ox), z: Math.round(oz), y: +G.terrainHeight(ox, oz).toFixed(2) });
           }
         }
       }
     }
-    add('tree-in-water', wet, cand, worst, 'park trees standing in water or below the tide line');
+    add('tree-in-water', wet, planted, worst,
+      'trunks actually standing in water (from ' + cand + ' candidates, ' + wetCand.length + ' of them wet)');
   }
 
   // --- ground that stands above the water covering it --------------------
@@ -165,15 +244,18 @@ const CHECKS = `(() => {
     const down = new THREE.Vector3(0, -1, 0);
     const worst = [];
     let n = 0, of = 0;
-    const step = Math.max(1, Math.floor(city.edges.length / 700));
-    for (let ei = 0; ei < city.edges.length; ei += step) {
-      const e = city.edges[ei];
+    for (const [sx, sz] of roadSites(20, 31)) {
+      settle(sx, sz);
+      let took = 0;
+      for (const e of city.edges) {
+      if (took >= 140) break;
       if (e.elev || e.len < 12) continue;
       const a = city.nodes[e.a], b = city.nodes[e.b];
+      if (!nearSite(a.x, a.z, sx, sz) || !nearSite(b.x, b.z, sx, sz)) continue;
+      took++;
       for (let sI = 1; sI < 4; sI++) {
         const t = sI / 4;
         const x = a.x + (b.x - a.x) * t, z = a.z + (b.z - a.z) * t;
-        world.update(x, z, 60);
         const top = G.terrainHeight(x, z) + 8;
         rc.set(new THREE.Vector3(x, top, z), down);
         rc.far = 20;
@@ -187,6 +269,7 @@ const CHECKS = `(() => {
           n++;
           if (worst.length < 40) worst.push({ x: Math.round(x), z: Math.round(z), over: +over.toFixed(2), cls: e.cls });
         }
+      }
       }
     }
     worst.sort((p, q) => q.over - p.over);
@@ -207,14 +290,16 @@ const CHECKS = `(() => {
     // Sample on the paved surface specifically -- that is where the two
     // sources of truth exist and can disagree.
     const nodes = city.nodes;
-    const stepN = Math.max(1, Math.floor(nodes.length / 900));
-    for (let ni = 0; ni < nodes.length; ni += stepN) {
-      const nd = nodes[ni];
-      if (nd.elev) continue;
+    for (const [sx, sz] of roadSites(20, 53)) {
+      settle(sx, sz);
+      let took = 0;
+      for (const nd of nodes) {
+      if (took >= 60) break;
+      if (nd.elev || !nearSite(nd.x, nd.z, sx, sz)) continue;
+      took++;
       for (const [ox, oz] of [[0, 0], [4, 0], [0, 4], [-4, 0], [0, -4], [5, 5]]) {
         const x = nd.x + ox, z = nd.z + oz;
         if (!city.onRoad(x, z, 1.5, false) && city.roadLift(x, z) <= 0) continue;
-        world.update(x, z, 60);
         const lift = city.roadLift(x, z);
         const stand = city.groundAt(x, z, null, lift);
         rc.set(new THREE.Vector3(x, stand + 12, z), down);
@@ -233,6 +318,7 @@ const CHECKS = `(() => {
           if (worst.length < 40) worst.push({ x: Math.round(x), z: Math.round(z), gap: +gap.toFixed(2) });
         }
       }
+      }
     }
     worst.sort((a, b) => Math.abs(b.gap) - Math.abs(a.gap));
     add('sink', n, of, worst, 'drawn pavement disagreeing with the height you stand at');
@@ -247,16 +333,17 @@ const CHECKS = `(() => {
       const bd = city.buildings[bi];
       if (bd.style !== 'house') continue;
       of++;
-      // meshGable builds in the building's own frame; the failure mode this
-      // catches is a roof sized off the wrong axis, which leaves the gable
-      // hanging past the wall on the narrow side.
+      // Ask world.js's OWN decision. Re-deriving the threshold here measured
+      // the DATA -- how many elongated houses exist, which is a fixed property
+      // of the map and never changes -- so the check reported the same 3 before
+      // and after the guard that fixed it, and could not have noticed either.
       const over = Math.max(bd.w, bd.d) / Math.min(bd.w, bd.d);
-      if (over > 4.5) {
+      if (over > 4.5 && world.constructor.gables(bd)) {
         n++;
         if (worst.length < 6) worst.push({ x: Math.round(bd.x), z: Math.round(bd.z), w: +bd.w.toFixed(1), d: +bd.d.toFixed(1) });
       }
     }
-    add('roof', n, of, worst, 'houses so elongated a gable cannot sit on them');
+    add('roof', n, of, worst, 'houses given a gable that cannot sit on them');
   }
 
   // --- buildings standing in water ---------------------------------------
@@ -334,7 +421,7 @@ const CHECKS = `(() => {
         // road, whichever strip put it there.
         const x = a.x + (b.x - a.x) * t, z = a.z + (b.z - a.z) * t;
         if (!city.onRoad(x, z, 0, false)) continue;
-        world.update(x, z, 60);
+        settle(x, z);
         rc.set(new THREE.Vector3(x, G.terrainHeight(x, z) + 8, z), down);
         rc.far = 20;
         const hits = rc.intersectObject(world.group, true).filter((h) => h.object.isMesh

--- a/tools/jank.mjs
+++ b/tools/jank.mjs
@@ -302,9 +302,9 @@ const CHECKS = `(() => {
       settle(sx, sz);
       let took = 0;
       for (const nd of nodes) {
-      if (took >= 60) break;
-      if (nd.elev || !nearSite(nd.x, nd.z, sx, sz)) continue;
-      took++;
+        if (took >= 60) break;
+        if (nd.elev || !nearSite(nd.x, nd.z, sx, sz)) continue;
+        took++;
       for (const [ox, oz] of [[0, 0], [4, 0], [0, 4], [-4, 0], [0, -4], [5, 5]]) {
         const x = nd.x + ox, z = nd.z + oz;
         if (!city.onRoad(x, z, 1.5, false) && city.roadLift(x, z) <= 0) continue;
@@ -393,9 +393,12 @@ const CHECKS = `(() => {
     const sites = [];
     for (const e of city.edges) {
       if (!e.elev) continue;
-      const a = city.nodes[e.a];
-      if (sites.some(([x, z]) => Math.abs(x - a.x) < SITE_R && Math.abs(z - a.z) < SITE_R)) continue;
-      sites.push([a.x, a.z]);
+      // Cluster on the span's MIDPOINT. Keying on endpoint a alone can seat a
+      // site off the end of a long span.
+      const a = city.nodes[e.a], bN = city.nodes[e.b];
+      const mx = (a.x + bN.x) / 2, mz = (a.z + bN.z) / 2;
+      if (sites.some(([x, z]) => Math.abs(x - mx) < SITE_R && Math.abs(z - mz) < SITE_R)) continue;
+      sites.push([mx, mz]);
       if (sites.length >= 22) break;
     }
     for (const [sx, sz] of sites) {
@@ -447,27 +450,34 @@ const CHECKS = `(() => {
     const down = new THREE.Vector3(0, -1, 0);
     const worst = [];
     let n = 0, of = 0;
-    const step = Math.max(1, Math.floor(city.edges.length / 500));
-    for (let ei = 0; ei < city.edges.length; ei += step) {
-      const e = city.edges[ei];
-      if (e.elev || e.len < 20) continue;
-      const a = city.nodes[e.a], b = city.nodes[e.b];
-      for (let sI = 1; sI < 4; sI++) {
-        const t = sI / 4;
-        // Sample the carriageway itself: pavement drawn here is pavement in the
-        // road, whichever strip put it there.
-        const x = a.x + (b.x - a.x) * t, z = a.z + (b.z - a.z) * t;
-        if (!city.onRoad(x, z, 0, false)) continue;
-        settle(x, z);
-        rc.set(new THREE.Vector3(x, G.terrainHeight(x, z) + 8, z), down);
-        rc.far = 20;
-        const hits = rc.intersectObject(world.group, true).filter((h) => h.object.isMesh
-          && (h.object.material === world.mats.road || h.object.material === world.mats.walk));
-        if (!hits.length) continue;
-        of++;
-        if (hits[0].object.material === world.mats.walk) {
-          n++;
-          if (worst.length < 8) worst.push({ x: Math.round(x), z: Math.round(z), cls: e.cls });
+    // Site-by-site, like every other raycast check. This one settled inside the
+    // innermost loop -- once per sample, scattered across the whole map --
+    // which is the exact cost the settle helper's own comment warns against.
+    for (const [sx, sz] of roadSites(20, 71)) {
+      settle(sx, sz);
+      let took = 0;
+      for (const e of city.edges) {
+        if (took >= 140) break;
+        if (e.elev || e.len < 20) continue;
+        const a = city.nodes[e.a], b = city.nodes[e.b];
+        if (!nearSite(a.x, a.z, sx, sz) || !nearSite(b.x, b.z, sx, sz)) continue;
+        took++;
+        for (let sI = 1; sI < 4; sI++) {
+          const t = sI / 4;
+          // Sample the carriageway itself: pavement drawn here is pavement in
+          // the road, whichever strip put it there.
+          const x = a.x + (b.x - a.x) * t, z = a.z + (b.z - a.z) * t;
+          if (!city.onRoad(x, z, 0, false)) continue;
+          rc.set(new THREE.Vector3(x, G.terrainHeight(x, z) + 8, z), down);
+          rc.far = 20;
+          const hits = rc.intersectObject(world.group, true).filter((h) => h.object.isMesh
+            && (h.object.material === world.mats.road || h.object.material === world.mats.walk));
+          if (!hits.length) continue;
+          of++;
+          if (hits[0].object.material === world.mats.walk) {
+            n++;
+            if (worst.length < 8) worst.push({ x: Math.round(x), z: Math.round(z), cls: e.cls });
+          }
         }
       }
     }

--- a/tools/jank.mjs
+++ b/tools/jank.mjs
@@ -426,7 +426,12 @@ const CHECKS = `(() => {
       }
     }
     worst.sort((a, b) => b.buried - a.buried);
-    add('bridge', n, of, worst, 'elevated deck buried under the terrain it spans');
+    // Say what the sampling misses, rather than letting a rate imply the whole
+    // map was looked at. 22 sites cover 62.1 % of elevated edges; measured, no
+    // span over 100 m is dropped, so the long floating crossings are all in.
+    // The same cap applies to sink / road-poke / walk-on-road.
+    add('bridge', n, of, worst,
+      'elevated deck buried under the terrain it spans (22 sites, ~62 % of elevated edges)');
   }
 
   // --- pavement crossing a carriageway -----------------------------------

--- a/tools/jank.mjs
+++ b/tools/jank.mjs
@@ -371,30 +371,55 @@ const CHECKS = `(() => {
   // A deck that sits below the terrain it spans is a bridge through a hill; one
   // that meets its neighbour at a different height is a step in the road.
   if (want('bridge')) {
+    // Raycast the DRAWN deck, not the node-to-node chord.
+    //
+    // meshViaduct lofts a deck between mitred edge points and the chord is not
+    // that surface -- the same flaw that made road-poke read 9.2 % and
+    // walk-on-road 2.95 % when both are actually clean. Settle a site over each
+    // elevated span, then ask what is really there.
+    d.scene.updateMatrixWorld(true);
+    const rc = new THREE.Raycaster();
+    const down = new THREE.Vector3(0, -1, 0);
     const worst = [];
     let n = 0, of = 0;
-    for (let ei = 0; ei < city.edges.length; ei++) {
-      const e = city.edges[ei];
+    // Deck sites: one per cluster of elevated spans.
+    const sites = [];
+    for (const e of city.edges) {
       if (!e.elev) continue;
-      const a = city.nodes[e.a], b = city.nodes[e.b];
-      for (let s = 0; s <= 4; s++) {
-        const t = s / 4;
-        const x = a.x + (b.x - a.x) * t, z = a.z + (b.z - a.z) * t;
-        const deck = a.y + (b.y - a.y) * t;
-        const ground = G.terrainHeight(x, z);
-        of++;
-        if (ground > deck + 0.5) {
-          n++;
-          if (worst.length < 40) worst.push({ x: Math.round(x), z: Math.round(z), buried: +(ground - deck).toFixed(2) });
+      const a = city.nodes[e.a];
+      if (sites.some(([x, z]) => Math.abs(x - a.x) < SITE_R && Math.abs(z - a.z) < SITE_R)) continue;
+      sites.push([a.x, a.z]);
+      if (sites.length >= 22) break;
+    }
+    for (const [sx, sz] of sites) {
+      settle(sx, sz);
+      for (const e of city.edges) {
+        if (!e.elev) continue;
+        const a = city.nodes[e.a], b = city.nodes[e.b];
+        if (!nearSite(a.x, a.z, sx, sz) || !nearSite(b.x, b.z, sx, sz)) continue;
+        for (let sI = 1; sI < 4; sI++) {
+          const t = sI / 4;
+          const x = a.x + (b.x - a.x) * t, z = a.z + (b.z - a.z) * t;
+          const ground = G.terrainHeight(x, z);
+          // Look down from well above the chord and take the highest road
+          // surface -- that is the deck as drawn.
+          const top = Math.max(ground, a.y + (b.y - a.y) * t) + 30;
+          rc.set(new THREE.Vector3(x, top, z), down);
+          rc.far = 80;
+          const hits = rc.intersectObject(world.group, true)
+            .filter((h) => h.object.isMesh && h.object.material === world.mats.road);
+          if (!hits.length) continue;
+          const deck = hits[0].point.y;
+          of++;
+          if (ground > deck + 0.5) {
+            n++;
+            if (worst.length < 40) worst.push({ x: Math.round(x), z: Math.round(z), buried: +(ground - deck).toFixed(2) });
+          }
         }
       }
     }
     worst.sort((a, b) => b.buried - a.buried);
-    add('bridge', n, of, worst,
-      'elevated deck buried under the terrain it spans'
-      + ' -- UNVERIFIED: compares the node-to-node chord, not the drawn deck,'
-      + ' which is the same flaw that made road-poke read 9.2% and'
-      + ' walk-on-road 2.95% when both are actually clean');
+    add('bridge', n, of, worst, 'elevated deck buried under the terrain it spans');
   }
 
   // --- pavement crossing a carriageway -----------------------------------

--- a/tools/jank.mjs
+++ b/tools/jank.mjs
@@ -147,9 +147,17 @@ const CHECKS = `(() => {
     // world.buildChunk registers each trunk into city.obstacles, so the
     // obstacle list IS the drawn record. Settle over each wet candidate and
     // count the trunks that actually stand in water.
+    // Capped, like roadSites and bridge. Seattle's shoreline is long enough to
+    // dedupe into many 600 m clusters and each one costs a settle (~243
+    // world.update calls cold), so an uncapped list can quietly dominate the
+    // whole battery's runtime. Report what was dropped rather than letting the
+    // rate imply every wet candidate was visited.
+    const SITE_CAP = 24;
+    let clusters = 0;
     for (const [wx, wz] of wetCand) {
       if (sites.some(([x, z]) => Math.abs(x - wx) < SITE_R && Math.abs(z - wz) < SITE_R)) continue;
-      sites.push([wx, wz]);
+      clusters++;
+      if (sites.length < SITE_CAP) sites.push([wx, wz]);
     }
     for (const [sx, sz] of sites) {
       settle(sx, sz);
@@ -169,7 +177,7 @@ const CHECKS = `(() => {
           if (seen.has(key)) continue;
           seen.add(key);
           planted++;
-          if (G.isWater(ox, oz) || G.terrainHeight(ox, oz) < 0.35) {
+          if (G.isWater(ox, oz) || G.terrainHeight(ox, oz) < d.WET_FLOOR) {
             wet++;
             if (worst.length < 6) worst.push({ x: Math.round(ox), z: Math.round(oz), y: +G.terrainHeight(ox, oz).toFixed(2) });
           }
@@ -177,7 +185,9 @@ const CHECKS = `(() => {
       }
     }
     add('tree-in-water', wet, planted, worst,
-      'trunks actually standing in water (from ' + cand + ' candidates, ' + wetCand.length + ' of them wet)');
+      'trunks actually standing in water (from ' + cand + ' candidates, '
+      + wetCand.length + ' of them wet, in ' + sites.length + ' of '
+      + clusters + ' clusters)');
   }
 
   // --- ground that stands above the water covering it --------------------
@@ -251,36 +261,36 @@ const CHECKS = `(() => {
       settle(sx, sz);
       let took = 0;
       for (const e of city.edges) {
-      if (took >= 140) break;
-      if (e.elev || e.len < 12) continue;
-      const a = city.nodes[e.a], b = city.nodes[e.b];
-      if (!nearSite(a.x, a.z, sx, sz) || !nearSite(b.x, b.z, sx, sz)) continue;
-      took++;
-      for (let sI = 1; sI < 4; sI++) {
-        const t = sI / 4;
-        const x = a.x + (b.x - a.x) * t, z = a.z + (b.z - a.z) * t;
-        const top = G.terrainHeight(x, z) + 8;
-        rc.set(new THREE.Vector3(x, top, z), down);
-        rc.far = 20;
-        // Road surface only. world.group also carries flat/glow/glass/facade
-        // meshes and tree canopies -- the scatter keeps a 0.8 m pad off the
-        // TRUNK, not the canopy, so a canopy overhanging a narrow residential
-        // street sits inside this ray's span. A hit on one makes the overlap
-        // deeply negative, so the sample silently passes -- hiding a real
-        // poke-through at exactly the points most likely to have clutter
-        // overhead. Samples are on centrelines, so mats.walk is not expected.
-        const hits = rc.intersectObject(world.group, true)
-          .filter((h) => h.object.isMesh && h.object.material === world.mats.road);
-        const terr = rc.intersectObject(world.terrainGroup, true);
-        if (!hits.length || !terr.length) continue;
-        of++;
-        // Positive: the ground is drawn ABOVE the road surface at this point.
-        const over = terr[0].point.y - hits[0].point.y;
-        if (over > 0.02) {
-          n++;
-          if (worst.length < 40) worst.push({ x: Math.round(x), z: Math.round(z), over: +over.toFixed(2), cls: e.cls });
+        if (took >= 140) break;
+        if (e.elev || e.len < 12) continue;
+        const a = city.nodes[e.a], b = city.nodes[e.b];
+        if (!nearSite(a.x, a.z, sx, sz) || !nearSite(b.x, b.z, sx, sz)) continue;
+        took++;
+        for (let sI = 1; sI < 4; sI++) {
+          const t = sI / 4;
+          const x = a.x + (b.x - a.x) * t, z = a.z + (b.z - a.z) * t;
+          const top = G.terrainHeight(x, z) + 8;
+          rc.set(new THREE.Vector3(x, top, z), down);
+          rc.far = 20;
+          // Road surface only. world.group also carries flat/glow/glass/facade
+          // meshes and tree canopies -- the scatter keeps a 0.8 m pad off the
+          // TRUNK, not the canopy, so a canopy overhanging a narrow residential
+          // street sits inside this ray's span. A hit on one makes the overlap
+          // deeply negative, so the sample silently passes -- hiding a real
+          // poke-through at exactly the points most likely to have clutter
+          // overhead. Samples are on centrelines, so mats.walk is not expected.
+          const hits = rc.intersectObject(world.group, true)
+            .filter((h) => h.object.isMesh && h.object.material === world.mats.road);
+          const terr = rc.intersectObject(world.terrainGroup, true);
+          if (!hits.length || !terr.length) continue;
+          of++;
+          // Positive: the ground is drawn ABOVE the road surface at this point.
+          const over = terr[0].point.y - hits[0].point.y;
+          if (over > 0.02) {
+            n++;
+            if (worst.length < 40) worst.push({ x: Math.round(x), z: Math.round(z), over: +over.toFixed(2), cls: e.cls });
+          }
         }
-      }
       }
     }
     worst.sort((p, q) => q.over - p.over);

--- a/tools/jank.mjs
+++ b/tools/jank.mjs
@@ -10,6 +10,14 @@
 // whole 16 km map and driven to zero, and a regression shows up as a number
 // rather than as someone noticing months later.
 //
+// A check is only worth its output if it measures what is DRAWN. Two of the
+// original nine compared an analytic surface -- the chord between an edge's end
+// nodes, or where a pavement strip would be offset to -- against the terrain,
+// and both reported large problems that do not exist: road-poke read 9.2 % and
+// walk-on-road 2.95 %, and raycasting the actual meshes puts them at 0.28 % and
+// 0 %. Measuring intent instead of geometry does not just give a wrong number,
+// it sends someone to fix a bug that is not there.
+//
 // Every check reports a count, a rate against however many samples it took, and
 // the worst offenders with coordinates -- so a bad one can be walked to with
 // `AUTO_PROBE` or photographed with tools/survey.mjs instead of being argued
@@ -145,33 +153,44 @@ const CHECKS = `(() => {
 
   // --- terrain poking through the road surface ---------------------------
   //
-  // A road quad is a chord and the heightfield bulges under it. ROAD_LIFT is
-  // 30 cm; anything above that is grass growing through the tarmac.
+  // Raycast the DRAWN meshes. Comparing the terrain against the chord between
+  // an edge's two end nodes measured a surface nobody renders -- meshRoad
+  // subdivides by grade and by bow and samples the heightfield at every corner,
+  // so the tarmac follows the ground far more closely than a chord does. That
+  // check reported 9.2 % and was wrong; the only honest question is which mesh
+  // the ray hits first.
   if (want('road-poke')) {
+    d.scene.updateMatrixWorld(true);
+    const rc = new THREE.Raycaster();
+    const down = new THREE.Vector3(0, -1, 0);
     const worst = [];
     let n = 0, of = 0;
-    const step = Math.max(1, Math.floor(city.edges.length / 4000));
+    const step = Math.max(1, Math.floor(city.edges.length / 700));
     for (let ei = 0; ei < city.edges.length; ei += step) {
       const e = city.edges[ei];
-      if (e.elev || e.len < 8) continue;
+      if (e.elev || e.len < 12) continue;
       const a = city.nodes[e.a], b = city.nodes[e.b];
-      for (let s = 1; s < 5; s++) {
-        const t = s / 5;
+      for (let sI = 1; sI < 4; sI++) {
+        const t = sI / 4;
         const x = a.x + (b.x - a.x) * t, z = a.z + (b.z - a.z) * t;
-        // The drawn surface interpolates the ends; the ground is what is really
-        // there. The gap is what pokes through.
-        const drawn = (a.y + (b.y - a.y) * t);
-        const real = G.terrainHeight(x, z);
+        world.update(x, z, 60);
+        const top = G.terrainHeight(x, z) + 8;
+        rc.set(new THREE.Vector3(x, top, z), down);
+        rc.far = 20;
+        const hits = rc.intersectObject(world.group, true).filter((h) => h.object.isMesh);
+        const terr = rc.intersectObject(world.terrainGroup, true);
+        if (!hits.length || !terr.length) continue;
         of++;
-        const over = real - drawn;
-        if (over > 0.30) {
+        // Positive: the ground is drawn ABOVE the road surface at this point.
+        const over = terr[0].point.y - hits[0].point.y;
+        if (over > 0.02) {
           n++;
           if (worst.length < 40) worst.push({ x: Math.round(x), z: Math.round(z), over: +over.toFixed(2), cls: e.cls });
         }
       }
     }
-    worst.sort((a, b) => b.over - a.over);
-    add('road-poke', n, of, worst, 'terrain standing more than ROAD_LIFT above the road it carries');
+    worst.sort((p, q) => q.over - p.over);
+    add('road-poke', n, of, worst, 'terrain drawn above the road surface it carries');
   }
 
   // --- things you sink into ----------------------------------------------
@@ -200,7 +219,11 @@ const CHECKS = `(() => {
         const stand = city.groundAt(x, z, null, lift);
         rc.set(new THREE.Vector3(x, stand + 12, z), down);
         rc.far = 24;
-        const hits = rc.intersectObject(world.group, true).filter((h) => h.object.isMesh);
+        // Ground surfaces only. A ray that lands on a bollard, a bin or a kerb
+        // face is not evidence that the pavement is at the wrong height, and
+        // counting those inflated this check by about a twentieth.
+        const hits = rc.intersectObject(world.group, true).filter((h) => h.object.isMesh
+          && (h.object.material === world.mats.road || h.object.material === world.mats.walk));
         if (!hits.length) continue;
         of++;
         const surf = hits[0].point.y;
@@ -280,35 +303,51 @@ const CHECKS = `(() => {
       }
     }
     worst.sort((a, b) => b.buried - a.buried);
-    add('bridge', n, of, worst, 'elevated deck buried under the terrain it spans');
+    add('bridge', n, of, worst,
+      'elevated deck buried under the terrain it spans'
+      + ' -- UNVERIFIED: compares the node-to-node chord, not the drawn deck,'
+      + ' which is the same flaw that made road-poke read 9.2% and'
+      + ' walk-on-road 2.95% when both are actually clean');
   }
 
   // --- pavement crossing a carriageway -----------------------------------
+  //
+  // Raycast for the pavement MATERIAL at points that are on a carriageway. The
+  // previous version computed where a strip would be offset to and asked
+  // whether that spot was tarmac -- which measures intent, not geometry: a
+  // piece the builder already rejected still counted, and the figure never
+  // moved when the builder's own test was improved. Only what is drawn counts.
   if (want('walk-on-road')) {
+    d.scene.updateMatrixWorld(true);
+    const rc = new THREE.Raycaster();
+    const down = new THREE.Vector3(0, -1, 0);
     const worst = [];
     let n = 0, of = 0;
-    const step = Math.max(1, Math.floor(city.edges.length / 2500));
+    const step = Math.max(1, Math.floor(city.edges.length / 500));
     for (let ei = 0; ei < city.edges.length; ei += step) {
       const e = city.edges[ei];
       if (e.elev || e.len < 20) continue;
-      if (e.cls !== 'st' && e.cls !== 'art' && e.cls !== 'res') continue;
       const a = city.nodes[e.a], b = city.nodes[e.b];
-      const px = -e.dz, pz = e.dx;
-      const sw = e.cls === 'art' ? 3.2 : 2.6;
-      for (const sg of [-1, 1]) {
-        for (let s = 1; s < 4; s++) {
-          const t = s / 4;
-          const x = a.x + (b.x - a.x) * t + px * sg * (e.hw + sw * 0.5);
-          const z = a.z + (b.z - a.z) * t + pz * sg * (e.hw + sw * 0.5);
-          of++;
-          if (city.onRoad(x, z, 0, false)) {
-            n++;
-            if (worst.length < 6) worst.push({ x: Math.round(x), z: Math.round(z), cls: e.cls });
-          }
+      for (let sI = 1; sI < 4; sI++) {
+        const t = sI / 4;
+        // Sample the carriageway itself: pavement drawn here is pavement in the
+        // road, whichever strip put it there.
+        const x = a.x + (b.x - a.x) * t, z = a.z + (b.z - a.z) * t;
+        if (!city.onRoad(x, z, 0, false)) continue;
+        world.update(x, z, 60);
+        rc.set(new THREE.Vector3(x, G.terrainHeight(x, z) + 8, z), down);
+        rc.far = 20;
+        const hits = rc.intersectObject(world.group, true).filter((h) => h.object.isMesh
+          && (h.object.material === world.mats.road || h.object.material === world.mats.walk));
+        if (!hits.length) continue;
+        of++;
+        if (hits[0].object.material === world.mats.walk) {
+          n++;
+          if (worst.length < 8) worst.push({ x: Math.round(x), z: Math.round(z), cls: e.cls });
         }
       }
     }
-    add('walk-on-road', n, of, worst, 'pavement mid-line sitting on a carriageway');
+    add('walk-on-road', n, of, worst, 'pavement drawn as the top surface of a carriageway');
   }
 
   return JSON.stringify(out);

--- a/tools/jank.mjs
+++ b/tools/jank.mjs
@@ -3,7 +3,7 @@
 //   node tools/jank.mjs [--json] [--only=name,name]
 //
 // The defects this looks for -- pavement that does not meet, props standing in
-// water, terrain poking through the asphalt, roofs that miss their building,
+// water, terrain poking through the asphalt,
 // things you sink into -- are all things a screenshot can only find one at a
 // time, by luck, in whichever direction the camera happened to be pointing.
 // They are also all *measurable*, which means they can be counted over the
@@ -259,7 +259,15 @@ const CHECKS = `(() => {
         const top = G.terrainHeight(x, z) + 8;
         rc.set(new THREE.Vector3(x, top, z), down);
         rc.far = 20;
-        const hits = rc.intersectObject(world.group, true).filter((h) => h.object.isMesh);
+        // Road surface only. world.group also carries flat/glow/glass/facade
+        // meshes and tree canopies -- the scatter keeps a 0.8 m pad off the
+        // TRUNK, not the canopy, so a canopy overhanging a narrow residential
+        // street sits inside this ray's span. A hit on one makes the overlap
+        // deeply negative, so the sample silently passes -- hiding a real
+        // poke-through at exactly the points most likely to have clutter
+        // overhead. Samples are on centrelines, so mats.walk is not expected.
+        const hits = rc.intersectObject(world.group, true)
+          .filter((h) => h.object.isMesh && h.object.material === world.mats.road);
         const terr = rc.intersectObject(world.terrainGroup, true);
         if (!hits.length || !terr.length) continue;
         of++;
@@ -325,26 +333,25 @@ const CHECKS = `(() => {
   }
 
   // --- roofs that miss their building ------------------------------------
-  if (want('roof')) {
-    const worst = [];
-    let n = 0, of = 0;
-    const step = Math.max(1, Math.floor(city.buildings.length / 6000));
-    for (let bi = 0; bi < city.buildings.length; bi += step) {
-      const bd = city.buildings[bi];
-      if (bd.style !== 'house') continue;
-      of++;
-      // Ask world.js's OWN decision. Re-deriving the threshold here measured
-      // the DATA -- how many elongated houses exist, which is a fixed property
-      // of the map and never changes -- so the check reported the same 3 before
-      // and after the guard that fixed it, and could not have noticed either.
-      const over = Math.max(bd.w, bd.d) / Math.min(bd.w, bd.d);
-      if (over > 4.5 && world.constructor.gables(bd)) {
-        n++;
-        if (worst.length < 6) worst.push({ x: Math.round(bd.x), z: Math.round(bd.z), w: +bd.w.toFixed(1), d: +bd.d.toFixed(1) });
-      }
-    }
-    add('roof', n, of, worst, 'houses given a gable that cannot sit on them');
-  }
+  //
+  // REMOVED, because the defect it reported does not exist.
+  //
+  // It counted houses whose min-area rectangle is more elongated than 4.5:1 and
+  // called them roofs a gable cannot sit on. That threshold was invented here
+  // and never checked against meshGable, which sizes its eaves from the actual
+  // w and d (a fixed 0.45 m overhang on all four sides) and runs the ridge along
+  // the longer side -- so a terrace gets a long ridge and a low pitch, which is
+  // what a terrace has. Nothing about elongation breaks it.
+  //
+  // Measured, on the three footprints this check named: with the gable built,
+  // contiguous roof surface past the narrow wall was 0.4 m, 6.0 m and 5.8 m --
+  // and with the gable SUPPRESSED it was 0 m, 6.0 m and 5.8 m. The metres are
+  // neighbouring terrace roofs, which touch and so cannot be told apart by
+  // contiguity; the gable's own contribution is the 0.45 m eave it is supposed
+  // to have. The check was reporting the map's shape, not a defect.
+  //
+  // A drawn-geometry version would have to attribute roof surface to one
+  // building, which in a terrace it cannot do. Better absent than green.
 
   // --- buildings standing in water ---------------------------------------
   if (want('building-in-water')) {

--- a/tools/jank.mjs
+++ b/tools/jank.mjs
@@ -132,7 +132,10 @@ const CHECKS = `(() => {
           if (city.onRoad(x, z, 2.5)) continue;
           if (world.inBuilding && world.inBuilding(x, z, 0.8)) continue;
           cand++;
-          if (G.isWater(x, z) || G.terrainHeight(x, z) < 0.35) wetCand.push([x, z]);
+          // world.js's own constant, so the candidate set cannot drift from
+          // what the scatter treats as wet. Only site SELECTION uses it -- the
+          // verdict below comes from city.obstacles, the built record.
+          if (G.isWater(x, z) || G.terrainHeight(x, z) < d.WET_FLOOR) wetCand.push([x, z]);
         }
       }
     }


### PR DESCRIPTION
Real fixes, each measured before and after. The tooling changes are here because
several checks turned out to be measuring the map instead of the game, and could
not have detected their own fixes in either direction.

## Fixes

| | before | after |
|---|---|---|
| `sink` — drawn pavement vs the height you stand at | 11.8 % | **6.79 %** (worst 0.67 m → 0.39 m) |
| trunks standing in water | **63** | 0 |
| ground nodes carrying a wrong height | **55,282 of 64,170** (worst 6.63 m) | 0 |

**Junction squares were one quad.** A crossing was drawn as a single quad up to
~9 m across, sampling terrain at its four corners, while `groundAt` samples the
heightfield at the exact point. Those are different surfaces the moment the
ground is not planar. The corner samples were never wrong; the middle was. On a
5×5 grid across one residential crossing: worst gap 74.2 → 31.3 cm, mean 31.1 →
9.8 cm, samples over 10 cm 22/25 → 7/25.

**Gate that subdivision on bow, not spread.** A junction on a uniform grade has
a large corner spread and is still exactly representable by one quad — a plane
is a plane. What one quad cannot follow is curvature. Gating on spread
subdivided nearly every junction downtown (Seattle is hilly) and saved almost
nothing: 432814 triangles against 432214.

**Trees in the sea.** The green mask and the water mask are separate rasters
whose shorelines disagree, so `inPark()` says yes on cells under Puget Sound.
The obvious test — terrain against `waterLevelAt` — is wrong: that answers over
a lake's *axis-aligned bounding box*, so it reports Green Lake's 50.3 m for the
whole park ringing it, and deleted 105 of its 717 trees plus 251 around Lake
Union. Caught by measuring.

**Ground node heights.** `build_roads.py` bakes them bilinear and its docstring
still claimed that matched `geo.terrainHeight()` — untrue since `terrainHeight`
was changed to interpolate the way the terrain mesh is triangulated. This does
**not** move `sink`; it restores the one-height-surface invariant, and is
documented as that rather than as a fix for anything visible.

## Checks that were measuring nothing

`tree-in-water` re-implemented the scatter's filters and counted the points that
passed — a property of the rasters, which never changes. It reported an
unchanged 16 before and after the scatter was fixed. Against the trees that
actually get planted the real figure was **63**. `bridge` compared the
node-to-node chord instead of the drawn deck (0.4 % → 0.2 % honest, worst 2.42 →
1.42 m). `road-poke` wasn't filtered to the road material, so a tree canopy over
a narrow street could absorb the ray and silently pass the sample.

All now read the built result. The battery also settles the chunk streamer
before raycasting — it was querying half-built chunks, which is why every
worst-point diagnosis returned `drawn: null`.

## Withdrawn: there was no roof bug

An earlier revision of this PR claimed 3 elongated houses were getting gables
that could not fit, and added a `World.gables()` guard. **Both the finding and
the fix were wrong**, and review caught the check that hid it (`over > 4.5 &&
gables(bd)` where `gables` is `over < 4.5` — mutually exclusive, so it reported
0 however the mesher behaved).

`meshGable` sizes eaves from the actual `w`/`d` (a fixed 0.45 m overhang) and
runs the ridge along the longer side, so a terrace gets a long ridge and a low
pitch. Measured contiguous roof past the narrow wall on the three named
footprints:

| | gable built | gable **suppressed** |
|---|---|---|
| (-3465,-5948) | 0.4 m | 0 m |
| (-2371,-2904) | 6.0 m | 6.0 m |
| (-1486,5109) | 5.8 m | 5.8 m |

The metres do not change when the gable is removed — they are neighbouring
terrace roofs, which touch and so cannot be separated by contiguity. The guard
was suppressing pitched roofs on three *correct* terraces. Guard reverted, check
deleted: one that cannot be made honest is better absent than green. (The
"24:1" figure quoted earlier was a width in metres misread as an aspect ratio;
the real worst is 5.1:1.)

## Also not taken

Overriding the strip scan with the junction ring. A ramping 0.06 m tail
suppresses the ring's 0.52 m and leaves you 0.46 m inside visible pavement — but
the fix measures **worse** (`sink` 11.8 % → 12.44 %), because `nodeSurface`
reports the ring as a plain box while `meshNode` drops the ring pieces covering
each approach. Documented in place. (Reverting it initially deleted the
pre-existing empty-scan fallback as well, reintroducing a 44 cm drop on ring
corners — caught in review and restored.)

2.5 m junction cells: mean improves to 5.6 cm, worst does not move at all, and
`trisFrame` regresses past the guard.

## Verification

`tools/perfguard.mjs --check`: **no regressions.** Draw calls unchanged
(213/299), triangles +2.7 % steady, streaming max 23.2 → 17.1 ms.
`tools/verify.mjs`: landmarks mean 21 m / worst 53 m, 0 ground-level edges over
water, 0 exceptions.

No screenshots: the tarmac is continuous either way and before/after renders of
the fixed junction are indistinguishable. The defect is where you *stand*
relative to what is drawn, so the raycast is the evidence and a picture is not.

## Remaining, honestly counted

`island` 0.56 %, `missing-water` 0.49 % — both trace to `carve_lakes` in the
raster importer, so fixing them means regenerating `height.png`. `bridge` 0.2 %
(11 real buried decks; 22 sites reach 62 % of elevated edges, and no span over
100 m is dropped). `building-in-water` 0.7 %, mostly real piers and houseboats
per the existing notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B