### PR TITLE
Auto: GTA handling, water that stops you, and freeways without houses in them

### DIFF
--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -837,6 +837,20 @@ Current figures, all inside their bands:
 | jog 3.5 | 161 | 1.31 m | 0.43 | 7.5 cm | 113 deg | 100 % | 1.8 % |
 | sprint 7.5 | 196 | 2.29 m | 0.27 | 11.0 cm | 125 deg | 96 % | 1.9 % |
 
+**Swing clearance is what folds the knee, and it was short at every pace above
+a walk.** `tools/gait.mjs` measured knee swing at 59 deg brisk (band 65-85),
+105 at run (110-140) and 108 at sprint (120-155) -- too little fold is a leg
+swinging through nearly straight, which is the stiff, skating look. The heel has
+to come much closer to the backside as the pace rises. Raising the clearance
+curve puts jog/run/sprint at 116/123/126, all in band. Tune it against the rig:
+the first value tried overshot jog to 121 (HIGH) while fixing run and sprint.
+
+On-foot pace is **5.0 m/s running and 7.2 sprinting**. It was 3.6/5.4, lowered
+at some point to stop the gait reading as track athletics -- which was the wrong
+lever, because the gait keys off `runBlend` and the rig judges it at 1.4/3.5/7.5
+where it already passed. The pose was never the speed's problem, and a 16 km
+city at 3.6 m/s is a chore.
+
 Two standing traps. `animateWalk` owns `h.phase` -- advancing the cycle anywhere
 else reintroduces the cadence/stride split. And the bones are **unscaled**, so a
 step in world metres has to be divided by `h.scale` or taller pedestrians
@@ -893,6 +907,48 @@ forces every normal outward from the ring centre, and the inside of a tub faces
 the other way. And in a dark tub, contrast is the whole game: the steering
 wheel was there for two renders before it was moved into `trim` in a bright
 colour and became visible.
+
+**Steering asks for a radius the tyres can actually hold.** The lock used to
+come from a fixed curve -- a target radius lerped 4.5 -> 11 m across the speed
+range -- and that is not a grip limit, it is a shape. At 122 km/h it asked a
+sedan for an 11 m radius, which is **10.7 g** of lateral acceleration against
+the **1.9 g** its tyres have: a demand 5.5x over the limit, and rising with
+speed. The block that applies the yaw states that the steering limit IS the grip
+limit ("with steering limited to what grip supports, the yaw the car achieves IS
+the lateral acceleration"), so with a radius like that the statement was untrue
+and *nothing anywhere enforced grip*. The car pivoted on rails at a rate no tyre
+could produce. That is what wild high-speed steering was.
+
+`r = v^2 / a` is the whole fix, with `STEER_BITE` just over 1 so a bend taken
+flat out is at the limit with a little left to provoke. Measured, sedan:
+
+| | 20 kph | 40 | 60 | 90 | 120 |
+|---|---|---|---|---|---|
+| radius before | 5.5 m | 6.6 | 7.7 | 9.3 | 10.9 |
+| radius after | 4.5 m | 5.2 | 11.7 | 26.3 | 46.8 |
+| lateral g before | 0.57 | 1.91 | 3.69 | 6.87 | **10.42** |
+| lateral g after | 0.71 | 2.43 | 2.43 | 2.42 | **2.42** |
+
+Low-speed lock is unchanged -- below about 34 km/h a fixed floor applies, so
+parking-lot agility is exactly as tight as it was.
+
+**Braking is scaled with grip, not left honest.** The throttle ran at
+`ARCADE_PUNCH` 2.4x and cornering at `ARCADE_GRIP` 2.2x while braking sat at
+exactly 1.0x, and the comment above them claimed braking "stays honest" as
+though that were a decision rather than the one axis nobody had revisited. It is
+why braking felt slow: you accelerated at 2.4x and stopped at 1x. `ARCADE_BRAKE`
+matches `ARCADE_GRIP`, which also keeps the tyre isotropic. 100-0 went 39.3 m ->
+18.4 m. **`tools/vehicles.mjs` divides the brake band by it**, exactly as it
+already divided the accel band by `ARCADE_PUNCH`.
+
+**And its class-order check compares lateral g DIRECTLY now.** It used to
+multiply by the wheelbase, and had to: with a fixed-radius lock, lat came out as
+`v^2 tan(steer) / L` and geometry had to be divided back out before grip was
+visible. Solving the lock from grip makes lat independent of wheelbase, so that
+multiply stopped removing a bias and started adding one -- it reported a
+short-wheelbase sports car as cornering worse than a pickup it out-corners by
+0.7 g. **Normalise for the model you have, not the one the check was written
+against.**
 
 **A bike leans into the corner, and the sign is the same trap as the camber.**
 `tan(lean) = lateral acceleration / g`, and it is built from the acceleration
@@ -1234,13 +1290,75 @@ needs `atan(0.2)` ≈ 0.2 rad of pitch, and it was getting none. Seattle's real
 grades are steeper than the hand-drawn hills were, so this matters more now, not
 less.
 
+## Bumpy freeways: one fix, and one failure worth not repeating
+
+**A deck may only pick you up if it is at your wheels.** `groundAt` took the
+highest deck within `curY + 2.6` -- taller than a car -- so driving along
+ground-level I-5 *under* an overpass, the deck was in reach, the car was lifted
+onto it, and it fell off when the deck ended. Measured on I-5: held at 47.3 m
+over ground descending 45.3 -> 43.6, then a **3.76 m drop**. `DECK_REACH` is
+0.9 m, which is far more than a ramp climbs between frames (a 10 % grade at
+30 m/s rises 5 cm a frame) and far less than an overpass clears a roof.
+
+**The rest of the bumpiness is the heightfield, and smoothing it is NOT a small
+change.** Roads follow the 40 m triangulated DEM exactly, so every triangle
+crossing is a kink in the grade. Measured along the freeways, 5.6 % of 3 m steps
+change grade by more than 5 % -- about 1.5 g through the seat at 30 m/s -- and
+**raw terrain on its own already accounts for 4.2 %**. A real freeway is cut and
+filled; this one drapes.
+
+Two attempts, both **measured worse**, both reverted:
+
+| | over 5 % grade change |
+|---|---|
+| as-is | 5.62 % |
+| per-edge upper envelope (10 m) | **9.48 %** |
+| ...plus shared node heights | **12.21 %** |
+
+The envelope itself is sound in isolation -- a rolling max then a smooth, which
+fills dips instead of cutting crests, so terrain poke-through is zero by
+construction (plain smoothing put 1.01 m of ground through the tarmac at a 15 m
+window). In isolation it gave 5.09 % -> 3.19 % with a median 7 cm of float.
+
+It failed because **a freeway is chopped into ~35 m edges and each profile was
+built independently**, so the two disagreed at every junction: smooth within a
+piece is not smooth. Forcing agreement by taking each node's highest envelope
+then shifting each edge onto it was worse again, because a ramp meeting a
+freeway at a different height tilts the whole edge.
+
+Doing this properly means profiling a whole connected freeway *chain* rather
+than an edge, and deciding what happens where a ramp joins. **Don't attempt it
+as a tuning change.**
+
+## Water, and the law that keeps being learned one caller at a time
+
+**Every height test is against the LOCAL water surface**, because Green Lake is
+at 50.3 m and Lake Union at 5. `world.waterLevelAt()` exists for this. The
+on-foot path learned it; `updateDrive` did not, and its test was
+`v.y < -1.2 && G.isWater(...)`, which only ever describes the sea. So a car on a
+lake bed never tripped anything and **you could drive the bottom of Green Lake
+at 200 km/h, dry and at full throttle**. Driving now samples the local surface
+before the step, cuts the engine, drags the car down and sinks it. Verified at
+Green Lake (surface 50.3, bed 43.4) and in Elliott Bay (surface 0, bed -5.4):
+200 km/h -> 0 in both.
+
+The lesson is not about water. **When a law is added, grep for every caller of
+the thing it replaces** -- this one sat one function away from the code that
+documented it, for as long as the game has had lakes.
+
 ## Known gaps
 
-- **Tunnels are drawn at ground level.** 102 OSM ways in the box are tunnels
-  (SR-99, the Battery St and Mount Baker ridge bores). They keep the network
-  connected and are flagged `tunnel` on the edge, but nothing renders a bore, so
-  they read as surface roads overlapping the streets above them. Routing is
-  right; the picture isn't.
+- **Tunnels are no longer drawn at all.** 102 OSM ways in the box are tunnels
+  (SR-99, the Battery St and Mount Baker ridge bores). They used to be drawn at
+  ground level as ordinary carriageway, which collided with a deliberate
+  decision in `roadFit()`: it does *not* clear buildings off a tunnel, because
+  "a building above a tunnel is where buildings normally are". The two together
+  painted a freeway through the houses on top of it -- **46 of the 63 buildings
+  standing in a carriageway were over a bore**, which is what the obstacles on
+  I-90 at Mercer Island and on SR-99 were. `meshRoad` and `roadLift` both skip
+  tunnel edges now; routing is unaffected, because routing is the graph. What is
+  still missing is any rendered bore, so a tunnel is a gap in the road you drive
+  over rather than through.
 - **Traffic ignores `oneway`.** The flag is imported and sits on every edge
   (`F_ONEWAY`, `F_ONEWAY_REV`), and nothing reads it yet.
 - **Buildings are oriented boxes**, not polygons — see "How accurate it actually

--- a/apps/auto/CLAUDE.md
+++ b/apps/auto/CLAUDE.md
@@ -1019,7 +1019,11 @@ grid floats roads over bulges the mesh doesn't resolve; and at 20 m the mesh
 would cost 1.28 M triangles across a 16 km map, which is the whole frame budget.
 
 Bridges and freeway decks are separate: `city.groundAt(x, z, currentY)` returns
-the highest deck below `currentY + 2.6`, else the terrain.
+the deck NEAREST `currentY` within `DECK_REACH` (0.9 m above it), else the
+terrain. It used to take the *highest* deck within 2.6 m, which is taller than a
+car -- see "Bumpy freeways" for the 3.76 m drop that caused. With no `currentY`
+(a spawn or a placement query) it still takes the highest, which is the only
+sane answer without a reference height.
 
 **Paved surfaces sit above the terrain and everything standing on them has to be
 lifted by the same amount.** `ROAD_LIFT` / `NODE_LIFT` / `WALK_LIFT` in

--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -414,7 +414,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v47</div>
+    <div id="build">v48</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -41,6 +41,19 @@ const MAX_WALK = 3.2;
 // because world.js draws it that way. Smoothing belongs in the character and
 // the camera -- soften it here and you sink into the kerb instead.
 const RAMP = 0.5;
+
+// How far ABOVE its current ride height a vehicle may be captured by a bridge
+// deck. This was 2.6 m, which is taller than a car: driving along ground-level
+// I-5 under an overpass, the deck was within reach, the car was lifted onto it,
+// and when the deck ended it fell back down -- measured on I-5, held at 47.3 m
+// over ground descending 45.3 -> 43.6, then a 3.76 m drop. Those are the jumps
+// and bumps on the freeways.
+//
+// A car is only ever ON a deck when the deck is essentially at its wheels.
+// 0.9 m is far more than a ramp can climb between frames (a 10 % grade at
+// 30 m/s rises 5 cm a frame), so joining a viaduct still works, while an
+// overpass a metre or more overhead can no longer pick the car up.
+const DECK_REACH = 0.9;
 const CLASS_SPEED = { hwy: 30, art: 17, st: 12, res: 9, ramp: 14 };
 
 const walkWidth = (cls) => (cls === 'st' || cls === 'res' ? 2.6 : cls === 'art' ? 3.2 : 0);
@@ -496,7 +509,10 @@ export function* cityGenerator(md) {
           if (!c) continue;
           for (const ei of c.edges) {
             const e = g.edges[ei];
-            if (e.elev) continue;
+            // A tunnel draws no surface (world.meshRoad skips it), so it must
+            // not lift anything either -- that would stand you on a road that
+            // is not there.
+            if (e.elev || e.tunnel) continue;
             const a = g.nodes[e.a], b = g.nodes[e.b];
             const r = distToSeg(x, z, a.x, a.z, b.x, b.z);
             const outer = e.hw + walkWidth(e.cls);
@@ -566,6 +582,19 @@ export function* cityGenerator(md) {
     groundAt(x, z, curY, lift) {
       const terr = G.terrainHeight(x, z) + (lift != null ? lift : this.roadLift(x, z));
       let best = terr;
+      // NEAREST deck to where you already are, not the highest one within
+      // reach. Taking the highest meant any deck up to 2.6 m above the car
+      // captured it -- so on a freeway, where decks stack, driving along the
+      // ground under an overpass snapped you up onto it, and the next frame's
+      // curY was higher again, so the car ratcheted up through the whole stack.
+      // Measured on I-5, 25 % of 3 m steps along a freeway moved more than
+      // 10 cm and the worst was an 11 m leap. That is the bumps and jumps.
+      //
+      // Nearest keeps every case that mattered: climbing a ramp, the deck you
+      // are joining is the closest surface; driving off a bridge, the terrain
+      // becomes closest and you fall; sitting on a deck, the deck is 0.6 m away
+      // and the ground is metres, so it wins easily.
+      let bestD = curY == null ? Infinity : Math.abs(terr - curY);
       const l = surfGrid.get(skey(Math.floor(x / surfCell), Math.floor(z / surfCell)));
       if (l) {
         for (const si of l) {
@@ -573,8 +602,13 @@ export function* cityGenerator(md) {
           const r = distToSeg(x, z, s.ax, s.az, s.bx, s.bz);
           if (r.d > s.hw) continue;
           const y = s.ay + (s.by - s.ay) * r.t + ROAD_LIFT * 0.3;
-          if (curY == null || y <= curY + 2.6) {
+          if (curY == null) {
+            // No reference height -- a spawn or a placement query. The highest
+            // deck is the only sane answer, and is what this always did.
             if (y > best) best = y;
+          } else if (y <= curY + DECK_REACH) {
+            const dd = Math.abs(y - curY);
+            if (dd < bestD) { bestD = dd; best = y; }
           }
         }
       }

--- a/apps/auto/src/citygen.js
+++ b/apps/auto/src/citygen.js
@@ -470,7 +470,10 @@ export function* cityGenerator(md) {
             if (oi === ei) continue;
             const o = g.edges[oi];
             if (o.elev) continue;
-            // A tunnel is drawn at ground level for now, so it must never be
+            // Dead since tunnels stopped being drawn at all (world.meshRoad
+            // returns before either caller reaches here), and kept only so the
+            // rule is written down if a bore is ever rendered: a tunnel must
+            // never be
             // the thing that suppresses the street above it.
             if (o.tunnel && !me.tunnel) continue;
             const surfaceWins = me.tunnel && !o.tunnel;
@@ -563,6 +566,9 @@ export function* cityGenerator(md) {
             let hw = 0, rot = 0, sw = 0;
             for (const ei of n.e) {
               const e = g.edges[ei];
+              // Mirrors world.meshNode: a tunnel draws no surface, so it must
+              // not size the crossing square nor lift anything standing on it.
+              if (e.tunnel) continue;
               if (e.hw > hw) { hw = e.hw; rot = Math.atan2(e.dx, -e.dz); }
               sw = Math.max(sw, walkWidth(e.cls));
             }

--- a/apps/auto/src/peds.js
+++ b/apps/auto/src/peds.js
@@ -478,7 +478,12 @@ export function animateWalk(h, amp, dt, speed) {
   // Swing clearance, and the main thing that sets how much the knee folds. A
   // sprinter's heel comes most of the way to the backside, which is where the
   // 120-155 deg of swing-phase knee flexion comes from.
-  const lift = ((0.085 + 0.20 * runBlend) / sc) * settle;
+  // Measured against tools/gait.mjs, this was short at every pace above a
+  // walk: knee swing came out 59 deg at brisk (band 65-85), 105 at run
+  // (110-140) and 108 at sprint (120-155). Too little fold is a leg that
+  // swings through nearly straight, which is the stiff, skating look. The heel
+  // has to come much closer to the backside as the pace rises.
+  const lift = ((0.105 + 0.295 * runBlend) / sc) * settle;
   const stanceSpan = TAU * duty;
   // THE FOOT HAS LENGTH, and that is what keeps a person standing up.
   //

--- a/apps/auto/src/player.js
+++ b/apps/auto/src/player.js
@@ -196,7 +196,7 @@ export class Player {
     // Union at 5, so you could stand on a lake bed indefinitely -- and
     // `world.waterLevelAt()`, written for exactly this, had no callers at all.
     const wl = this.world.waterLevelAt(this.x, this.z);
-    if (wl !== null && this.y < wl - 0.6) this.game.onDrown();
+    if (wl !== null && G.isWater(this.x, this.z) && this.y < wl - 0.6) this.game.onDrown();
 
     animateWalk(this.h, clamp(this.speed * 0.16, 0, 0.85), dt, this.speed);
     this.h.group.position.set(this.x, this.y, this.z);
@@ -248,8 +248,14 @@ export class Player {
     //
     // Sampled before the step, so an engine that has drowned cannot make power
     // for the frame that put it under.
+    // BOTH tests, and the mask is the one that says whether this is water.
+    // waterLevelAt answers over a lake's axis-aligned BOUNDING BOX, so inside
+    // Green Lake's rectangle it reports 50.3 m for the dry park ringing it --
+    // the trap this file's own notes describe, which once deleted 105 real
+    // trees. Height alone would cut the engine on a street that happens to dip
+    // below the lake beside it. The level is a reference height, not a region.
     const wl = this.world.waterLevelAt(v.x, v.z);
-    const wading = wl !== null && v.y < wl - 0.35;
+    const wading = wl !== null && G.isWater(v.x, v.z) && v.y < wl - 0.35;
 
     v.update(dt, {
       // A drowned engine makes no power and the wheels find nothing to push
@@ -274,7 +280,7 @@ export class Player {
     });
     // Deep enough to be over the roof rather than merely through a ford. One
     // test now, against the local surface, instead of a separate sea-only path.
-    if (wl !== null && v.y < wl - 1.6) this.game.onCarSank(v);
+    if (wading && v.y < wl - 1.6) this.game.onCarSank(v);
     if (v.dead) this.game.onCarDestroyed(v);
   }
 

--- a/apps/auto/src/player.js
+++ b/apps/auto/src/player.js
@@ -120,7 +120,14 @@ export class Player {
     // speeds the gait correctly came out looking like track athletics. The
     // character is a person moving around a city, so the speeds come down and
     // the pose follows: 3.6 is an easy run, 5.4 a hard one.
-    const run = input.sprint ? 5.4 : 3.6;
+    // 3.6 / 5.4 was too slow to cross a city this size, and slowing the
+    // character down was the wrong lever anyway: it was done to stop the gait
+    // reading as track athletics, but the gait keys off runBlend and is judged
+    // by tools/gait.mjs against published bands at 1.4 / 3.5 / 7.5 m/s -- all
+    // of which it already passes. So the pose was never the speed's problem.
+    // 5.0 is a purposeful run and 7.2 a sprint, which is about where a game of
+    // this kind sits.
+    const run = input.sprint ? 7.2 : 5.0;
     let target = 0;
     if (mag > 0.12) {
       // Stick is camera-relative. Note HEADING_SENSE: heading is three.js
@@ -231,7 +238,30 @@ export class Player {
     // which is most of what makes a pad feel different from a touch button.
     const throttle = input.gasAmt != null ? input.gasAmt : (input.gas ? 1 : 0);
     const brake = input.brakeAmt != null ? input.brakeAmt : (input.brake ? 1 : 0);
-    v.update(dt, { throttle, brake, steer, handbrake: input.hand ? 1 : 0 });
+
+    // Water is against the LOCAL surface, the same law the on-foot path above
+    // already follows -- and this was the one place that never learned it. The
+    // test used to be `v.y < -1.2 && G.isWater(...)`, which only ever describes
+    // the sea: with Green Lake at 50.3 m and Lake Union at 5, a car on a lake
+    // bed never came close to tripping it, so you could drive the bottom of
+    // Green Lake at 200 km/h, dry and at full throttle.
+    //
+    // Sampled before the step, so an engine that has drowned cannot make power
+    // for the frame that put it under.
+    const wl = this.world.waterLevelAt(v.x, v.z);
+    const wading = wl !== null && v.y < wl - 0.35;
+
+    v.update(dt, {
+      // A drowned engine makes no power and the wheels find nothing to push
+      // against, which is what makes water read as water and not as a
+      // differently-coloured road.
+      throttle: wading ? 0 : throttle,
+      brake, steer, handbrake: input.hand ? 1 : 0,
+    });
+    if (wading) {
+      v.vLong -= v.vLong * Math.min(1, 2.6 * dt);
+      v.vLat -= v.vLat * Math.min(1, 2.6 * dt);
+    }
     // Scraping a wall is many frames of contact, not many crashes. Debounced
     // like vehicle-vehicle damage: unthrottled, holding the accelerator into a
     // building killed the player in about a sixth of a second.
@@ -242,7 +272,9 @@ export class Player {
       this.game.onCrash(imp, false);
       if (imp > 8) this.game.damagePlayer(imp * 0.5, 'crash');
     });
-    if (v.y < -1.2 && G.isWater(v.x, v.z)) this.game.onCarSank(v);
+    // Deep enough to be over the roof rather than merely through a ford. One
+    // test now, against the local surface, instead of a separate sea-only path.
+    if (wl !== null && v.y < wl - 1.6) this.game.onCarSank(v);
     if (v.dead) this.game.onCarDestroyed(v);
   }
 

--- a/apps/auto/src/vehicles.js
+++ b/apps/auto/src/vehicles.js
@@ -54,8 +54,9 @@ const V0_100 = 100 / 3.6;
 // So the ratios between vehicles stay real and the whole scale is compressed:
 // everything accelerates ARCADE_PUNCH times harder than its spec sheet, which
 // keeps a sports car quicker than a van by the right margin while making both
-// enjoyable. Top speed, braking and grip stay honest -- those are what make a
-// corner dangerous, and they are not what makes a car feel slow.
+// enjoyable. Top speed stays honest; grip and braking are scaled together by
+// ARCADE_GRIP / ARCADE_BRAKE, so the ratios between classes survive and the
+// whole scale moves as one.
 const ARCADE_PUNCH = 2.4;
 
 // And how much more grip than real. Same bargain as ARCADE_PUNCH: the ratios
@@ -63,6 +64,23 @@ const ARCADE_PUNCH = 2.4;
 // sedan's cornering radius at 72 km/h is 46 m, which in a city built from real
 // street widths means you cannot make a junction at any speed worth driving.
 const ARCADE_GRIP = 2.2;
+
+// How hard a corner may be asked for, as a fraction of the grip that exists.
+// Above 1 on purpose: this is a GTA-style car, not a simulator. It should feel
+// planted and willing -- lane changes and sweeping bends at speed take no
+// thought, a hairpin at 120 km/h is simply not on -- so the car leans on its
+// tyres a bit harder than physics allows without ever demanding the multiples
+// that made it pivot on rails.
+const STEER_BITE = 1.25;
+
+// Braking was the one axis left at real-world scale, and that is why it felt
+// slow: you accelerated 2.4x harder than the spec sheet and cornered at 2.2x
+// the grip, then braked at exactly 1.0x. The comment above used to claim
+// braking stayed honest alongside grip -- but grip has not been honest since
+// ARCADE_GRIP arrived, so all that survived was an inconsistency. A tyre that
+// gives 2.2x laterally gives it longitudinally too, which also keeps the
+// friction budget isotropic.
+const ARCADE_BRAKE = 2.2;
 
 export const TYPES = {
   sedan: deriveSpec({ wheelbase: 2.98,len: 5.06, wid: 1.90, wheelR: 0.34, sill: 0.30, belt: 1.06, roof: 1.50, cab: [-0.26, 0.10], hand: 'sedan', mass: 1.0, acc: 4.1, topKph: 205, brakeM: 40, latG: 0.88 }),
@@ -133,7 +151,8 @@ function deriveSpec(s) {
   // supply the target deceleration MINUS what the air and the tyres already
   // give. Ignoring it made every vehicle stop about 15 % shorter than declared.
   const vMean = V0_100 / 2;
-  s.brakeA = (V0_100 * V0_100) / (2 * s.brakeM) - (DRAG * vMean * vMean + ROLL * vMean);
+  s.brakeA = ((V0_100 * V0_100) / (2 * s.brakeM) - (DRAG * vMean * vMean + ROLL * vMean))
+    * ARCADE_BRAKE;
   // Lateral limit in m/s^2, which is what the friction circle below compares.
   s.latA = s.latG * 9.81;
   return s;
@@ -3063,7 +3082,23 @@ export class Vehicle {
     // Asking for a radius and solving `atan(L / R)` for the angle gives every
     // vehicle a comparable, controllable turn, and short wheelbases correctly
     // come out slightly tighter rather than uncontrollable.
-    const turnR = lerp(4.5, 11.0, clamp(sp / 34, 0, 1)) / agility;
+    //
+    // The radius has to come from the grip that EXISTS, not from a curve picked
+    // by feel. Lerping 4.5 -> 11 m across the speed range asked a sedan at
+    // 122 km/h to hold an 11 m radius, which is 10.7 g of lateral acceleration
+    // against the 1.9 g its tyres actually have -- a demand 5.5x over the
+    // limit, rising with speed. The block below states that the steering limit
+    // IS the grip limit ("the yaw the car achieves IS the lateral
+    // acceleration"); with a radius like that the statement was simply untrue,
+    // nothing anywhere enforced grip, and the car pivoted on rails at a rate no
+    // tyre could produce. That is the wild high-speed steering.
+    //
+    // r = v^2 / a is the whole of it. STEER_BITE sits just over 1 so a corner
+    // taken flat out is at the limit with a little left to provoke, and every
+    // class differs by its own latG rather than by a fudge. The low-speed floor
+    // is unchanged, so parking-lot lock is exactly as tight as before -- below
+    // about 34 km/h the floor is what applies.
+    const turnR = Math.max(4.5 / agility, (sp * sp) / (spec.latA * ARCADE_GRIP * STEER_BITE));
     const lock = Math.min(0.62, Math.atan(wheelbase / turnR))
       * (hand > 0.5 ? 1.25 : 1)
       * (brake > 0 && this.vLong > 0.4 ? 0.92 : 1);

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -1148,6 +1148,7 @@ export class World {
     let hw = 0;
     for (const ei of n.e) {
       const e = this.city.edges[ei];
+      if (e.tunnel) continue;   // draws nothing, so it sizes nothing
       if (e.hw > hw) hw = e.hw;
     }
     return hw;
@@ -1234,6 +1235,13 @@ export class World {
     let sw = 0;
     for (const ei of n.e) {
       const e = city.edges[ei];
+      // A bore paves nothing on the surface, so it cannot size a crossing
+      // either. Skipping the edge in meshRoad but not here left a junction
+      // square sitting on the ground over the tunnel -- a patch of carriageway
+      // in somebody's garden, and 638 centreline samples still reporting a
+      // paved lift with no road drawn. nodeSurface() does the same, because the
+      // drawn surface and the lift query have to agree.
+      if (e.tunnel) continue;
       if (e.hw > hw) { hw = e.hw; rot = Math.atan2(e.dx, -e.dz); }
       if (e.cls === 'st' || e.cls === 'art' || e.cls === 'res') {
         sw = Math.max(sw, e.cls === 'art' ? 3.2 : 2.6);

--- a/apps/auto/src/world.js
+++ b/apps/auto/src/world.js
@@ -917,6 +917,22 @@ export class World {
 
   meshRoad(road, walk, flat, e, a, b, lod, ei) {
     if (e.elev) { this.meshViaduct(road, flat, e, a, b); return; }
+    // A bore is not a carriageway on the surface.
+    //
+    // Tunnels are kept in the graph so the network stays connected and
+    // routable, and they were drawn at ground level as ordinary road. But
+    // roadFit() deliberately does NOT clear buildings off a tunnel -- "a
+    // building above a tunnel is where buildings normally are" -- so the two
+    // decisions together painted a freeway straight through the houses above
+    // it. Measured, 46 of the 63 buildings standing in a carriageway were over
+    // a bore: the Mount Baker Ridge Tunnel under Mercer Island and SR-99. Those
+    // are the obstacles in the middle of the freeway.
+    //
+    // Nothing is lost by not drawing it. Traffic still routes through, because
+    // routing is the graph; what goes away is a road surface laid across
+    // somebody's front garden. `roadLift` skips them for the same reason -- a
+    // lift with no drawn road under it is a step into thin air.
+    if (e.tunnel) return;
     const hw = e.hw;
     const U1 = (hw * 2) / ROAD_TILE;
     const px = -e.dz, pz = e.dx;

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v47';
+const CACHE = 'auto-v48';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',

--- a/tools/vehicles.mjs
+++ b/tools/vehicles.mjs
@@ -26,6 +26,9 @@ const HTTP_PORT = process.env.AUTO_HTTP_PORT || 8000;
 const JSON_OUT = process.argv.includes('--json');
 // Keep in step with apps/auto/src/vehicles.js.
 const ARCADE_PUNCH = 2.4;
+// Braking is scaled the same way now (vehicles.js ARCADE_BRAKE), so its band
+// gets divided by it for the same reason the accel band does. Keep in step.
+const ARCADE_BRAKE = 2.2;
 const ARCADE_GRIP = 2.2;
 
 // Real-world bands per class, for the types we ship. 0-100 km/h in seconds,
@@ -39,8 +42,10 @@ const ARCADE_GRIP = 2.2;
 // throttle, because a real sedan's 8.6 s to 100 km/h feels broken to drive --
 // you spend the whole time waiting. The RATIOS between classes stay real, so
 // the accel band is divided by the same constant here and the check still
-// catches a van out-dragging a sports car. Top speed, braking and grip are
-// compared against the real figures unchanged.
+// catches a van out-dragging a sports car. BRAKING is now scaled the same way
+// by ARCADE_BRAKE and its band is divided to match -- it was the one axis left
+// at real-world scale, which is precisely why it felt slow next to a throttle
+// running at 2.4x. Top speed is compared against the real figures unchanged.
 //
 // GRIP is no longer checked against a real-world band at all, and pretending
 // otherwise would be dishonest. Steering is a game control here: grip does not
@@ -219,7 +224,7 @@ async function main() {
       if (!b) { console.log(`${name}: no band`); continue; }
       const marks = [
         band(r.accel, b.accel.map((v) => v / ARCADE_PUNCH)), band(r.top, b.top),
-        band(r.brake, b.brake), 'ok',
+        band(r.brake, b.brake.map((v) => v / ARCADE_BRAKE)), 'ok',
       ];
       bad += marks.filter((m) => m !== 'ok').length;
       const f = (v, m) => `${v === null ? '  --' : v.toFixed(v < 100 ? 1 : 0).padStart(6)}${m === 'ok' ? ' ' : '!'}`;
@@ -250,11 +255,15 @@ async function main() {
       for (const [nb, rb] of rows) {
         if (group(na) !== group(nb)) continue;
         if ((ra.latG || 0) - (rb.latG || 0) < 0.12) continue;
-        // Take the wheelbase out. lat ~= v^2 * tan(steer) / L, so a motorcycle
-        // out-corners a saloon on geometry alone and a bus loses on it -- the
-        // grip term only enters through the steering lock. Multiplying by the
-        // wheelbase leaves the part that grip is actually responsible for.
-        if (ra.lat * ra.wheelbase < rb.lat * rb.wheelbase) {
+        // Compare lateral acceleration DIRECTLY. This used to multiply by the
+        // wheelbase, and had to: the steering lock was a fixed radius curve, so
+        // lat came out as v^2 * tan(steer) / L and geometry had to be divided
+        // back out before grip was visible. The lock is now solved from the
+        // grip itself (r = v^2 / a), which makes lat independent of wheelbase --
+        // so multiplying by it no longer removes a bias, it ADDS one, and it
+        // reported a short-wheelbase sports car as cornering worse than a
+        // pickup that it out-corners by 0.7 g. Normalise for the model you have.
+        if (ra.lat < rb.lat) {
           wrong.push(`${na} (latG ${ra.latG}) corners worse than ${nb} (latG ${rb.latG})`);
         }
       }

--- a/tools/verify.mjs
+++ b/tools/verify.mjs
@@ -220,6 +220,90 @@ async function main() {
     console.log('\n--- drive test ------------------------------------------');
     console.log('  ' + JSON.stringify(drive));
 
+    // --- water and tunnels ------------------------------------------------
+    //
+    // Both of these were shipped broken once and neither had an assertion.
+    // waterLevelAt answers over a lake's axis-aligned BOUNDING BOX, so a height
+    // test alone drowns you on the dry park ringing Green Lake -- the same trap
+    // that once deleted 105 of its trees. And a tunnel drawn as surface road
+    // put 46 buildings in a freeway.
+    const water = await session.eval(`(() => {
+      const d = window.__dbg, w = d.world, G = d.G, city = d.city;
+      const out = { dryInsideLakeBox: 0, checked: 0, wetDetected: 0, tunnelLift: 0, tunnelSampled: 0 };
+      for (const l of (w.lakeSpecs || [])) {
+        for (let i = 0; i <= 12; i++) {
+          for (let j = 0; j <= 12; j++) {
+            const x = l.x0 + (l.x1 - l.x0) * (i / 12);
+            const z = l.z0 + (l.z1 - l.z0) * (j / 12);
+            const wl = w.waterLevelAt(x, z);
+            if (wl === null) continue;
+            out.checked++;
+            const wet = G.isWater(x, z);
+            const lowEnough = G.terrainHeight(x, z) < wl - 0.6;
+            if (wet && lowEnough) out.wetDetected++;
+            // Dry ground that a height-only test would call submerged.
+            if (!wet && lowEnough) out.dryInsideLakeBox++;
+          }
+        }
+      }
+      // A tunnel must not lift anything BY ITSELF. It may still be under a real
+      // street -- that is what a bore is -- and the street above legitimately
+      // paves the ground, so the honest test is: where nothing but the tunnel
+      // covers this point, the lift has to be zero.
+      const covered = (x, z) => {
+        for (const e of city.edges) {
+          if (e.tunnel || e.elev) continue;
+          const a = city.nodes[e.a], b = city.nodes[e.b];
+          const dx = b.x - a.x, dz = b.z - a.z;
+          const L2 = dx * dx + dz * dz || 1;
+          let t = ((x - a.x) * dx + (z - a.z) * dz) / L2;
+          t = t < 0 ? 0 : t > 1 ? 1 : t;
+          const px = a.x + dx * t - x, pz = a.z + dz * t - z;
+          if (Math.hypot(px, pz) <= e.hw + 3.4) return true;
+        }
+        // A junction ring reaches past the strips, and its DIAGONAL corner is
+        // sqrt(2) x (hw + sw) from the node -- further than any straight-line
+        // test along an edge gets. Four samples sat in exactly that gap.
+        for (const n of city.nodes) {
+          if (n.elev) continue;
+          let hw = 0, any = false;
+          for (const ei of n.e) {
+            const e = city.edges[ei];
+            if (e.tunnel) continue;
+            any = true;
+            if (e.hw > hw) hw = e.hw;
+          }
+          if (!any || hw <= 0) continue;
+          if (Math.hypot(n.x - x, n.z - z) <= (hw + 3.2) * 1.45) return true;
+        }
+        return false;
+      };
+      for (const e of city.edges) {
+        if (!e.tunnel || e.elev) continue;
+        const a = city.nodes[e.a], b = city.nodes[e.b];
+        for (let k = 1; k < 4; k++) {
+          const t = k / 4;
+          const x = a.x + (b.x - a.x) * t, z = a.z + (b.z - a.z) * t;
+          if (covered(x, z)) continue;   // a real street above the bore
+          out.tunnelSampled++;
+          if (city.roadLift(x, z) > 0.01) out.tunnelLift++;
+        }
+      }
+      return out;
+    })()`, true);
+    console.log('\n--- water and tunnels -----------------------------------');
+    console.log(`  lake-box points: ${water.checked}, genuinely wet ${water.wetDetected},`
+      + ` dry-but-below-level ${water.dryInsideLakeBox}`);
+    console.log(`  ${water.dryInsideLakeBox > 0
+      ? 'those are why the mask must be tested as well as the height'
+      : 'no dry points below level in any lake box'}`);
+    console.log(`  tunnel-only samples (no street above) ${water.tunnelSampled},`
+      + ` with a paved lift ${water.tunnelLift}`);
+    if (water.tunnelLift > 0) {
+      console.error(`FAIL: ${water.tunnelLift} tunnel-only samples report a paved lift with no road drawn`);
+      process.exitCode = 1;
+    }
+
     if (SHOTS) {
       mkdirSync(OUT, { recursive: true });
       const views = [

--- a/tools/verify.mjs
+++ b/tools/verify.mjs
@@ -304,6 +304,69 @@ async function main() {
       process.exitCode = 1;
     }
 
+    // --- decks: DECK_REACH must not strand anyone ---------------------------
+    //
+    // groundAt's reach shrank from 2.6 m to 0.9 m above the caller's reference
+    // height, which fixed cars being picked up by overpasses they drive under.
+    // But every caller with a curY shares it -- pedestrians and the vehicle's
+    // own wheel and lookahead samplers -- so the two things that would break
+    // are riding a viaduct and getting onto one. Both are asserted rather than
+    // reasoned about.
+    const decks = await session.eval(`(() => {
+      const d = window.__dbg, city = d.city, G = d.G;
+      let rode = 0, fell = 0, cases = 0, failed = 0;
+      for (const e of city.edges) {
+        if (!e.elev || e.len < 30) continue;
+        const a = city.nodes[e.a], b = city.nodes[e.b];
+        let cur = a.y + 0.6;
+        const n = Math.max(6, Math.floor(e.len / 3));
+        for (let k = 0; k <= n; k++) {
+          const t = k / n;
+          const x = a.x + (b.x - a.x) * t, z = a.z + (b.z - a.z) * t;
+          const deck = a.y + (b.y - a.y) * t;
+          const y = city.groundAt(x, z, cur, city.roadLift(x, z));
+          rode++;
+          if (y < deck - 1.0) fell++;
+          cur = y + 0.6;
+        }
+      }
+      for (const e of city.edges) {
+        if (!e.elev) continue;
+        for (const [nid, oid] of [[e.a, e.b], [e.b, e.a]]) {
+          const nd = city.nodes[nid];
+          let g = null;
+          for (const ei of nd.e) {
+            const c = city.edges[ei];
+            if (c === e || c.elev || c.tunnel || c.len < 12) continue;
+            g = c; break;
+          }
+          if (!g) continue;
+          cases++;
+          const far = city.nodes[g.a === nid ? g.b : g.a], o = city.nodes[oid];
+          const pts = [];
+          for (let k = 10; k >= 0; k--) {
+            const t = k / 10 * Math.min(1, 20 / g.len);
+            pts.push([far.x + (nd.x - far.x) * (1 - t), far.z + (nd.z - far.z) * (1 - t)]);
+          }
+          for (let k = 1; k <= 10; k++) {
+            const t = k / 10 * Math.min(1, 20 / e.len);
+            pts.push([nd.x + (o.x - nd.x) * t, nd.z + (o.z - nd.z) * t]);
+          }
+          let cur = G.terrainHeight(far.x, far.z) + 0.6, y = cur;
+          for (const [x, z] of pts) { y = city.groundAt(x, z, cur, city.roadLift(x, z)); cur = y + 0.6; }
+          if (y < nd.y + (o.y - nd.y) * Math.min(1, 20 / e.len) - 1.0) failed++;
+        }
+      }
+      return { rode, fell, cases, failed };
+    })()`, true);
+    console.log('\n--- decks -----------------------------------------------');
+    console.log(`  riding viaducts: ${decks.fell} of ${decks.rode} samples fell through`);
+    console.log(`  driving onto one: ${decks.failed} of ${decks.cases} approaches failed to climb`);
+    if (decks.fell > 0 || decks.failed > 0) {
+      console.error(`FAIL: DECK_REACH strands drivers (${decks.fell} fell, ${decks.failed} could not climb)`);
+      process.exitCode = 1;
+    }
+
     if (SHOTS) {
       mkdirSync(OUT, { recursive: true });
       const views = [


### PR DESCRIPTION
Six reports from playing v47, each measured before and after.

## Steering asked for grip that does not exist

The lock came from a fixed radius curve, which is a shape rather than a limit.
At 122 km/h it asked a sedan for an 11 m radius — **10.7 g against the 1.9 g its
tyres have**, 5.5× over and worse the faster you go. The block that applies the
yaw *states* that the steering limit is the grip limit, so with a radius like
that the statement was untrue and nothing anywhere enforced grip: the car
pivoted on rails at a rate no tyre could produce.

`r = v² / a` is the whole fix.

| sedan | 20 kph | 40 | 60 | 90 | 120 |
|---|---|---|---|---|---|
| radius before | 5.5 m | 6.6 | 7.7 | 9.3 | 10.9 |
| radius after | 4.5 m | 5.2 | 11.7 | 26.3 | 46.8 |
| lateral g before | 0.57 | 1.91 | 3.69 | 6.87 | **10.42** |
| lateral g after | 0.71 | 2.43 | 2.43 | 2.42 | **2.42** |

Low-speed lock is untouched — below ~34 km/h a floor applies, so parking-lot
agility is exactly as tight as before.

## Braking was the one axis left at real-world scale

Throttle ran at 2.4×, cornering at 2.2×, braking at exactly 1.0× — which is why
it felt slow. `ARCADE_BRAKE` matches `ARCADE_GRIP`, keeping the tyre isotropic.
**100–0: 39.3 m → 18.4 m.**

`tools/vehicles.mjs` divides the brake band by it, as it already did for accel.
Its class-order check now compares lateral g **directly**: multiplying by
wheelbase was correct for a fixed-radius lock and became wrong once the lock
comes from grip — it reported a sports car as cornering worse than a pickup it
beats by 0.7 g. Normalise for the model you have.

## You could drive the bottom of Green Lake at 200 km/h

`updateDrive` tested `v.y < -1.2`, which only ever describes the sea; Green Lake
is at 50.3 m. The on-foot path had already learned to use `waterLevelAt()` — this
one, one function away, never did. Engine cuts, car drags down and sinks.
Verified at Green Lake (surface 50.3, bed 43.4) and Elliott Bay (surface 0, bed
−5.4): 200 km/h → 0 in both.

## The houses standing in the freeway were tunnels

Bores were drawn at ground level as ordinary carriageway, while `roadFit()`
deliberately does *not* clear buildings off a tunnel ("a building above a tunnel
is where buildings normally are"). Together they painted a freeway through the
houses on top of it. **46 of the 63 buildings standing in a carriageway were over
a bore** — exactly I-90 at Mercer Island and SR-99. `meshRoad` and `roadLift`
skip tunnel edges now; routing is the graph and is unaffected. Verified: road
drawn at 13/81 samples over the Mercer Island bore (the rest are real surface
streets), and 0 of 2340 non-tunnel freeway samples lost their lift.

## Bumpy freeways — partly fixed, and honestly so

`groundAt` took the highest deck within `curY + 2.6`, taller than a car, so
driving *under* an overpass lifted you onto it and dropped you when it ended —
measured, a **3.76 m fall** on I-5. `DECK_REACH` is 0.9 m.

**The rest is the heightfield itself and is not fixed.** Roads drape a 40 m
triangulated DEM, so every triangle crossing is a grade kink: 5.6% of 3 m steps
change grade by over 5% (~1.5 g at 30 m/s), of which **raw terrain alone accounts
for 4.2%**. I tried an upper-envelope profile twice and **both measured worse**:

| | over 5% grade change |
|---|---|
| as-is | 5.62% |
| per-edge envelope | **9.48%** |
| ...plus shared node heights | **12.21%** |

The envelope is sound in isolation (5.09% → 3.19%, zero poke-through by
construction). It failed because a freeway is chopped into ~35 m edges and each
profile was built independently, so they disagree at every junction — smooth
within a piece is not smooth. Reverted and written up; doing it properly means
profiling a connected chain, not an edge.

## Running was slow and stiff

3.6/5.4 m/s → **5.0/7.2**. It had been slowed to stop the gait reading as
athletics, which was the wrong lever — the gait keys off `runBlend` and
`tools/gait.mjs` already passed it at 1.4/3.5/7.5. The stiffness was swing
clearance: knee swing measured 59/105/108° at brisk/run/sprint against bands of
65–85 / 110–140 / 120–155, and a leg swinging through straight is the skating
look. Now **116/123/126, all in band**.

## Verification

`tools/verify.mjs` 0 exceptions, landmarks unchanged. `tools/vehicles.mjs`
0 of 54 figures outside band, class order holds. Against master the scene is
**419762 triangles vs 420952, with identical draw calls** — slightly lighter,
from the tunnels no longer being drawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B