### PR TITLE
Auto: SW updates bypass the HTTP cache and re-check on foreground

### DIFF
--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -414,7 +414,7 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v52</div>
+    <div id="build">v53</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 
@@ -428,7 +428,20 @@
 <script>
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
-      navigator.serviceWorker.register('sw.js').catch(() => {});
+      // updateViaCache: 'none' makes the BROWSER's HTTP cache irrelevant to
+      // the update check: without it, GitHub Pages' max-age=600 means a
+      // relaunch inside ten minutes of a deploy refetches the OLD sw.js and
+      // sees "no change" -- which, byte-compare being the update trigger,
+      // reads as no update at all. And check again whenever the app comes
+      // back to the foreground, because an iOS PWA can sit resident for days
+      // without a fresh launch.
+      navigator.serviceWorker.register('sw.js', { updateViaCache: 'none' })
+        .then((reg) => {
+          document.addEventListener('visibilitychange', () => {
+            if (!document.hidden) reg.update().catch(() => {});
+          });
+        })
+        .catch(() => {});
     });
   }
 </script>

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v52';
+const CACHE = 'auto-v53';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',


### PR DESCRIPTION
Why "stuck on 49" outlived the v52 fix: GitHub Pages serves `sw.js` with
`max-age=600`, and iOS applies HTTP caching to the SW update fetch. Anyone
relaunching within ~10 minutes of a deploy refetches the *old* `sw.js`, and
byte-compare-as-update-trigger reads that as "no update." The prompt
force-quit-twice dance — the exact thing a keen player does right after a
merge — is the most likely path into it.

- `updateViaCache: 'none'` removes the HTTP cache from the update path.
- `reg.update()` on `visibilitychange`, since an iOS PWA can stay resident
  for days and otherwise only checks at launch.
- v53 so this deploy itself turns the cache over.

`verify.mjs`: 0 exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B