### PR TITLE
Auto: show the build number in portrait

### DIFF
--- a/apps/auto/index.html
+++ b/apps/auto/index.html
@@ -414,13 +414,17 @@
     <div id="loadTrack"><div id="loadBar"></div></div>
     <div id="loadMsg">Starting up</div>
     <!-- Bumped once per change, in step with CACHE in sw.js. See CLAUDE.md. -->
-    <div id="build">v53</div>
+    <div id="build">v54</div>
     <div id="attrib">Map data © OpenStreetMap contributors (ODbL) · elevation USGS 3DEP</div>
   </div>
 
   <div id="rotate">
     <div style="font-size:34px">📱↻</div>
     <div>Rotate your device sideways to play.</div>
+    <!-- Filled from #build at boot: the version must be readable in portrait
+         too, because "which build are you on" is asked of a phone being held
+         upright, and the rotate overlay covers the launch screen's badge. -->
+    <div id="rotateBuild" style="font-size:11px;letter-spacing:.18em;opacity:.4"></div>
   </div>
 </div>
 
@@ -435,6 +439,8 @@
       // reads as no update at all. And check again whenever the app comes
       // back to the foreground, because an iOS PWA can sit resident for days
       // without a fresh launch.
+      const rb = document.getElementById('rotateBuild');
+      if (rb) rb.textContent = document.getElementById('build').textContent;
       navigator.serviceWorker.register('sw.js', { updateViaCache: 'none' })
         .then((reg) => {
           document.addEventListener('visibilitychange', () => {

--- a/apps/auto/sw.js
+++ b/apps/auto/sw.js
@@ -23,7 +23,7 @@
 // launch to prove it hadn't changed, and PINNED is wrong too: these URLs carry
 // no version, so a bump has to be able to replace them. The map only changes
 // when tools/ re-imports it, and that comes with a bump.
-const CACHE = 'auto-v53';
+const CACHE = 'auto-v54';
 const PINNED = ['vendor/three-0.160.0.module.js'];
 const isMapData = (url) => new URL(url).pathname.includes('/apps/auto/data/');
 const SHELL = ['./', './index.html', './manifest.webmanifest',


### PR DESCRIPTION
The rotate overlay covers the launch screen exactly when someone holds the
phone upright to check which build they're on. The overlay now shows the
version, copied from `#build`'s text at boot — one literal, no drift (a
drifting duplicate is precisely what stuck-on-49 was made of).

Verified with a portrait headless render: the overlay reads "Rotate your
device sideways to play." with **v54** beneath it.

v53 → v54, `CACHE` bumped to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V56RnrzLsQEVAyY6wa5w7B